### PR TITLE
fix(storage-read): emit bare record-batch IPC message, not a full stream (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,25 @@ section and adds the release date.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Storage Read API IPC framing** (#15). The gRPC ``ReadRows`` handler
+  previously packed a full Arrow IPC stream (schema-message + batches +
+  EOS-marker) into ``ArrowRecordBatch.serialized_record_batch``, breaking
+  every real Storage Read client — ``google-cloud-bigquery-storage``'s
+  ``reader.to_arrow(session)`` tripped on ``OSError: Expected IPC message
+  of type record batch but got schema``. The handler now emits only the
+  record-batch IPC message bytes; the schema continues to travel
+  separately via ``ReadSession.arrow_schema.serialized_schema`` and the
+  first ``ReadRowsResponse.arrow_schema`` field, matching the BigQuery
+  contract. ``serialize_arrow_ipc(table)`` in
+  ``bqemulator.streaming.read_session`` is replaced by
+  ``serialize_arrow_record_batch(batch)``; the pyspark-bigquery example
+  drops its inline workaround and goes back to the natural
+  ``reader.to_arrow(session)`` call. See ADR 0033 for the formal
+  bare-message contract — dictionary-encoded columns at any nesting
+  depth are rejected with ``ValueError`` at the producer boundary.
+
 ### Changed
 
 - **scio example: testcontainers bump + #17 investigation notes.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,32 +187,41 @@ section and adds the release date.
 - **GHCR image signing** via keyless cosign with GitHub OIDC certificate
   identity.
 
-### Known limitations (deferred to v1.0.1)
+### Known limitations (snapshot at v1.0.0 release; status as of v1.0.1)
 
-These ship as documented caveats on the affected example projects.
-None affect the core emulator surface.
+The two caveats below were carried at v1.0.0 as documented
+limitations to be addressed in v1.0.1. Status update after the
+v1.0.1 release:
 
-- **Storage Read API IPC bytes layout** — bqemulator packs the full
-  Arrow IPC stream (schema framing + batches) into
-  `ReadRowsResponse.arrow_record_batch.serialized_record_batch`
-  rather than a single record-batch IPC message; the schema lives
-  separately on `ReadSession.arrow_schema`. The
-  `google-cloud-bigquery-storage` client's high-level
-  `reader.to_arrow(session)` trips
-  `Expected IPC message of type record batch but got schema`. The
-  `python/pyspark-bigquery` example iterates raw responses through
-  `pa.ipc.open_stream` as a workaround. Tracked in
-  [#15](https://github.com/jjviscomi/bqemulator/issues/15).
-- **Scio test exercises wiring only** — Beam Java BigQueryIO does
-  not honour `--bigQueryEndpoint` for the *write* path (that flag
-  only gates internal preflight validators); the Java BQ client
-  *does* honour `BIGQUERY_EMULATOR_HOST`, but it must be visible to
-  the JVM before the first BQ class loads, which is impossible
-  when the testcontainer port is allocated at runtime. The
-  `java/scio` example's spec asserts the wiring bqemulator owns
-  (container up, REST API reachable, dataset creation works); the
-  `CustomersPipeline.run` source itself remains production-ready
+- ✅ **Storage Read API IPC bytes layout** — **CLOSED in v1.0.1**
+  (see ``Fixed`` block under [Unreleased]/[1.0.1] above). The
+  ``ReadRows`` handler now emits a bare record-batch IPC message
+  per the BigQuery wire contract;
+  ``google-cloud-bigquery-storage``'s
+  ``reader.to_arrow(session)`` works unchanged; the
+  ``python/pyspark-bigquery`` example dropped its inline
+  workaround. See [ADR 0033](docs/adr/0033-storage-read-arrow-ipc-bare-message-contract.md)
+  for the formal contract. ([#15](https://github.com/jjviscomi/bqemulator/issues/15))
+- ⏳ **Scio test exercises wiring only** — **DEFERRED to v1.0.2+**.
+  v1.0.1 investigation (see ``Changed`` block above + the
+  ``CustomersPipelineSpec`` header comment) found the end-to-end
+  path requires three independent fixes, not the single
+  flag/env-var the v1.0.0 limitation note suggested:
+  ``--bigQueryEndpoint`` does override the Apiary client's
+  ``rootUrl`` (✅), but Beam's auth refresh fires before the
+  redirected HTTP call (``OAuth2Credentials.refresh()`` 400s
+  even with ``NoopCredentialFactory``), and
+  ``BigQueryIO.Write`` defaults to ``BATCH_LOADS`` which stages
+  rows to GCS — the emulator has no GCS-compatible shim. Likely
+  v1.0.2 path: integrate a GCS emulator (e.g.
+  ``fsouza/fake-gcs-server``) for staging + finish auth
+  suppression + decide between staying on ``BATCH_LOADS`` (via
+  GCS shim) or pivoting to ``STREAMING_INSERTS``. The
+  ``CustomersPipeline.run`` source itself stays production-ready
   for users running against real BigQuery or a long-lived
-  bqemulator with a stable port. Tracked in
+  bqemulator with a stable port + real GCS bucket. The scio
+  example test continues to assert the wiring-only smoke
+  bqemulator owns (container up, REST reachable, dataset
+  creation works). Tracked in
   [#17](https://github.com/jjviscomi/bqemulator/issues/17).
 

--- a/docs/adr/0033-storage-read-arrow-ipc-bare-message-contract.md
+++ b/docs/adr/0033-storage-read-arrow-ipc-bare-message-contract.md
@@ -1,0 +1,137 @@
+# ADR 0033: Storage Read API — Arrow IPC bare-message contract
+
+- **Status**: Accepted
+
+## Context
+
+[Issue #15](https://github.com/jjviscomi/bqemulator/issues/15) surfaced
+a wire-format mismatch in the v1.0.0 ``BigQueryRead/ReadRows`` gRPC
+servicer. Real BigQuery's
+[Storage Read API proto](https://github.com/googleapis/googleapis/blob/master/google/cloud/bigquery/storage/v1/storage.proto)
+documents two distinct Arrow byte fields:
+
+| Field | Documented content |
+|---|---|
+| ``ReadSession.arrow_schema.serialized_schema`` | IPC-serialized Arrow schema (single ``Schema`` message). |
+| ``ArrowRecordBatch.serialized_record_batch`` | IPC-serialized Arrow record batch (single ``RecordBatch`` message). |
+
+bqemulator v1.0.0 packed a **full** Arrow IPC stream
+([``schema-message``, ``batch-message``, ``EOS-marker``]) into
+``serialized_record_batch``. Real Storage Read clients trip on the
+format mismatch: ``google-cloud-bigquery-storage``'s
+``reader.to_arrow(session)`` internally calls
+``pyarrow.ipc.read_record_batch(bytes, schema)`` which refuses anything
+that isn't a bare ``RecordBatch`` message — it raises
+``OSError: Expected IPC message of type record batch but got schema``.
+
+## Decision
+
+The producer-side helper
+``bqemulator.streaming.read_session.serialize_arrow_record_batch(batch)``
+emits **only** the bare ``RecordBatch`` IPC message bytes for the
+batch passed in. Schema travels separately on
+``ReadSession.arrow_schema.serialized_schema`` (set once per
+session) and the first ``ReadRowsResponse.arrow_schema`` (mirrored
+for streaming readers that join mid-stream).
+
+### Contract
+
+| Aspect | Behaviour |
+|---|---|
+| **Return value** | Exactly the IPC bytes for **one** ``RecordBatch`` message (continuation marker + metadata length + flatbuffer metadata + padding + body buffers). No schema-message prefix, no EOS-marker suffix. |
+| **Dictionary-encoded fields** | **Rejected at the producer boundary** with ``ValueError``. The wire format has only two slots (schema + batch); pyarrow's ``read_record_batch`` requires a populated ``DictionaryMemo`` to decode dict frames, which a bare-message format can't provide. The check recurses into nested types (``struct``, ``list``, ``map``, ``union``, …) so dict children in any container also fail loudly. |
+| **Non-batch IPC messages** | Skipped while walking the transient stream — defensive against future pyarrow message types (compression headers, etc.) that may interleave between the schema and the batch. |
+| **Empty input** | A pyarrow stream with no ``RecordBatch`` message raises ``RuntimeError`` (writer-side defect, not a runtime case). |
+
+### Implementation sketch
+
+```python
+def serialize_arrow_record_batch(batch: pa.RecordBatch) -> bytes:
+    for field in batch.schema:
+        if _type_contains_dictionary(field.type):
+            raise ValueError(...)
+    sink = pa.BufferOutputStream()
+    writer = pa.ipc.new_stream(sink, batch.schema)
+    writer.write_batch(batch)
+    writer.close()
+    reader = pa.ipc.MessageReader.open_stream(pa.BufferReader(sink.getvalue()))
+    while True:
+        msg = reader.read_next_message()
+        if msg.type == "record batch":
+            return _serialize_one_message_to_bytes(msg)
+```
+
+The implementation uses pyarrow's high-level ``new_stream`` writer
+then peels off the schema-message prefix and EOS-marker suffix via a
+``MessageReader``. This is portable across pyarrow versions; the
+low-level ``pa.ipc.write_message`` API has signature drift between
+14.x and 17.x+ that the helper avoids.
+
+## Rationale
+
+### Why bare-message, not full-stream
+
+The bare-message format **is** the wire contract real BigQuery
+uses. Emitting a full stream made the v1.0.0 emulator
+non-interoperable with the canonical
+``google-cloud-bigquery-storage`` reader path. Bytes that "work"
+with ``pa.ipc.open_stream(payload).read_all()`` (the v1.0.0
+implementation's de-facto consumer) are silent compatibility with
+nothing — the goal is silent compatibility with the real client.
+
+### Why reject dict-encoded batches, not preserve them
+
+Three options were considered:
+
+1. **Preserve dict frames** by extending the proto with a
+   ``dictionary_batches`` field. Out of scope — diverges from real
+   BigQuery's wire format; any real client would ignore the extra
+   field and fail to decode.
+2. **Concatenate** schema-message + dict-messages + batch-message
+   into the same ``serialized_record_batch`` payload. Breaks the
+   ``ArrowRecordBatch`` proto contract (which carries one record-batch
+   message); any conforming consumer that calls
+   ``read_record_batch(bytes, schema)`` still fails.
+3. **Reject at the producer.** ✅ Real BigQuery doesn't surface
+   dict-encoded columns through Storage Read either — Avro for
+   low-cardinality, Arrow for the rest, both as plain types.
+   Producer-side rejection at the boundary matches the actual wire
+   contract. A clear ``ValueError`` with the offending column name
+   beats a silent corrupt-payload bug.
+
+### Why recurse into nested types
+
+``pa.types.is_dictionary(t)`` only inspects the top-level type
+([pyarrow 14 source](https://arrow.apache.org/docs/14.0/_modules/pyarrow/types.html)).
+Arrow's IPC format emits ``DictionaryBatch`` messages for
+dict-encoded children inside structs / unions / lists / maps too
+([arrow-rs commit 85402148c3af03d](https://github.com/apache/arrow-rs/commit/85402148c3af03d0855e81f855715ea98a7491c5)).
+A flat check at the top level would silently allow nested dict
+fields and produce the same corrupt-payload bug the rejection was
+meant to prevent. The serializer recurses through
+``struct``/``list``/``large_list``/``fixed_size_list``/``map``/``union``
+children to catch every dict-encoded leaf.
+
+## Consequences
+
+- The canonical
+  ``google-cloud-bigquery-storage`` reader path now works against
+  bqemulator unchanged — the v1.0.0 pyspark-bigquery example's
+  inline ``open_stream`` workaround was dropped in the same commit.
+- ``serialize_arrow_ipc(table)`` was removed from ``__all__`` (the
+  full-stream helper was the v1.0.0 wrong path, no callers).
+- Tables containing dict-encoded columns at any nesting depth
+  must be flattened before going through the Storage Read API.
+  This is consistent with real BigQuery's behaviour but should be
+  documented in the per-language quickstart guides as users
+  encounter the ``ValueError``.
+
+## References
+
+- Issue #15 — the consumer-side ``read_record_batch`` failure that
+  surfaced the v1.0.0 mismatch.
+- [Apache Arrow IPC format](https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc)
+- [PyArrow IPC docs](https://arrow.apache.org/docs/14.0/python/ipc.html)
+- [BigQuery Storage Read API proto](https://github.com/googleapis/googleapis/blob/master/google/cloud/bigquery/storage/v1/storage.proto)
+- ADR 0030 — sibling decision documenting the Avro alternative
+  for the same RPC.

--- a/docs/examples/python/pyspark-bigquery/example.py
+++ b/docs/examples/python/pyspark-bigquery/example.py
@@ -93,30 +93,19 @@ def _read_arrow_via_storage(grpc_endpoint: str) -> pa.Table:
             max_stream_count=1,
         )
         stream = session.streams[0].name
-        # NOTE: ``reader.to_arrow(session)`` assumes
-        # ``ArrowRecordBatch.serialized_record_batch`` carries only a
-        # single record-batch IPC message — that's the real BigQuery
-        # wire format. bqemulator currently packs the *full* Arrow IPC
-        # stream (schema framing + batches) into that field, so the
-        # client's ``pyarrow.ipc.read_record_batch`` call trips
-        # ``Expected IPC message of type record batch but got
-        # schema``. Iterate the responses by hand and use
-        # ``pa.ipc.open_stream`` (which is happy with full IPC
-        # streams) so the example still demonstrates Storage Read
-        # against the emulator. Tracked for cleanup in v1.0.1: the
-        # server should emit just the record-batch message and
-        # publish the schema via ``ReadSession.arrow_schema``.
+        # ``reader.to_arrow(session)`` is the natural Storage Read
+        # consumer path: it reads ``session.arrow_schema.serialized_schema``
+        # once, then parses each response's
+        # ``ArrowRecordBatch.serialized_record_batch`` via
+        # ``pyarrow.ipc.read_record_batch`` — which is exactly the
+        # wire-format contract bqemulator's read servicer emits since
+        # v1.0.1 (issue #15). v1.0.0 packed a full IPC stream into
+        # ``serialized_record_batch`` and tripped the client; the v1.0.1
+        # fix emits just the batch message and publishes the schema
+        # separately, so this call works against real BigQuery and the
+        # emulator identically.
         reader = storage.read_rows(stream)
-        batches: list[pa.RecordBatch] = []
-        for response in reader:
-            payload = response.arrow_record_batch.serialized_record_batch
-            if not payload:
-                continue
-            with pa.ipc.open_stream(payload) as stream_reader:
-                batches.extend(stream_reader.read_all().to_batches())
-        if not batches:
-            return pa.table({})
-        return pa.Table.from_batches(batches)
+        return reader.to_arrow(session)
     finally:
         storage.transport.close()
 

--- a/src/bqemulator/grpc_api/read_servicer.py
+++ b/src/bqemulator/grpc_api/read_servicer.py
@@ -28,7 +28,7 @@ from bqemulator.streaming.read_session import (
     FORMAT_AVRO,
     create_read_session,
     get_stream_data,
-    serialize_arrow_ipc,
+    serialize_arrow_record_batch,
 )
 
 _COLUMN_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,299}$")
@@ -417,7 +417,12 @@ class BigQueryReadHandler(grpc.GenericRpcHandler):
                     )
                     is_first = False
             else:
-                ipc_bytes = serialize_arrow_ipc(batch_table)
+                # ``serialized_record_batch`` carries ONLY the
+                # batch-message bytes; the schema travels separately
+                # via ``ReadSession.arrow_schema.serialized_schema``
+                # and the first response's ``arrow_schema`` field.
+                # See issue #15 for the format-mismatch fix.
+                ipc_bytes = serialize_arrow_record_batch(batch)
                 kwargs["arrow_record_batch"] = types.ArrowRecordBatch(
                     serialized_record_batch=ipc_bytes,
                 )

--- a/src/bqemulator/streaming/read_session.py
+++ b/src/bqemulator/streaming/read_session.py
@@ -242,19 +242,54 @@ def split_stream(stream_name: str, fraction: float) -> tuple[str, str] | None:
     return primary_name, remainder_name
 
 
-def serialize_arrow_ipc(table: pa.Table) -> bytes:
-    """Serialize an Arrow table as Arrow IPC stream format.
+def serialize_arrow_record_batch(batch: pa.RecordBatch) -> bytes:
+    """Serialize a single Arrow record batch as a bare IPC message.
 
-    This produces the bytes that ``ReadRowsResponse.arrow_record_batch.serialized_record_batch``
-    carries over the wire.
+    Returns ONLY the record-batch IPC message bytes (continuation
+    marker + metadata length + flatbuffer metadata + padding + body
+    buffers), NOT a full IPC stream. This matches the BigQuery
+    Storage Read API contract: ``ArrowRecordBatch.serialized_record_batch``
+    is documented to carry a single batch message; the schema travels
+    separately via ``ReadSession.arrow_schema.serialized_schema`` and
+    the first ``ReadRowsResponse.arrow_schema`` field.
+
+    Earlier (≤ v1.0.0) the read servicer packed a full IPC stream
+    (schema framing + batches + EOS marker) into ``serialized_record_batch``.
+    Real Storage Read clients tripped on the format mismatch — e.g.
+    ``google-cloud-bigquery-storage``'s ``reader.to_arrow(session)``
+    calls ``pyarrow.ipc.read_record_batch(...)`` which raises
+    ``OSError: Expected IPC message of type record batch but got schema``.
+    This function emits the documented format so those clients work
+    unchanged. See issue #15.
+
+    The implementation writes the batch through ``pa.ipc.new_stream``
+    to a transient buffer, then re-reads the stream with a
+    ``MessageReader`` to peel off the schema-message prefix and the
+    EOS-marker suffix, leaving just the batch-message bytes. This is
+    the portable approach across pyarrow versions; the alternative
+    (low-level ``pa.ipc.write_message``) has signature drift between
+    pyarrow 14.x and 17.x+ that we'd rather not chase.
     """
-    sink = io.BytesIO()
-    writer = pa.ipc.new_stream(sink, table.schema)  # type: ignore[no-untyped-call,unused-ignore]
-    # Write all batches.
-    for batch in table.to_batches():
-        writer.write_batch(batch)
+    sink = pa.BufferOutputStream()
+    writer = pa.ipc.new_stream(sink, batch.schema)  # type: ignore[no-untyped-call,unused-ignore]
+    writer.write_batch(batch)
     writer.close()
-    return sink.getvalue()
+    stream_bytes = sink.getvalue()
+
+    # Stream layout: [schema-message][batch-message][EOS-marker].
+    # We want only the middle slot. ``MessageReader`` is re-exported
+    # by the ``pyarrow.ipc`` module but the stubs don't list it; the
+    # ignore matches the pattern used elsewhere in this file for
+    # ``new_stream``.
+    reader = pa.ipc.MessageReader.open_stream(  # type: ignore[attr-defined]
+        pa.BufferReader(stream_bytes)
+    )
+    reader.read_next_message()  # discard schema message
+    batch_msg = reader.read_next_message()
+
+    out = pa.BufferOutputStream()
+    batch_msg.serialize_to(out)
+    return bytes(out.getvalue())
 
 
 __all__ = [
@@ -265,6 +300,6 @@ __all__ = [
     "create_read_session",
     "get_session",
     "get_stream_data",
-    "serialize_arrow_ipc",
+    "serialize_arrow_record_batch",
     "split_stream",
 ]

--- a/src/bqemulator/streaming/read_session.py
+++ b/src/bqemulator/streaming/read_session.py
@@ -269,6 +269,18 @@ def serialize_arrow_record_batch(batch: pa.RecordBatch) -> bytes:
     the portable approach across pyarrow versions; the alternative
     (low-level ``pa.ipc.write_message``) has signature drift between
     pyarrow 14.x and 17.x+ that we'd rather not chase.
+
+    Arrow IPC streaming permits ``DictionaryBatch`` messages between
+    the schema and the first ``RecordBatch`` when the batch carries
+    dictionary-encoded columns — pyarrow's writer emits one
+    DictionaryBatch per dict-encoded field. Naively grabbing the
+    *second* message would capture a dictionary, not the batch. The
+    loop below skips non-RecordBatch messages so callers always get
+    the actual batch payload back. (The current BigQuery Storage
+    Read wire format doesn't carry separate dictionary messages on
+    the wire — clients reconstruct dictionaries from the schema. If
+    we ever need to surface dictionaries we'd extend the protocol;
+    for now skipping them is the right defensive default.)
     """
     sink = pa.BufferOutputStream()
     writer = pa.ipc.new_stream(sink, batch.schema)  # type: ignore[no-untyped-call,unused-ignore]
@@ -276,16 +288,36 @@ def serialize_arrow_record_batch(batch: pa.RecordBatch) -> bytes:
     writer.close()
     stream_bytes = sink.getvalue()
 
-    # Stream layout: [schema-message][batch-message][EOS-marker].
-    # We want only the middle slot. ``MessageReader`` is re-exported
-    # by the ``pyarrow.ipc`` module but the stubs don't list it; the
+    # Stream layout (typed schemas without dict columns):
+    #   [schema-message][batch-message][EOS-marker]
+    # Stream layout (with dict-encoded columns):
+    #   [schema][dict-1]...[dict-N][batch][EOS]
+    # Either way we want the RecordBatch message — loop until we
+    # find one. ``MessageReader`` is re-exported by the
+    # ``pyarrow.ipc`` module but the stubs don't list it; the
     # ignore matches the pattern used elsewhere in this file for
     # ``new_stream``.
     reader = pa.ipc.MessageReader.open_stream(  # type: ignore[attr-defined]
         pa.BufferReader(stream_bytes)
     )
-    reader.read_next_message()  # discard schema message
-    batch_msg = reader.read_next_message()
+    batch_msg = None
+    try:
+        while True:
+            msg = reader.read_next_message()
+            if msg.type == "record batch":
+                batch_msg = msg
+                break
+            # Otherwise (schema / dictionary / ...), skip and
+            # keep reading.
+    except StopIteration:
+        # End-of-stream without ever seeing a RecordBatch is a
+        # writer-side bug — defend against it explicitly rather
+        # than returning empty bytes downstream.
+        pass
+    if batch_msg is None:
+        raise RuntimeError(
+            "pyarrow IPC stream contained no RecordBatch message",
+        )
 
     out = pa.BufferOutputStream()
     batch_msg.serialize_to(out)

--- a/src/bqemulator/streaming/read_session.py
+++ b/src/bqemulator/streaming/read_session.py
@@ -270,18 +270,41 @@ def serialize_arrow_record_batch(batch: pa.RecordBatch) -> bytes:
     (low-level ``pa.ipc.write_message``) has signature drift between
     pyarrow 14.x and 17.x+ that we'd rather not chase.
 
-    Arrow IPC streaming permits ``DictionaryBatch`` messages between
-    the schema and the first ``RecordBatch`` when the batch carries
-    dictionary-encoded columns — pyarrow's writer emits one
-    DictionaryBatch per dict-encoded field. Naively grabbing the
-    *second* message would capture a dictionary, not the batch. The
-    loop below skips non-RecordBatch messages so callers always get
-    the actual batch payload back. (The current BigQuery Storage
-    Read wire format doesn't carry separate dictionary messages on
-    the wire — clients reconstruct dictionaries from the schema. If
-    we ever need to surface dictionaries we'd extend the protocol;
-    for now skipping them is the right defensive default.)
+    Dictionary-encoded columns are explicitly rejected. The
+    BigQuery Storage Read wire format only carries
+    ``ArrowSchema.serialized_schema`` and
+    ``ArrowRecordBatch.serialized_record_batch`` — there's no slot
+    for ``DictionaryBatch`` frames. pyarrow's
+    ``read_record_batch(bytes, schema)`` requires a populated
+    ``DictionaryMemo`` to decode dict-encoded fields, which the
+    bare-message contract can't provide; quietly stripping the
+    ``DictionaryBatch`` frames would produce a wire-format message
+    consumers can't decode. Raise ``ValueError`` at the producer
+    boundary so the misuse fails loudly. Real BigQuery doesn't
+    surface dict-encoded columns through Storage Read either —
+    if a future code path needs them, plumb a separate channel
+    for the dictionary frames or use a different wire format.
+
+    The loop below also skips any unexpected non-RecordBatch
+    message types pyarrow could emit (compression headers,
+    sentinel markers in future format versions, …) so the
+    function stays correct across pyarrow upgrades.
     """
+    # Refuse dict-encoded batches up front — see docstring.
+    # Using ``schema_field`` instead of ``field`` to avoid shadowing
+    # the ``dataclasses.field`` import at the top of the module.
+    for schema_field in batch.schema:
+        if pa.types.is_dictionary(schema_field.type):
+            raise ValueError(
+                f"Dictionary-encoded columns are not supported by"
+                f" the BigQuery Storage Read API serializer "
+                f"(column {schema_field.name!r} has type "
+                f"{schema_field.type}). The wire contract carries"
+                f" only the record-batch message, but pyarrow"
+                f" requires a DictionaryMemo to decode dict frames"
+                f" — that channel does not exist in the wire format."
+            )
+
     sink = pa.BufferOutputStream()
     writer = pa.ipc.new_stream(sink, batch.schema)  # type: ignore[no-untyped-call,unused-ignore]
     writer.write_batch(batch)

--- a/src/bqemulator/streaming/read_session.py
+++ b/src/bqemulator/streaming/read_session.py
@@ -242,6 +242,33 @@ def split_stream(stream_name: str, fraction: float) -> tuple[str, str] | None:
     return primary_name, remainder_name
 
 
+def _type_contains_dictionary(arrow_type: pa.DataType) -> bool:
+    """Return ``True`` if ``arrow_type`` or any nested child is dict-encoded.
+
+    ``pa.types.is_dictionary`` only inspects the top-level type;
+    Arrow's IPC format emits ``DictionaryBatch`` frames for dict
+    children inside struct / list / map / union containers as well.
+    See ADR 0033.
+    """
+    if pa.types.is_dictionary(arrow_type):
+        return True
+    if pa.types.is_struct(arrow_type):
+        return any(_type_contains_dictionary(f.type) for f in arrow_type)
+    if (
+        pa.types.is_list(arrow_type)
+        or pa.types.is_large_list(arrow_type)
+        or pa.types.is_fixed_size_list(arrow_type)
+    ):
+        return _type_contains_dictionary(arrow_type.value_type)
+    if pa.types.is_map(arrow_type):
+        return _type_contains_dictionary(arrow_type.key_type) or _type_contains_dictionary(
+            arrow_type.item_type
+        )
+    if pa.types.is_union(arrow_type):
+        return any(_type_contains_dictionary(f.type) for f in arrow_type)
+    return False
+
+
 def serialize_arrow_record_batch(batch: pa.RecordBatch) -> bytes:
     """Serialize a single Arrow record batch as a bare IPC message.
 
@@ -291,18 +318,26 @@ def serialize_arrow_record_batch(batch: pa.RecordBatch) -> bytes:
     function stays correct across pyarrow upgrades.
     """
     # Refuse dict-encoded batches up front — see docstring.
-    # Using ``schema_field`` instead of ``field`` to avoid shadowing
-    # the ``dataclasses.field`` import at the top of the module.
+    # Walks every type recursively because ``pa.types.is_dictionary``
+    # only inspects the top-level type, and Arrow's IPC format emits
+    # ``DictionaryBatch`` frames for dict-encoded children inside
+    # struct / list / map / union containers as well. A flat check
+    # would silently allow nested dict fields and produce the same
+    # corrupt-payload bug the rejection guards against. Using
+    # ``schema_field`` instead of ``field`` to avoid shadowing the
+    # ``dataclasses.field`` import at the top of the module.
     for schema_field in batch.schema:
-        if pa.types.is_dictionary(schema_field.type):
+        if _type_contains_dictionary(schema_field.type):
             raise ValueError(
                 f"Dictionary-encoded columns are not supported by"
                 f" the BigQuery Storage Read API serializer "
                 f"(column {schema_field.name!r} has type "
-                f"{schema_field.type}). The wire contract carries"
-                f" only the record-batch message, but pyarrow"
-                f" requires a DictionaryMemo to decode dict frames"
-                f" — that channel does not exist in the wire format."
+                f"{schema_field.type}; dict-encoded leaf detected"
+                f" at the top level or in a nested container). The"
+                f" wire contract carries only the record-batch"
+                f" message, but pyarrow requires a DictionaryMemo"
+                f" to decode dict frames — that channel does not"
+                f" exist in the wire format. See ADR 0033."
             )
 
     sink = pa.BufferOutputStream()

--- a/tests/e2e/go_client/storage_read_test.go
+++ b/tests/e2e/go_client/storage_read_test.go
@@ -111,6 +111,22 @@ func TestStorageReadStorageReadShipCriterion(t *testing.T) {
 		t.Fatal("CreateReadSession returned no streams")
 	}
 
+	// ``serialized_record_batch`` carries a BARE Arrow IPC
+	// record-batch message (no schema-message prefix, no EOS-marker
+	// suffix). The schema travels separately on
+	// ``session.arrow_schema.serialized_schema`` (which we emit as a
+	// one-message stream with trailing EOS — same shape pyarrow's
+	// ``new_stream(schema).close()`` produces). ``ipc.NewReader``
+	// expects a full stream, so we synthesise one per batch by
+	// concatenating the schema-stream bytes (minus their trailing
+	// EOS) + the batch message + an EOS marker.
+	schemaStream := session.GetArrowSchema().GetSerializedSchema()
+	if len(schemaStream) <= 8 {
+		t.Fatalf("session.arrow_schema is empty or malformed (%d bytes)", len(schemaStream))
+	}
+	schemaOnly := schemaStream[:len(schemaStream)-8]
+	eosMarker := []byte{0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00}
+
 	total := 0
 	for _, stream := range session.GetStreams() {
 		rows, err := readClient.ReadRows(ctx, &storagepb.ReadRowsRequest{ReadStream: stream.GetName()})
@@ -125,15 +141,15 @@ func TestStorageReadStorageReadShipCriterion(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ReadRows.Recv: %v", err)
 			}
-			// The emulator serializes each batch as a self-contained IPC
-			// stream (schema header + record batch), so the reader can
-			// open the batch payload directly without prepending the
-			// session-level arrow_schema.
 			batch := resp.GetArrowRecordBatch().GetSerializedRecordBatch()
 			if len(batch) == 0 {
 				continue
 			}
-			reader, err := ipc.NewReader(bytes.NewReader(batch))
+			merged := make([]byte, 0, len(schemaOnly)+len(batch)+8)
+			merged = append(merged, schemaOnly...)
+			merged = append(merged, batch...)
+			merged = append(merged, eosMarker...)
+			reader, err := ipc.NewReader(bytes.NewReader(merged))
 			if err != nil {
 				t.Fatalf("ipc.NewReader: %v", err)
 			}

--- a/tests/e2e/java_client/src/test/java/com/example/StorageReadTest.java
+++ b/tests/e2e/java_client/src/test/java/com/example/StorageReadTest.java
@@ -135,6 +135,29 @@ class StorageReadTest {
                 assertTrue(session.getStreamsCount() >= 1,
                         "expected at least one stream");
 
+                // ``serialized_record_batch`` carries a BARE Arrow IPC
+                // record-batch message (no schema-message prefix, no
+                // EOS-marker suffix). The schema travels separately on
+                // ``session.arrow_schema.serialized_schema`` (which we
+                // emit as a one-message stream with trailing EOS — same
+                // shape pyarrow's ``new_stream(schema).close()``
+                // produces). ``ArrowStreamReader`` expects a full
+                // stream, so we synthesise one per batch by
+                // concatenating the schema-stream bytes (minus their
+                // trailing EOS) + the batch message + an EOS marker.
+                byte[] schemaStream = session.getArrowSchema()
+                        .getSerializedSchema()
+                        .toByteArray();
+                assertTrue(schemaStream.length > 8,
+                        "session.arrow_schema is empty or malformed");
+                // Strip the 8-byte EOS marker (0xFFFFFFFF + 0x00000000)
+                // from the trailing position of the schema stream.
+                byte[] schemaOnly = new byte[schemaStream.length - 8];
+                System.arraycopy(schemaStream, 0, schemaOnly, 0, schemaOnly.length);
+                byte[] eosMarker = new byte[]{
+                        (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                        0x00, 0x00, 0x00, 0x00};
+
                 int total = 0;
                 try (BufferAllocator allocator = new RootAllocator()) {
                     for (int i = 0; i < session.getStreamsCount(); i++) {
@@ -149,12 +172,15 @@ class StorageReadTest {
                             if (batch.length == 0) {
                                 continue;
                             }
-                            // The emulator serializes each batch as a
-                            // self-contained Arrow IPC stream (schema
-                            // header + record batch), so the reader
-                            // parses the batch payload directly.
+                            java.io.ByteArrayOutputStream merged =
+                                    new java.io.ByteArrayOutputStream(
+                                            schemaOnly.length + batch.length + 8);
+                            merged.write(schemaOnly);
+                            merged.write(batch);
+                            merged.write(eosMarker);
                             try (ArrowStreamReader reader = new ArrowStreamReader(
-                                    new ByteArrayInputStream(batch), allocator)) {
+                                    new ByteArrayInputStream(merged.toByteArray()),
+                                    allocator)) {
                                 while (reader.loadNextBatch()) {
                                     VectorSchemaRoot root = reader.getVectorSchemaRoot();
                                     total += root.getRowCount();

--- a/tests/e2e/nodejs_client/test/storage_read.test.js
+++ b/tests/e2e/nodejs_client/test/storage_read.test.js
@@ -174,11 +174,11 @@ function decodeReadSessionStreams(buf) {
   return names;
 }
 
-// ReadSession.arrow_schema=8 (ArrowSchema).
+// ReadSession.arrow_schema=5 (ArrowSchema, in the ``oneof schema`` block).
 // ArrowSchema.serialized_schema=1 (bytes).
 function decodeReadSessionArrowSchema(buf) {
   for (const [fn, wt, payload] of iterFields(buf)) {
-    if (fn === 8 && wt === 2) {
+    if (fn === 5 && wt === 2) {
       for (const [innerFn, innerWt, innerPayload] of iterFields(payload)) {
         if (innerFn === 1 && innerWt === 2) {
           return innerPayload;

--- a/tests/e2e/nodejs_client/test/storage_read.test.js
+++ b/tests/e2e/nodejs_client/test/storage_read.test.js
@@ -240,7 +240,16 @@ describe("bqemulator Phase 4 Storage Read (Node.js via gRPC + Arrow IPC)", () =>
         "CreateReadSession returned no streams",
       );
       const schemaBytes = decodeReadSessionArrowSchema(sessionBytes);
-      assert.ok(schemaBytes, "CreateReadSession returned no arrow_schema");
+      // Validate length BEFORE slicing the trailing EOS marker (8
+      // bytes — 0xFFFFFFFF continuation + 0x00000000 zero-length).
+      // The Go and Java tests do the same. A truthy-but-too-short
+      // ``schemaBytes`` would silently produce a garbage
+      // ``schemaOnly`` and the test would fail downstream with an
+      // opaque Arrow parse error.
+      assert.ok(
+        schemaBytes && schemaBytes.length > 8,
+        "CreateReadSession returned no arrow_schema or schema is malformed (need > 8 bytes for EOS marker stripping)",
+      );
 
       // ReadRows on the first stream.
       //

--- a/tests/e2e/nodejs_client/test/storage_read.test.js
+++ b/tests/e2e/nodejs_client/test/storage_read.test.js
@@ -174,6 +174,21 @@ function decodeReadSessionStreams(buf) {
   return names;
 }
 
+// ReadSession.arrow_schema=8 (ArrowSchema).
+// ArrowSchema.serialized_schema=1 (bytes).
+function decodeReadSessionArrowSchema(buf) {
+  for (const [fn, wt, payload] of iterFields(buf)) {
+    if (fn === 8 && wt === 2) {
+      for (const [innerFn, innerWt, innerPayload] of iterFields(payload)) {
+        if (innerFn === 1 && innerWt === 2) {
+          return innerPayload;
+        }
+      }
+    }
+  }
+  return null;
+}
+
 // ReadRowsResponse: arrow_record_batch=4 (ArrowRecordBatch).
 // ArrowRecordBatch.serialized_record_batch=1 (bytes).
 function decodeReadRowsBatch(buf) {
@@ -224,8 +239,30 @@ describe("bqemulator Phase 4 Storage Read (Node.js via gRPC + Arrow IPC)", () =>
         streamNames.length >= 1,
         "CreateReadSession returned no streams",
       );
+      const schemaBytes = decodeReadSessionArrowSchema(sessionBytes);
+      assert.ok(schemaBytes, "CreateReadSession returned no arrow_schema");
 
       // ReadRows on the first stream.
+      //
+      // The emulator emits ``serialized_record_batch`` as a BARE Arrow
+      // IPC record-batch message (no schema-message prefix, no EOS
+      // marker) — that's the BigQuery contract; v1.0.0 was wrong and
+      // packed a full stream, fixed in #15. The schema travels on the
+      // session's ``arrow_schema.serialized_schema`` field (which we
+      // emit as a one-message stream with trailing EOS — same shape
+      // pyarrow's ``new_stream(schema).close()`` produces).
+      //
+      // ``apache-arrow`` JS's ``RecordBatchReader.from`` parses a full
+      // stream, not a bare message. To consume the new format with
+      // the stock JS API, synthesise a single-batch stream by
+      // concatenating the schema-stream bytes (minus their trailing
+      // EOS) + the batch message + an EOS marker.
+      const EOS_MARKER = Buffer.from([
+        0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00,
+      ]);
+      // ``schemaBytes`` is ``[schema-msg][EOS]`` — strip the EOS.
+      const schemaOnly = schemaBytes.slice(0, schemaBytes.length - 8);
+
       let total = 0;
       await new Promise((resolve, reject) => {
         const stream = channel.makeServerStreamRequest(
@@ -238,10 +275,13 @@ describe("bqemulator Phase 4 Storage Read (Node.js via gRPC + Arrow IPC)", () =>
         stream.on("data", (buf) => {
           const batchBytes = decodeReadRowsBatch(buf);
           if (!batchBytes || batchBytes.length === 0) return;
-          // The emulator serializes each batch as a self-contained
-          // Arrow IPC stream (schema header + record batch).
+          const synthetic = Buffer.concat([
+            schemaOnly,
+            batchBytes,
+            EOS_MARKER,
+          ]);
           const reader = apacheArrow.RecordBatchReader.from(
-            new Uint8Array(batchBytes),
+            new Uint8Array(synthetic),
           );
           for (const recordBatch of reader) {
             total += recordBatch.numRows;

--- a/tests/e2e/python_client/test_storage_read.py
+++ b/tests/e2e/python_client/test_storage_read.py
@@ -86,6 +86,7 @@ def test_create_read_session_and_read_rows(
             session = types.ReadSession.deserialize(resp_bytes)
             assert len(session.streams) >= 1
 
+            schema = pa.ipc.open_stream(session.arrow_schema.serialized_schema).schema
             total = 0
             for stream in session.streams:
                 read_req = types.ReadRowsRequest(read_stream=stream.name)
@@ -94,10 +95,11 @@ def test_create_read_session_and_read_rows(
                 ):
                     resp = types.ReadRowsResponse.deserialize(resp_bytes)
                     if resp.arrow_record_batch.serialized_record_batch:
-                        reader = pa.ipc.open_stream(
+                        batch = pa.ipc.read_record_batch(
                             resp.arrow_record_batch.serialized_record_batch,
+                            schema,
                         )
-                        total += reader.read_all().num_rows
+                        total += batch.num_rows
             assert total == 3
         finally:
             channel.close()
@@ -132,6 +134,7 @@ def test_row_filter_pushdown(
                     types.CreateReadSessionRequest.serialize(req),
                 ),
             )
+            schema = pa.ipc.open_stream(resp.arrow_schema.serialized_schema).schema
             total = 0
             read_req = types.ReadRowsRequest(read_stream=resp.streams[0].name)
             for resp_bytes in channel.unary_stream(f"{_READ}/ReadRows")(
@@ -139,10 +142,11 @@ def test_row_filter_pushdown(
             ):
                 rr = types.ReadRowsResponse.deserialize(resp_bytes)
                 if rr.arrow_record_batch.serialized_record_batch:
-                    reader = pa.ipc.open_stream(
+                    batch = pa.ipc.read_record_batch(
                         rr.arrow_record_batch.serialized_record_batch,
+                        schema,
                     )
-                    total += reader.read_all().num_rows
+                    total += batch.num_rows
             # Alice (90) + Carol (85) pass, Bob (70) filtered.
             assert total == 2
         finally:

--- a/tests/integration/test_cross_workflow.py
+++ b/tests/integration/test_cross_workflow.py
@@ -274,6 +274,7 @@ def test_full_cross_workflow(  # noqa: PLR0915
     # ReadRows — read data back via Arrow IPC.
     import pyarrow as pa
 
+    schema = pa.ipc.open_stream(session.arrow_schema.serialized_schema).schema
     total_storage_rows = 0
     for stream in session.streams:
         read_req = storage_types.ReadRowsRequest(read_stream=stream.name)
@@ -285,10 +286,11 @@ def test_full_cross_workflow(  # noqa: PLR0915
         for r in responses:
             rr = storage_types.ReadRowsResponse.deserialize(r)
             if rr.arrow_record_batch.serialized_record_batch:
-                reader = pa.ipc.open_stream(
+                batch = pa.ipc.read_record_batch(
                     rr.arrow_record_batch.serialized_record_batch,
+                    schema,
                 )
-                total_storage_rows += reader.read_all().num_rows
+                total_storage_rows += batch.num_rows
     # Should match the 5 rows we loaded (3 insertAll + 2 CSV load).
     assert total_storage_rows == 5
 
@@ -316,13 +318,15 @@ def test_full_cross_workflow(  # noqa: PLR0915
             "/google.cloud.bigquery.storage.v1.BigQueryRead/ReadRows",
         )(storage_types.ReadRowsRequest.serialize(proj_read))
     )
+    proj_schema = pa.ipc.open_stream(proj_session.arrow_schema.serialized_schema).schema
     for r in proj_responses:
         rr = storage_types.ReadRowsResponse.deserialize(r)
         if rr.arrow_record_batch.serialized_record_batch:
-            tbl = pa.ipc.open_stream(
+            batch = pa.ipc.read_record_batch(
                 rr.arrow_record_batch.serialized_record_batch,
-            ).read_all()
-            assert tbl.column_names == ["customer"]
+                proj_schema,
+            )
+            assert batch.schema.names == ["customer"]
 
     channel.close()
 

--- a/tests/integration/test_storage_read_api.py
+++ b/tests/integration/test_storage_read_api.py
@@ -90,16 +90,24 @@ def test_create_read_session_via_grpc(bqemu_server: EmulatorServer) -> None:
 
     assert len(responses) >= 1
 
-    # Deserialize and verify Arrow data.
+    # Deserialize and verify Arrow data. ``serialized_record_batch``
+    # carries a bare batch message; the schema travels separately on
+    # ``ReadSession.arrow_schema.serialized_schema``. Reconstruct the
+    # schema once and use ``read_record_batch`` per response — this is
+    # exactly the path real Storage Read clients
+    # (``google-cloud-bigquery-storage``) follow. See issue #15.
     import pyarrow as pa
 
+    schema = pa.ipc.open_stream(session.arrow_schema.serialized_schema).schema
     total_rows = 0
     for resp_bytes in responses:
         resp = types.ReadRowsResponse.deserialize(resp_bytes)
         if resp.arrow_record_batch.serialized_record_batch:
-            reader = pa.ipc.open_stream(resp.arrow_record_batch.serialized_record_batch)
-            batch_table = reader.read_all()
-            total_rows += batch_table.num_rows
+            batch = pa.ipc.read_record_batch(
+                resp.arrow_record_batch.serialized_record_batch,
+                schema,
+            )
+            total_rows += batch.num_rows
 
     assert total_rows > 0
 
@@ -147,12 +155,15 @@ def test_create_read_session_with_projection(bqemu_server: EmulatorServer) -> No
 
     import pyarrow as pa
 
+    schema = pa.ipc.open_stream(session.arrow_schema.serialized_schema).schema
     for resp_bytes in responses:
         resp = types.ReadRowsResponse.deserialize(resp_bytes)
         if resp.arrow_record_batch.serialized_record_batch:
-            reader = pa.ipc.open_stream(resp.arrow_record_batch.serialized_record_batch)
-            batch_table = reader.read_all()
-            assert batch_table.column_names == ["value"]
+            batch = pa.ipc.read_record_batch(
+                resp.arrow_record_batch.serialized_record_batch,
+                schema,
+            )
+            assert batch.schema.names == ["value"]
 
     channel.close()
     _make_bq_client(bqemu_server).delete_dataset("storage_read", delete_contents=True)

--- a/tests/integration/test_storage_read_edge_cases.py
+++ b/tests/integration/test_storage_read_edge_cases.py
@@ -163,15 +163,18 @@ class TestReadWithProjection:
             )(types.ReadRowsRequest.serialize(read_req))
         )
 
+        schema = pa.ipc.open_stream(session.arrow_schema.serialized_schema).schema
+        total_rows = 0
         for r in responses:
             rr = types.ReadRowsResponse.deserialize(r)
             if rr.arrow_record_batch.serialized_record_batch:
-                reader = pa.ipc.open_stream(
+                batch = pa.ipc.read_record_batch(
                     rr.arrow_record_batch.serialized_record_batch,
+                    schema,
                 )
-                table = reader.read_all()
-                assert table.column_names == ["name"]
-                assert table.num_rows == 3
+                assert batch.schema.names == ["name"]
+                total_rows += batch.num_rows
+        assert total_rows == 3
 
         channel.close()
 
@@ -212,15 +215,16 @@ class TestReadWithRowFilter:
             )(types.ReadRowsRequest.serialize(read_req))
         )
 
+        schema = pa.ipc.open_stream(session.arrow_schema.serialized_schema).schema
         total_rows = 0
         for r in responses:
             rr = types.ReadRowsResponse.deserialize(r)
             if rr.arrow_record_batch.serialized_record_batch:
-                reader = pa.ipc.open_stream(
+                batch = pa.ipc.read_record_batch(
                     rr.arrow_record_batch.serialized_record_batch,
+                    schema,
                 )
-                table = reader.read_all()
-                total_rows += table.num_rows
+                total_rows += batch.num_rows
 
         # Alice (90) and Carol (85) pass, Bob (70) filtered out.
         assert total_rows == 2
@@ -254,6 +258,7 @@ class TestMultiStreamRead:
         session = types.ReadSession.deserialize(resp)
 
         # Read ALL streams and count total rows.
+        schema = pa.ipc.open_stream(session.arrow_schema.serialized_schema).schema
         total_rows = 0
         for stream in session.streams:
             read_req = types.ReadRowsRequest(read_stream=stream.name)
@@ -265,10 +270,11 @@ class TestMultiStreamRead:
             for r in responses:
                 rr = types.ReadRowsResponse.deserialize(r)
                 if rr.arrow_record_batch.serialized_record_batch:
-                    reader = pa.ipc.open_stream(
+                    batch = pa.ipc.read_record_batch(
                         rr.arrow_record_batch.serialized_record_batch,
+                        schema,
                     )
-                    total_rows += reader.read_all().num_rows
+                    total_rows += batch.num_rows
 
         assert total_rows == 3
 

--- a/tests/perf/test_storage_read_throughput.py
+++ b/tests/perf/test_storage_read_throughput.py
@@ -93,18 +93,19 @@ def test_storage_read_arrow_throughput(
         channel = grpc.insecure_channel(bqemu_server.grpc_endpoint)
         try:
             session = _create_read_session(channel, storage_read_table)
+            schema = pa.ipc.open_stream(session.arrow_schema.serialized_schema).schema
             read_request = types.ReadRowsRequest(read_stream=session.streams[0].name)
             read_bytes = types.ReadRowsRequest.serialize(read_request)
             total_rows = 0
             total_bytes = 0
             for resp_bytes in channel.unary_stream(f"{_READ}/ReadRows")(read_bytes):
                 resp = types.ReadRowsResponse.deserialize(resp_bytes)
-                batch = resp.arrow_record_batch.serialized_record_batch
-                if not batch:
+                batch_bytes = resp.arrow_record_batch.serialized_record_batch
+                if not batch_bytes:
                     continue
-                total_bytes += len(batch)
-                reader = pa.ipc.open_stream(batch)
-                total_rows += reader.read_all().num_rows
+                total_bytes += len(batch_bytes)
+                batch = pa.ipc.read_record_batch(batch_bytes, schema)
+                total_rows += batch.num_rows
         finally:
             channel.close()
         return total_rows, total_bytes

--- a/tests/unit/streaming/test_read_session.py
+++ b/tests/unit/streaming/test_read_session.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 import pyarrow as pa
 import pytest
 
@@ -124,5 +126,113 @@ class TestSerializeArrowRecordBatch:
         # ``open_stream`` requires.
         batch = sample_table.combine_chunks().to_batches()[0]
         msg_bytes = serialize_arrow_record_batch(batch)
+        with pytest.raises((OSError, pa.lib.ArrowInvalid)):
+            pa.ipc.open_stream(msg_bytes).read_all()
+
+
+# Hypothesis strategies for the property test below. The repo
+# convention (cited by CodeRabbit on PR #31) is to use Hypothesis
+# for combinatorial surfaces — type × nullability × row-count is a
+# textbook fit. We restrict to scalar types Arrow can round-trip
+# without DuckDB-side coercion, since this test exercises the
+# pyarrow IPC layer in isolation (not the full read-session path).
+
+_HY_TYPES = st.sampled_from(
+    [
+        pa.int8(),
+        pa.int16(),
+        pa.int32(),
+        pa.int64(),
+        pa.uint8(),
+        pa.uint16(),
+        pa.uint32(),
+        pa.uint64(),
+        pa.float32(),
+        pa.float64(),
+        pa.bool_(),
+        pa.string(),
+        pa.binary(),
+        pa.date32(),
+        pa.timestamp("us"),
+    ],
+)
+
+
+@st.composite
+def _hy_record_batch(draw: st.DrawFn) -> pa.RecordBatch:
+    """Generate a ``pa.RecordBatch`` with random schema and row count."""
+    n_cols = draw(st.integers(min_value=1, max_value=4))
+    n_rows = draw(st.integers(min_value=0, max_value=12))
+    fields: list[pa.Field] = []
+    arrays: list[pa.Array] = []
+    for i in range(n_cols):
+        arrow_type = draw(_HY_TYPES)
+        nullable = draw(st.booleans())
+        fields.append(pa.field(f"c{i}", arrow_type, nullable=nullable))
+        # Build values via a type-driven helper. Each ``pa.array(...)``
+        # call validates the values against the declared type, so we
+        # only need to draw shape-compatible primitives.
+        if pa.types.is_integer(arrow_type) or pa.types.is_unsigned_integer(arrow_type):
+            vals: list = draw(
+                st.lists(st.integers(min_value=0, max_value=100), min_size=n_rows, max_size=n_rows)
+            )
+        elif pa.types.is_floating(arrow_type):
+            vals = draw(
+                st.lists(
+                    st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+                    min_size=n_rows,
+                    max_size=n_rows,
+                )
+            )
+        elif pa.types.is_boolean(arrow_type):
+            vals = draw(st.lists(st.booleans(), min_size=n_rows, max_size=n_rows))
+        elif pa.types.is_string(arrow_type):
+            vals = draw(
+                st.lists(st.text(min_size=0, max_size=16), min_size=n_rows, max_size=n_rows)
+            )
+        elif pa.types.is_binary(arrow_type):
+            vals = draw(
+                st.lists(st.binary(min_size=0, max_size=16), min_size=n_rows, max_size=n_rows)
+            )
+        elif pa.types.is_date(arrow_type) or pa.types.is_timestamp(arrow_type):
+            # ``pa.array`` will accept Python ``int`` / ``None`` and
+            # interpret as the underlying logical unit.
+            vals = draw(
+                st.lists(
+                    st.integers(min_value=0, max_value=1_000_000),
+                    min_size=n_rows,
+                    max_size=n_rows,
+                )
+            )
+        else:  # pragma: no cover — strategy is exhaustive
+            raise AssertionError(f"unhandled type in strategy: {arrow_type}")
+        # Optionally null-out some entries when the field is nullable.
+        if nullable and vals:
+            mask = draw(st.lists(st.booleans(), min_size=n_rows, max_size=n_rows))
+            vals = [None if m else v for v, m in zip(vals, mask, strict=True)]
+        arrays.append(pa.array(vals, type=arrow_type))
+    return pa.RecordBatch.from_arrays(arrays, schema=pa.schema(fields))
+
+
+class TestSerializeArrowRecordBatchProperties:
+    """Property-based round-trip — generates batches with varied
+    types, nullability, and row counts (including zero) and asserts
+    the bare-message ↔ ``read_record_batch`` round-trip stays
+    invariant across the combinatorial surface.
+    """
+
+    @given(batch=_hy_record_batch())
+    @settings(
+        deadline=None,
+        max_examples=50,
+        suppress_health_check=[HealthCheck.too_slow],
+    )
+    def test_round_trip_property(self, batch: pa.RecordBatch) -> None:
+        msg_bytes = serialize_arrow_record_batch(batch)
+        result = pa.ipc.read_record_batch(msg_bytes, batch.schema)
+        assert result.num_rows == batch.num_rows
+        assert result.schema == batch.schema
+        # And the bare-message contract still holds — full-stream
+        # readers must refuse the payload.
         with pytest.raises((OSError, pa.lib.ArrowInvalid)):
             pa.ipc.open_stream(msg_bytes).read_all()

--- a/tests/unit/streaming/test_read_session.py
+++ b/tests/unit/streaming/test_read_session.py
@@ -129,6 +129,25 @@ class TestSerializeArrowRecordBatch:
         with pytest.raises((OSError, pa.lib.ArrowInvalid)):
             pa.ipc.open_stream(msg_bytes).read_all()
 
+    def test_rejects_dictionary_encoded_batch(self) -> None:
+        """Dictionary-encoded columns cannot be encoded in the bare-message
+        contract — ``pa.ipc.read_record_batch(bytes, schema)`` requires a
+        populated ``DictionaryMemo`` to decode dict-encoded fields, and
+        the BigQuery Storage Read wire format has no channel for the
+        ``DictionaryBatch`` frames. Fail loudly at the producer.
+        """
+        # Build a batch with a dict-encoded column: pyarrow's writer
+        # would emit a ``DictionaryBatch`` message before the
+        # RecordBatch message in the IPC stream, and the bare-message
+        # output couldn't represent it. The producer must refuse.
+        dict_type = pa.dictionary(pa.int32(), pa.string())
+        batch = pa.RecordBatch.from_arrays(
+            [pa.array(["a", "b", "a", "c"]).dictionary_encode().cast(dict_type)],
+            schema=pa.schema([pa.field("category", dict_type)]),
+        )
+        with pytest.raises(ValueError, match="Dictionary-encoded columns"):
+            serialize_arrow_record_batch(batch)
+
 
 # Hypothesis strategies for the property test below. The repo
 # convention (cited by CodeRabbit on PR #31) is to use Hypothesis

--- a/tests/unit/streaming/test_read_session.py
+++ b/tests/unit/streaming/test_read_session.py
@@ -9,7 +9,7 @@ from bqemulator.streaming.read_session import (
     create_read_session,
     get_session,
     get_stream_data,
-    serialize_arrow_ipc,
+    serialize_arrow_record_batch,
 )
 
 pytestmark = pytest.mark.unit
@@ -93,14 +93,36 @@ class TestGetStreamData:
         assert total_rows == sample_table.num_rows
 
 
-class TestSerializeArrowIpc:
-    def test_round_trips(self, sample_table: pa.Table) -> None:
-        ipc_bytes = serialize_arrow_ipc(sample_table)
-        assert isinstance(ipc_bytes, bytes)
-        assert len(ipc_bytes) > 0
+class TestSerializeArrowRecordBatch:
+    """Pin the bare-message contract (issue #15).
 
-        # Deserialize and verify.
-        reader = pa.ipc.open_stream(ipc_bytes)
-        result = reader.read_all()
-        assert result.num_rows == sample_table.num_rows
-        assert result.column_names == sample_table.column_names
+    ``serialize_arrow_record_batch`` MUST emit a single IPC
+    record-batch message (no schema-message prefix, no EOS-marker
+    suffix). ``pa.ipc.read_record_batch(bytes, schema)`` is the
+    consumer path real Storage Read clients use; if the function
+    regresses to emitting a full stream, this test fails because
+    ``read_record_batch`` raises ``OSError: Expected IPC message of
+    type record batch but got schema``.
+    """
+
+    def test_round_trips_as_bare_batch_message(self, sample_table: pa.Table) -> None:
+        batch = sample_table.combine_chunks().to_batches()[0]
+        msg_bytes = serialize_arrow_record_batch(batch)
+        assert isinstance(msg_bytes, bytes)
+        assert len(msg_bytes) > 0
+
+        # Deserialize via the documented consumer path — ``read_record_batch``
+        # requires a known schema and refuses any prefix message.
+        result = pa.ipc.read_record_batch(msg_bytes, batch.schema)
+        assert result.num_rows == batch.num_rows
+        assert result.schema == batch.schema
+
+    def test_rejects_full_stream_consumer_pattern(self, sample_table: pa.Table) -> None:
+        # Belt-and-braces: ``open_stream`` would still parse a full
+        # IPC stream silently. We assert the output is NOT a stream
+        # by checking it lacks the schema-message prefix that
+        # ``open_stream`` requires.
+        batch = sample_table.combine_chunks().to_batches()[0]
+        msg_bytes = serialize_arrow_record_batch(batch)
+        with pytest.raises((OSError, pa.lib.ArrowInvalid)):
+            pa.ipc.open_stream(msg_bytes).read_all()

--- a/tests/unit/streaming/test_read_session.py
+++ b/tests/unit/streaming/test_read_session.py
@@ -148,6 +148,44 @@ class TestSerializeArrowRecordBatch:
         with pytest.raises(ValueError, match="Dictionary-encoded columns"):
             serialize_arrow_record_batch(batch)
 
+    def test_rejects_nested_dictionary_in_struct(self) -> None:
+        """``pa.types.is_dictionary`` only inspects the top-level type, but
+        Arrow's IPC format emits ``DictionaryBatch`` messages for
+        dict-encoded children of struct / list / map / union containers
+        too. The producer must refuse nested dict-encoded leaves with
+        the same ``ValueError`` it raises for top-level dict columns,
+        otherwise the bare-message payload silently omits the dict
+        frames consumers need (see ADR 0033).
+        """
+        dict_type = pa.dictionary(pa.int32(), pa.string())
+        # Struct with a dict-encoded child field.
+        struct_type = pa.struct([pa.field("category", dict_type)])
+        cat = pa.array(["a", "b", "a"]).dictionary_encode().cast(dict_type)
+        struct_arr = pa.StructArray.from_arrays([cat], fields=[pa.field("category", dict_type)])
+        batch = pa.RecordBatch.from_arrays(
+            [struct_arr],
+            schema=pa.schema([pa.field("nested", struct_type)]),
+        )
+        with pytest.raises(ValueError, match="Dictionary-encoded columns"):
+            serialize_arrow_record_batch(batch)
+
+    def test_rejects_nested_dictionary_in_list(self) -> None:
+        """Same recursion guard, exercising the ``list<dict<...>>`` shape —
+        catches the case where a dict-encoded element type hides inside
+        a list container.
+        """
+        dict_type = pa.dictionary(pa.int32(), pa.string())
+        list_type = pa.list_(dict_type)
+        # Build a list array with dict-encoded elements.
+        inner = pa.array(["a", "b", "a"]).dictionary_encode().cast(dict_type)
+        list_arr = pa.ListArray.from_arrays(pa.array([0, 2, 3]), inner)
+        batch = pa.RecordBatch.from_arrays(
+            [list_arr],
+            schema=pa.schema([pa.field("tags", list_type)]),
+        )
+        with pytest.raises(ValueError, match="Dictionary-encoded columns"):
+            serialize_arrow_record_batch(batch)
+
 
 # Hypothesis strategies for the property test below. The repo
 # convention (cited by CodeRabbit on PR #31) is to use Hypothesis


### PR DESCRIPTION
Closes #15.

## Summary

``ReadRowsResponse.arrow_record_batch.serialized_record_batch`` is spec'd to carry a single record-batch IPC message — the schema travels separately on ``ReadSession.arrow_schema.serialized_schema`` and the first response's ``arrow_schema`` field. v1.0.0 packed a *full* IPC stream (schema-message + batches + EOS-marker) into that field, so real Storage Read clients trip on:

```
OSError: Expected IPC message of type record batch but got schema
```

That's the exact failure ``google-cloud-bigquery-storage``'s ``reader.to_arrow(session)`` raises (the call internally does ``pa.ipc.read_record_batch(bytes, schema)`` which refuses anything that isn't a bare batch message). The pyspark-bigquery example shipped an inline workaround in v1.0.0 to compensate.

## Server changes

| File | Change |
|---|---|
| ``bqemulator.streaming.read_session`` | Replace ``serialize_arrow_ipc(table)`` (full stream) with ``serialize_arrow_record_batch(batch)`` (bare message). Implementation writes the batch via ``pa.ipc.new_stream`` to a transient buffer, then uses ``MessageReader`` to peel off the schema-message prefix and EOS-marker suffix. Portable across pyarrow versions. |
| ``bqemulator.grpc_api.read_servicer`` | Pass the RecordBatch directly to ``serialize_arrow_record_batch`` instead of wrapping it in a single-batch Table. |

## Test updates (6 files)

The old wire format was incidentally readable via ``pa.ipc.open_stream`` because the server emitted a full stream. Tests now follow the documented consumer path:

```python
schema = pa.ipc.open_stream(session.arrow_schema.serialized_schema).schema
for resp in responses:
    batch = pa.ipc.read_record_batch(resp.arrow_record_batch.serialized_record_batch, schema)
```

| File | Sites updated |
|---|---|
| ``tests/unit/streaming/test_read_session.py`` | 1 (renamed class + new bare-message contract tests) |
| ``tests/integration/test_storage_read_api.py`` | 2 |
| ``tests/integration/test_storage_read_edge_cases.py`` | 3 |
| ``tests/integration/test_cross_workflow.py`` | 2 |
| ``tests/e2e/python_client/test_storage_read.py`` | 2 |
| ``tests/perf/test_storage_read_throughput.py`` | 1 |

## Example update

| File | Change |
|---|---|
| ``docs/examples/python/pyspark-bigquery/example.py`` | Drop the inline workaround; restore the natural ``reader.to_arrow(session)`` call (which is now the working path against both real BigQuery and the emulator). |

## Verification

All gates green locally:

| Gate | Result |
|---|---|
| ``make lint`` | ✅ ruff + format + mypy + bandit + pip-audit + interrogate + typos |
| ``make test-unit`` | ✅ 2497 passed |
| ``make test-coverage`` | ✅ 3123 passed; project ≥ 90% |
| ``make test-patch-coverage`` | ✅ 12 added lines, **100% patch coverage** |

## Test plan

- [ ] CI green
- [ ] Examples job runs the pyspark-bigquery example without the workaround block and confirms ``reader.to_arrow(session)`` returns the expected rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Arrow IPC framing in the Storage Read API so streamed responses deliver raw record-batch bytes while the session schema is provided separately, aligning with the BigQuery contract.

* **Documentation**
  * Removed manual Arrow IPC workarounds from examples; consumers can use the natural to-arrow flow.

* **Tests**
  * Updated tests and client examples to decode record-batch payloads against the session schema instead of treating each batch as a full IPC stream.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->