### PR TITLE
chore(scio): bump testcontainers + document #17 routing constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,23 +20,25 @@ section and adds the release date.
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
-- **scio example end-to-end Beam BigQueryIO routing** (#17). The
-  ``CustomersPipelineSpec`` only verified container wiring because
-  Beam Java BigQueryIO ignores ``--bigQueryEndpoint`` for its write
-  path — the internal write client always targets
-  ``https://bigquery.googleapis.com/``. Restored the end-to-end
-  assertion by binding the testcontainer on a fixed host port
-  (``9099`` by default, override via ``BQEMU_TEST_HOST_PORT``) and
-  setting ``BIGQUERY_EMULATOR_HOST`` via sbt's
-  ``Test / envVars`` — applied at fork time, so the env var is
-  present on the forked JVM before any BigQuery class loads. The
-  spec now runs ``CustomersPipeline.run`` end-to-end, verifies the 3
-  rows write succeeded, and confirms a read-back via
-  ``jobs.query`` returns ``COUNT(*) = 3``. Bumped
-  ``testcontainers`` 1.19.7 → 1.20.4 in the example's ``build.sbt``
-  for docker-daemon compatibility.
+- **scio example: testcontainers bump + #17 investigation notes.**
+  Bumped ``testcontainers`` 1.19.7 → 1.20.4 in the scio example's
+  ``build.sbt`` — the older docker-java 1.32 client doesn't talk to
+  Docker 27+ (modern Docker Desktop returns ``client version 1.32 is
+  too old``). The end-to-end Beam BigQueryIO routing attempted under
+  issue #17 turned out to be deeper than a single flag/env-var fix
+  — ``--bigQueryEndpoint`` does override the Apiary ``Bigquery``
+  client's ``rootUrl``, but Beam's ``BigQueryIO.Write`` defaults to
+  the ``BATCH_LOADS`` method which stages rows to GCS before
+  invoking a BigQuery LOAD job (no GCS-compatible shim in the
+  emulator), and Beam's auth refresh fires before the redirected
+  HTTP call so ``OAuth2Credentials.refresh()`` 400s against
+  ``oauth2.googleapis.com`` even with
+  ``--gcpCredentialFactoryClass=NoopCredentialFactory``. The
+  ``CustomersPipelineSpec`` stays at the wiring-only smoke for
+  v1.0.1; the full set of constraints is captured in the spec's
+  header comment and tracked on issue #17 for v1.0.2+.
 
 ## [1.0.0] — 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ section and adds the release date.
 
 ## [Unreleased]
 
+### Fixed
+
+- **scio example end-to-end Beam BigQueryIO routing** (#17). The
+  ``CustomersPipelineSpec`` only verified container wiring because
+  Beam Java BigQueryIO ignores ``--bigQueryEndpoint`` for its write
+  path — the internal write client always targets
+  ``https://bigquery.googleapis.com/``. Restored the end-to-end
+  assertion by binding the testcontainer on a fixed host port
+  (``9099`` by default, override via ``BQEMU_TEST_HOST_PORT``) and
+  setting ``BIGQUERY_EMULATOR_HOST`` via sbt's
+  ``Test / envVars`` — applied at fork time, so the env var is
+  present on the forked JVM before any BigQuery class loads. The
+  spec now runs ``CustomersPipeline.run`` end-to-end, verifies the 3
+  rows write succeeded, and confirms a read-back via
+  ``jobs.query`` returns ``COUNT(*) = 3``. Bumped
+  ``testcontainers`` 1.19.7 → 1.20.4 in the example's ``build.sbt``
+  for docker-daemon compatibility.
+
 ## [1.0.0] — 2026-05-22
 
 ### Added

--- a/docs/examples/java/scio/build.sbt
+++ b/docs/examples/java/scio/build.sbt
@@ -35,19 +35,5 @@ lazy val root = (project in file("."))
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
     ),
     Test / parallelExecution := false,
-    Test / fork := true,
-    // Beam Java BigQueryIO's write path uses the official Java
-    // ``google-cloud-bigquery`` client internally, which reads
-    // ``BIGQUERY_EMULATOR_HOST`` from the *process* environment when
-    // the client is built. ``System.getenv`` is immutable after JVM
-    // start, so the env var has to be present on the forked test JVM
-    // before it boots — which is exactly what ``Test / envVars``
-    // configures. Pair this with the fixed host port the spec binds
-    // for the container (``BqemuContainer`` in
-    // ``CustomersPipelineSpec``), so the JVM-start env var and the
-    // container's actual listener agree. Override per-developer via
-    // ``BQEMU_TEST_HOST_PORT=NNNN sbt test`` if 9099 is taken.
-    Test / envVars := Map(
-      "BIGQUERY_EMULATOR_HOST" -> s"localhost:${sys.env.getOrElse("BQEMU_TEST_HOST_PORT", "9099")}"
-    )
+    Test / fork := true
   )

--- a/docs/examples/java/scio/build.sbt
+++ b/docs/examples/java/scio/build.sbt
@@ -22,7 +22,11 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.4.14" % Runtime,
       "com.spotify" %% "scio-test" % scioVersion % Test,
       "org.scalatest" %% "scalatest" % "3.2.18" % Test,
-      "org.testcontainers" % "testcontainers" % "1.19.7" % Test
+      // ``testcontainers`` 1.19.x ships docker-java 1.32 which only
+      // talks to docker daemon API < 1.40 — modern Docker Desktop
+      // (27+) returns ``client version 1.32 is too old``. 1.20.x
+      // bundles the newer docker-java that handles current daemons.
+      "org.testcontainers" % "testcontainers" % "1.20.4" % Test
     ),
     dependencyOverrides ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
@@ -31,5 +35,19 @@ lazy val root = (project in file("."))
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
     ),
     Test / parallelExecution := false,
-    Test / fork := true
+    Test / fork := true,
+    // Beam Java BigQueryIO's write path uses the official Java
+    // ``google-cloud-bigquery`` client internally, which reads
+    // ``BIGQUERY_EMULATOR_HOST`` from the *process* environment when
+    // the client is built. ``System.getenv`` is immutable after JVM
+    // start, so the env var has to be present on the forked test JVM
+    // before it boots — which is exactly what ``Test / envVars``
+    // configures. Pair this with the fixed host port the spec binds
+    // for the container (``BqemuContainer`` in
+    // ``CustomersPipelineSpec``), so the JVM-start env var and the
+    // container's actual listener agree. Override per-developer via
+    // ``BQEMU_TEST_HOST_PORT=NNNN sbt test`` if 9099 is taken.
+    Test / envVars := Map(
+      "BIGQUERY_EMULATOR_HOST" -> s"localhost:${sys.env.getOrElse("BQEMU_TEST_HOST_PORT", "9099")}"
+    )
   )

--- a/docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
+++ b/docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
@@ -4,7 +4,6 @@ import java.net.URI
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import java.time.Duration
 
-import com.github.dockerjava.api.model.{ExposedPort, PortBinding, Ports}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.testcontainers.containers.GenericContainer
@@ -23,31 +22,48 @@ class BqemuContainer(image: DockerImageName)
 
 class CustomersPipelineSpec extends AnyFlatSpec with Matchers {
 
-  // Beam Java BigQueryIO does NOT honour ``--bigQueryEndpoint`` for
-  // its write path — that option is wired only into the internal
-  // preflight validators, and the actual writes go through the
-  // official Java ``google-cloud-bigquery`` client with the default
-  // ``https://bigquery.googleapis.com/`` base URL. The Java BQ client
-  // *does* honour the ``BIGQUERY_EMULATOR_HOST`` env var (it rewrites
-  // the host whenever a ``BigQuery`` client is built), but JVM env
-  // vars are immutable after process start — the var has to be set
-  // on the JVM *before* it boots.
+  // KNOWN LIMITATION (issue #17): running ``CustomersPipeline.run``
+  // end-to-end against bqemulator is harder than a single flag /
+  // env-var fix. v1.0.1 investigated three routes and surfaced the
+  // following constraints; all three would need to land together
+  // before this spec can flip to an end-to-end ``written shouldBe
+  // 3L`` assertion:
   //
-  // The fix (issue #17): bind the testcontainer to a FIXED host port
-  // and set ``BIGQUERY_EMULATOR_HOST`` via sbt's ``Test / envVars``
-  // (which is applied at fork time, before the JVM loads the
-  // BigQuery client classes). Both ends agree on the same port; the
-  // pipeline writes route to the emulator.
+  // 1. **Endpoint routing.** ``--bigQueryEndpoint=http://host:port``
+  //    DOES wire through to the Apiary ``Bigquery`` client's
+  //    ``rootUrl`` (verified locally — auth-failure stacks confirm
+  //    the override applied). But ``BIGQUERY_EMULATOR_HOST`` (which
+  //    the cloud-style ``com.google.cloud.bigquery.BigQuery`` client
+  //    honours) has to be set on the JVM at fork time, before any
+  //    BQ class loads — sbt's ``Test / envVars`` can do this with a
+  //    fixed host port, but the next two issues still bite.
   //
-  // Override per-developer via ``BQEMU_TEST_HOST_PORT`` if 9099 is
-  // taken on the host. ``build.sbt`` reads the same env var when
-  // composing ``BIGQUERY_EMULATOR_HOST``, so changing one changes
-  // both.
+  // 2. **Auth.** Beam still invokes ``OAuth2Credentials.refresh()``
+  //    at request time even when ``--bigQueryEndpoint`` is set, so
+  //    the redirected HTTP call never fires — auth refresh against
+  //    ``oauth2.googleapis.com`` 400s before the redirect happens.
+  //    ``--gcpCredentialFactoryClass=...NoopCredentialFactory`` is
+  //    the documented escape hatch but doesn't fully suppress the
+  //    discovery chain when application-default credentials exist
+  //    on the host (gcloud SDK auto-detects them past the flag).
+  //
+  // 3. **Batch-load path needs GCS.** ``BigQueryIO.Write`` defaults
+  //    to ``BATCH_LOADS`` for bounded pipelines, which stages rows
+  //    to GCS before issuing a BigQuery LOAD job. The emulator
+  //    doesn't expose a GCS-compatible shim Beam can stage to;
+  //    forcing ``Method.STREAMING_INSERTS`` would bypass GCS but
+  //    requires changing the ``CustomersPipeline`` source and
+  //    pulls in a different routing branch in BigQueryIO.
+  //
+  // For v1.0.1 this spec stays at the wiring-only smoke (container
+  // starts, REST API is reachable, dataset creation works — the
+  // bqemulator-owned part of the contract). The CustomersPipeline
+  // source itself is unchanged and remains accurate documentation
+  // for users running it against real BigQuery (Dataflow) or a
+  // long-lived bqemulator on a stable port + a real GCS bucket.
+  // Issue #17 stays open with the findings above scoped to v1.0.2+.
 
-  private val hostPort = sys.env.getOrElse("BQEMU_TEST_HOST_PORT", "9099").toInt
-  private val restBase = s"http://localhost:$hostPort"
-
-  "CustomersPipeline" should "write 3 rows and the emulator returns them on read" in {
+  "bqemulator" should "expose a working BigQuery REST surface that Scio could target" in {
     val image = sys.env.getOrElse("BQEMU_IMAGE", "ghcr.io/jjviscomi/bqemulator:dev")
 
     val container = new BqemuContainer(DockerImageName.parse(image))
@@ -57,45 +73,29 @@ class CustomersPipelineSpec extends AnyFlatSpec with Matchers {
       .withExposedPorts(9050, 9060)
       .waitingFor(Wait.forHttp("/healthz").forPort(9050))
 
-    // Fixed host-port binding via the docker-java create-cmd
-    // modifier. ``setPortBindings(List("9099:9050"))`` would also
-    // work for REST-only, but ``withCreateContainerCmdModifier``
-    // bundles both REST + gRPC bindings declaratively. Required
-    // because sbt-side ``BIGQUERY_EMULATOR_HOST`` is computed at
-    // JVM start — we cannot use a random testcontainer-mapped port
-    // and discover it post-hoc.
-    container.withCreateContainerCmdModifier({ cmd =>
-      val hostConfig = cmd.getHostConfig
-      hostConfig.withPortBindings(
-        new PortBinding(Ports.Binding.bindPort(hostPort), new ExposedPort(9050)),
-        new PortBinding(Ports.Binding.bindPort(hostPort + 10), new ExposedPort(9060))
-      )
-      ()
-    })
-
     container.start()
     try {
-      // Sanity-check the env var the forked JVM sees. If sbt-side
-      // ``Test / envVars`` is mis-configured, the pipeline routes
-      // writes to the real BigQuery URL and the test 404s with an
-      // opaque ``Not Found`` deep in BQIO — fail-fast here instead.
-      val emuHost = sys.env.getOrElse("BIGQUERY_EMULATOR_HOST", "")
-      withClue("BIGQUERY_EMULATOR_HOST must be set by sbt's Test / envVars") {
-        emuHost shouldBe s"localhost:$hostPort"
-      }
-
-      val client = HttpClient
-        .newBuilder()
+      val rest = s"http://${container.getHost}:${container.getMappedPort(9050)}"
+      // Bound the *connect* and per-request blocking time so a stalled
+      // container / NAT misconfig in CI fails fast instead of hanging
+      // until the runner times out (per CodeRabbit feedback).
+      //
+      // Pin HTTP/1.1 explicitly — Java 17's HttpClient defaults to
+      // ``HTTP_2`` and tries an h2c upgrade even on plaintext
+      // ``http://``. uvicorn / h11 only speaks HTTP/1.1 and bounces
+      // the negotiation with ``400 Invalid HTTP request received``,
+      // which surfaces here as a baffling 400 on a perfectly valid
+      // POST body.
+      val client = HttpClient.newBuilder()
         .version(HttpClient.Version.HTTP_1_1)
         .connectTimeout(Duration.ofSeconds(10))
         .build()
       val timeout = Duration.ofSeconds(30)
 
-      // Sanity check: /healthz reachable on the fixed port.
+      // 1. ``/healthz`` is reachable.
       val health = client.send(
-        HttpRequest
-          .newBuilder()
-          .uri(URI.create(s"$restBase/healthz"))
+        HttpRequest.newBuilder()
+          .uri(URI.create(s"$rest/healthz"))
           .timeout(timeout)
           .GET()
           .build(),
@@ -103,75 +103,33 @@ class CustomersPipelineSpec extends AnyFlatSpec with Matchers {
       )
       health.statusCode() shouldBe 200
 
-      // Pre-create the dataset so CREATE_IF_NEEDED on the table
-      // doesn't have to also handle dataset creation under one
-      // BQIO write call.
-      val createDs = HttpRequest
-        .newBuilder()
-        .uri(URI.create(s"$restBase/bigquery/v2/projects/bqemu-demo/datasets"))
+      // 2. Dataset creation via the REST surface succeeds.
+      //    Idempotent — 200/201 on first call, 409 on re-run.
+      val createDs = HttpRequest.newBuilder()
+        .uri(URI.create(s"$rest/bigquery/v2/projects/bqemu-demo/datasets"))
         .header("Content-Type", "application/json")
         .timeout(timeout)
-        .POST(
-          HttpRequest.BodyPublishers.ofString(
-            """{"datasetReference":{"projectId":"bqemu-demo","datasetId":"scio_demo"},"location":"US"}"""
-          )
-        )
+        .POST(HttpRequest.BodyPublishers.ofString(
+          """{"datasetReference":{"projectId":"bqemu-demo","datasetId":"scio_demo"},"location":"US"}"""
+        ))
         .build()
-      val createDsResp =
+      val createResp =
         client.send(createDs, HttpResponse.BodyHandlers.ofString())
-      withClue(s"create-dataset failed: ${createDsResp.statusCode()} ${createDsResp.body()}") {
-        Set(200, 201, 409) should contain(createDsResp.statusCode())
+      withClue(s"create-dataset failed: ${createResp.statusCode()} ${createResp.body()}") {
+        Set(200, 201, 409) should contain(createResp.statusCode())
       }
 
-      // Run the pipeline end-to-end. Beam needs TWO endpoint
-      // overrides to route everything to the emulator:
-      //
-      // * ``--bigQueryEndpoint=$restBase`` — covers Beam BigQueryIO's
-      //   preflight validators (dataset-exists, table-exists checks
-      //   issued via the low-level Apiary ``Bigquery`` client). Without
-      //   this the test fails with a 404 against
-      //   ``https://bigquery.googleapis.com/...`` on the pre-write
-      //   dataset lookup.
-      // * ``BIGQUERY_EMULATOR_HOST`` env var (set above by sbt's
-      //   ``Test / envVars``) — covers the actual WRITE path, which
-      //   uses the cloud-style ``com.google.cloud.bigquery.BigQuery``
-      //   client. That client picks up the env var at builder time.
-      //
-      // Either one alone is insufficient; both together close the
-      // routing gap.
-      val written = CustomersPipeline.run(
-        Array(
-          "--runner=DirectRunner",
-          "--project=bqemu-demo",
-          s"--bigQueryEndpoint=$restBase",
-          "--bqProject=bqemu-demo",
-          "--bqDataset=scio_demo"
-        )
+      // 3. The dataset shows up on the listing endpoint.
+      val list = client.send(
+        HttpRequest.newBuilder()
+          .uri(URI.create(s"$rest/bigquery/v2/projects/bqemu-demo/datasets"))
+          .timeout(timeout)
+          .GET()
+          .build(),
+        HttpResponse.BodyHandlers.ofString()
       )
-      written shouldBe 3L
-
-      // Read the rows back via the emulator REST + jobs.query and
-      // confirm BQIO actually wrote the 3 customers.
-      val countQuery = HttpRequest
-        .newBuilder()
-        .uri(URI.create(s"$restBase/bigquery/v2/projects/bqemu-demo/queries"))
-        .header("Content-Type", "application/json")
-        .timeout(timeout)
-        .POST(
-          HttpRequest.BodyPublishers.ofString(
-            """{"query":"SELECT COUNT(*) AS n FROM `bqemu-demo`.`scio_demo`.`customers`","useLegacySql":false}"""
-          )
-        )
-        .build()
-      val countResp = client.send(countQuery, HttpResponse.BodyHandlers.ofString())
-      withClue(s"count-query failed: ${countResp.statusCode()} ${countResp.body()}") {
-        countResp.statusCode() shouldBe 200
-      }
-      // Cheap structural check — the JSON body has ``"f": [{"v":"3"}]``
-      // for a single-row, single-column result. Skipping a JSON parser
-      // here keeps the spec free of an extra test-only dep; if the
-      // shape changes the substring assertion fails loudly.
-      countResp.body() should include("\"3\"")
+      list.statusCode() shouldBe 200
+      list.body() should include("scio_demo")
     } finally {
       container.stop()
     }

--- a/docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
+++ b/docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
@@ -123,14 +123,27 @@ class CustomersPipelineSpec extends AnyFlatSpec with Matchers {
         Set(200, 201, 409) should contain(createDsResp.statusCode())
       }
 
-      // Run the pipeline end-to-end. Beam DirectRunner; the
-      // ``BIGQUERY_EMULATOR_HOST`` env var on the forked JVM
-      // (applied by sbt's ``Test / envVars``) routes BQ client
-      // writes to the emulator.
+      // Run the pipeline end-to-end. Beam needs TWO endpoint
+      // overrides to route everything to the emulator:
+      //
+      // * ``--bigQueryEndpoint=$restBase`` — covers Beam BigQueryIO's
+      //   preflight validators (dataset-exists, table-exists checks
+      //   issued via the low-level Apiary ``Bigquery`` client). Without
+      //   this the test fails with a 404 against
+      //   ``https://bigquery.googleapis.com/...`` on the pre-write
+      //   dataset lookup.
+      // * ``BIGQUERY_EMULATOR_HOST`` env var (set above by sbt's
+      //   ``Test / envVars``) — covers the actual WRITE path, which
+      //   uses the cloud-style ``com.google.cloud.bigquery.BigQuery``
+      //   client. That client picks up the env var at builder time.
+      //
+      // Either one alone is insufficient; both together close the
+      // routing gap.
       val written = CustomersPipeline.run(
         Array(
           "--runner=DirectRunner",
           "--project=bqemu-demo",
+          s"--bigQueryEndpoint=$restBase",
           "--bqProject=bqemu-demo",
           "--bqDataset=scio_demo"
         )

--- a/docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
+++ b/docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
@@ -4,6 +4,7 @@ import java.net.URI
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import java.time.Duration
 
+import com.github.dockerjava.api.model.{ExposedPort, PortBinding, Ports}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.testcontainers.containers.GenericContainer
@@ -22,25 +23,31 @@ class BqemuContainer(image: DockerImageName)
 
 class CustomersPipelineSpec extends AnyFlatSpec with Matchers {
 
-  // KNOWN LIMITATION: Beam Java BigQueryIO does not honour the
-  // ``--bigQueryEndpoint`` flag for the *write* path — that option is
-  // restricted to internal preflight validators. The Java BQ client
-  // *does* honour the ``BIGQUERY_EMULATOR_HOST`` env var, but it has
-  // to be present on the JVM that runs the pipeline (not just on the
-  // container), and we don't know the testcontainer-mapped port
-  // until after the JVM is already alive. The result: actually
-  // running ``CustomersPipeline.run`` from this test routes writes to
-  // ``https://bigquery.googleapis.com/...`` and 404s.
+  // Beam Java BigQueryIO does NOT honour ``--bigQueryEndpoint`` for
+  // its write path — that option is wired only into the internal
+  // preflight validators, and the actual writes go through the
+  // official Java ``google-cloud-bigquery`` client with the default
+  // ``https://bigquery.googleapis.com/`` base URL. The Java BQ client
+  // *does* honour the ``BIGQUERY_EMULATOR_HOST`` env var (it rewrites
+  // the host whenever a ``BigQuery`` client is built), but JVM env
+  // vars are immutable after process start — the var has to be set
+  // on the JVM *before* it boots.
   //
-  // Until upstream Scio / Beam grows a per-call endpoint override
-  // (tracked for v1.0.1 follow-up), this spec verifies the
-  // *wiring* — container starts, REST API is reachable, dataset
-  // creation works — which is the part bqemulator owns. The
-  // CustomersPipeline source remains as documentation for users who
-  // will run it against either real BigQuery or a long-lived
-  // bqemulator with a stable port.
+  // The fix (issue #17): bind the testcontainer to a FIXED host port
+  // and set ``BIGQUERY_EMULATOR_HOST`` via sbt's ``Test / envVars``
+  // (which is applied at fork time, before the JVM loads the
+  // BigQuery client classes). Both ends agree on the same port; the
+  // pipeline writes route to the emulator.
+  //
+  // Override per-developer via ``BQEMU_TEST_HOST_PORT`` if 9099 is
+  // taken on the host. ``build.sbt`` reads the same env var when
+  // composing ``BIGQUERY_EMULATOR_HOST``, so changing one changes
+  // both.
 
-  "bqemulator" should "expose a working BigQuery REST surface that Scio could target" in {
+  private val hostPort = sys.env.getOrElse("BQEMU_TEST_HOST_PORT", "9099").toInt
+  private val restBase = s"http://localhost:$hostPort"
+
+  "CustomersPipeline" should "write 3 rows and the emulator returns them on read" in {
     val image = sys.env.getOrElse("BQEMU_IMAGE", "ghcr.io/jjviscomi/bqemulator:dev")
 
     val container = new BqemuContainer(DockerImageName.parse(image))
@@ -50,29 +57,45 @@ class CustomersPipelineSpec extends AnyFlatSpec with Matchers {
       .withExposedPorts(9050, 9060)
       .waitingFor(Wait.forHttp("/healthz").forPort(9050))
 
+    // Fixed host-port binding via the docker-java create-cmd
+    // modifier. ``setPortBindings(List("9099:9050"))`` would also
+    // work for REST-only, but ``withCreateContainerCmdModifier``
+    // bundles both REST + gRPC bindings declaratively. Required
+    // because sbt-side ``BIGQUERY_EMULATOR_HOST`` is computed at
+    // JVM start — we cannot use a random testcontainer-mapped port
+    // and discover it post-hoc.
+    container.withCreateContainerCmdModifier({ cmd =>
+      val hostConfig = cmd.getHostConfig
+      hostConfig.withPortBindings(
+        new PortBinding(Ports.Binding.bindPort(hostPort), new ExposedPort(9050)),
+        new PortBinding(Ports.Binding.bindPort(hostPort + 10), new ExposedPort(9060))
+      )
+      ()
+    })
+
     container.start()
     try {
-      val rest = s"http://${container.getHost}:${container.getMappedPort(9050)}"
-      // Bound the *connect* and per-request blocking time so a stalled
-      // container / NAT misconfig in CI fails fast instead of hanging
-      // until the runner times out (per CodeRabbit feedback).
-      //
-      // Pin HTTP/1.1 explicitly — Java 17's HttpClient defaults to
-      // ``HTTP_2`` and tries an h2c upgrade even on plaintext
-      // ``http://``. uvicorn / h11 only speaks HTTP/1.1 and bounces
-      // the negotiation with ``400 Invalid HTTP request received``,
-      // which surfaces here as a baffling 400 on a perfectly valid
-      // POST body.
-      val client = HttpClient.newBuilder()
+      // Sanity-check the env var the forked JVM sees. If sbt-side
+      // ``Test / envVars`` is mis-configured, the pipeline routes
+      // writes to the real BigQuery URL and the test 404s with an
+      // opaque ``Not Found`` deep in BQIO — fail-fast here instead.
+      val emuHost = sys.env.getOrElse("BIGQUERY_EMULATOR_HOST", "")
+      withClue("BIGQUERY_EMULATOR_HOST must be set by sbt's Test / envVars") {
+        emuHost shouldBe s"localhost:$hostPort"
+      }
+
+      val client = HttpClient
+        .newBuilder()
         .version(HttpClient.Version.HTTP_1_1)
         .connectTimeout(Duration.ofSeconds(10))
         .build()
       val timeout = Duration.ofSeconds(30)
 
-      // 1. ``/healthz`` is reachable.
+      // Sanity check: /healthz reachable on the fixed port.
       val health = client.send(
-        HttpRequest.newBuilder()
-          .uri(URI.create(s"$rest/healthz"))
+        HttpRequest
+          .newBuilder()
+          .uri(URI.create(s"$restBase/healthz"))
           .timeout(timeout)
           .GET()
           .build(),
@@ -80,33 +103,62 @@ class CustomersPipelineSpec extends AnyFlatSpec with Matchers {
       )
       health.statusCode() shouldBe 200
 
-      // 2. Dataset creation via the REST surface succeeds.
-      //    Idempotent — 200/201 on first call, 409 on re-run.
-      val createDs = HttpRequest.newBuilder()
-        .uri(URI.create(s"$rest/bigquery/v2/projects/bqemu-demo/datasets"))
+      // Pre-create the dataset so CREATE_IF_NEEDED on the table
+      // doesn't have to also handle dataset creation under one
+      // BQIO write call.
+      val createDs = HttpRequest
+        .newBuilder()
+        .uri(URI.create(s"$restBase/bigquery/v2/projects/bqemu-demo/datasets"))
         .header("Content-Type", "application/json")
         .timeout(timeout)
-        .POST(HttpRequest.BodyPublishers.ofString(
-          """{"datasetReference":{"projectId":"bqemu-demo","datasetId":"scio_demo"},"location":"US"}"""
-        ))
+        .POST(
+          HttpRequest.BodyPublishers.ofString(
+            """{"datasetReference":{"projectId":"bqemu-demo","datasetId":"scio_demo"},"location":"US"}"""
+          )
+        )
         .build()
-      val createResp =
+      val createDsResp =
         client.send(createDs, HttpResponse.BodyHandlers.ofString())
-      withClue(s"create-dataset failed: ${createResp.statusCode()} ${createResp.body()}") {
-        Set(200, 201, 409) should contain(createResp.statusCode())
+      withClue(s"create-dataset failed: ${createDsResp.statusCode()} ${createDsResp.body()}") {
+        Set(200, 201, 409) should contain(createDsResp.statusCode())
       }
 
-      // 3. The dataset shows up on the listing endpoint.
-      val list = client.send(
-        HttpRequest.newBuilder()
-          .uri(URI.create(s"$rest/bigquery/v2/projects/bqemu-demo/datasets"))
-          .timeout(timeout)
-          .GET()
-          .build(),
-        HttpResponse.BodyHandlers.ofString()
+      // Run the pipeline end-to-end. Beam DirectRunner; the
+      // ``BIGQUERY_EMULATOR_HOST`` env var on the forked JVM
+      // (applied by sbt's ``Test / envVars``) routes BQ client
+      // writes to the emulator.
+      val written = CustomersPipeline.run(
+        Array(
+          "--runner=DirectRunner",
+          "--project=bqemu-demo",
+          "--bqProject=bqemu-demo",
+          "--bqDataset=scio_demo"
+        )
       )
-      list.statusCode() shouldBe 200
-      list.body() should include("scio_demo")
+      written shouldBe 3L
+
+      // Read the rows back via the emulator REST + jobs.query and
+      // confirm BQIO actually wrote the 3 customers.
+      val countQuery = HttpRequest
+        .newBuilder()
+        .uri(URI.create(s"$restBase/bigquery/v2/projects/bqemu-demo/queries"))
+        .header("Content-Type", "application/json")
+        .timeout(timeout)
+        .POST(
+          HttpRequest.BodyPublishers.ofString(
+            """{"query":"SELECT COUNT(*) AS n FROM `bqemu-demo`.`scio_demo`.`customers`","useLegacySql":false}"""
+          )
+        )
+        .build()
+      val countResp = client.send(countQuery, HttpResponse.BodyHandlers.ofString())
+      withClue(s"count-query failed: ${countResp.statusCode()} ${countResp.body()}") {
+        countResp.statusCode() shouldBe 200
+      }
+      // Cheap structural check — the JSON body has ``"f": [{"v":"3"}]``
+      // for a single-row, single-column result. Skipping a JSON parser
+      // here keeps the spec free of an extra test-only dep; if the
+      // shape changes the substring assertion fails loudly.
+      countResp.body() should include("\"3\"")
     } finally {
       container.stop()
     }


### PR DESCRIPTION
Refines the v1.0.1 scope for issue #17. The original PR attempted to restore an end-to-end ``CustomersPipeline.run`` assertion; **local validation (#PR feedback) showed the end-to-end path needs more than the issue scoped**, so this PR rolls back to a wiring-only smoke and captures the investigation in code comments + CHANGELOG.

## What changed

| File | Change |
|---|---|
| ``build.sbt`` | testcontainers **1.19.7 → 1.20.4** (older docker-java 1.32 client can't talk to Docker 27+; modern Docker Desktop returns ``client version 1.32 is too old``). Infrastructure win independent of the routing investigation. |
| ``CustomersPipelineSpec.scala`` | Reset to wiring-only smoke (matching ``main`` baseline). Header comment rewritten with the three Beam BQIO routing blockers found during local validation. |
| ``CHANGELOG.md`` | Entry under ``Changed`` (not ``Fixed``) — reflects actual scope. Notes the three blockers and that #17 stays open for v1.0.2+. |

## Why the rollback

Tried locally with a manually-started bqemulator container on a fixed port (``docker run -d -p 9099:9050 -p 9109:9060 ghcr.io/jjviscomi/bqemulator:1.0.0``) plus various Beam options. Surfaced three independent blockers; any one sinks the e2e path:

1. **Endpoint routing works.** ``--bigQueryEndpoint=http://host:port`` DOES set the Apiary ``Bigquery`` client's ``rootUrl``. Confirmed because auth-failure stacks proved the override applied. The cloud-style client side (``BIGQUERY_EMULATOR_HOST`` via sbt's ``Test / envVars``) was the right approach for the v1.0.1 attempt.

2. **Auth refresh fires before the redirected HTTP call.** Even with ``--bigQueryEndpoint`` set, Beam invokes ``OAuth2Credentials.refresh()`` at request time. Local test failure:
   ```
   POST https://oauth2.googleapis.com/token → 400 invalid_grant
   ```
   ``--gcpCredentialFactoryClass=org.apache.beam.sdk.extensions.gcp.auth.NoopCredentialFactory`` is the documented escape hatch but doesn't fully suppress the discovery chain when application-default credentials exist on the host.

3. **BigQueryIO.Write defaults to BATCH_LOADS.** Bounded pipelines stage rows to GCS before invoking BigQuery LOAD jobs. The emulator has no GCS-compatible shim. Forcing ``Method.STREAMING_INSERTS`` would bypass GCS but requires changing the pipeline source and pulls in a different routing branch with its own flag/auth quirks.

## Verification

Tested locally before push (lesson learned from earlier rounds):

| Gate | Result |
|---|---|
| ``sbt Test/compile`` (scio) | ✅ Clean compile against testcontainers 1.20.4 |
| ``make lint`` | ✅ ruff + format + mypy + bandit + pip-audit + interrogate + typos |
| ``make test-unit`` | ✅ |
| ``make test-coverage`` | ✅ |
| ``make test-patch-coverage`` | ✅ No Python lines in diff (Scala-only change) |

## Test plan

- [ ] CI green
- [ ] Examples job's scio step still runs the wiring-only smoke
- [ ] Issue #17 stays open with the v1.0.2+ findings above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Unreleased changelog entry describing investigation notes and known constraints for the scio example.
  * Expanded the test's KNOWN LIMITATION section with detailed blockers for full end-to-end BigQuery verification.

* **Chores**
  * Bumped testcontainers dependency from 1.19.7 to 1.20.4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->