### PR TITLE
release: bump to v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ section and adds the release date.
 
 ## [Unreleased]
 
+## [1.0.1] — 2026-05-23
+
 ### Fixed
 
 - **Storage Read API IPC framing** (#15). The gRPC ``ReadRows`` handler

--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ See the [`docker-compose/full-stack`](docs/examples/docker-compose/full-stack/) 
 
 ## What works today
 
-`bqemulator` is at **v1.0.0** — the initial production-stable
-release. SemVer applies: breaking changes ship only in MAJOR,
+`bqemulator` is at **v1.0.1** — first patch on the production-stable
+line. SemVer applies: breaking changes ship only in MAJOR,
 deprecations live ≥2 MINOR or 6 months. The [compatibility matrix](https://jjviscomi.github.io/bqemulator/latest/reference/compatibility-matrix/) is auto-generated from the conformance corpus on every CI run; the [conformance coverage matrix](https://jjviscomi.github.io/bqemulator/latest/reference/conformance-coverage-matrix/) breaks down support by surface item.
 
 | Surface | Status |
@@ -270,14 +270,14 @@ Every example under [`docs/examples/`](docs/examples/) is a complete, runnable p
 
 ## Project status
 
-`bqemulator` is at **v1.0.0** — the initial production-stable
-release. SemVer applies: breaking changes ship only in MAJOR
+`bqemulator` is at **v1.0.1** — first patch on the production-stable
+line. SemVer applies: breaking changes ship only in MAJOR
 versions, preceded by ≥1 MINOR with deprecation warnings;
 deprecated APIs remain for ≥2 MINOR versions or 6 months.
 
 Maturity signals:
 
-- ✅ 32 Architecture Decision Records covering every non-obvious design choice (`docs/adr/0001`–`0032`).
+- ✅ 33 Architecture Decision Records covering every non-obvious design choice (`docs/adr/0001`–`0033`).
 - ✅ ≥90% line + branch coverage gated by CI (`make verify`).
 - ✅ 7 test tiers passing (unit + property + integration + conformance + e2e + perf + chaos).
 - ✅ 5-client e2e matrix (Python · Node.js · Go · Java · `bq` CLI).
@@ -285,8 +285,8 @@ Maturity signals:
 - ✅ Fuzz-tier (`Atheris`) harnesses on the SQL translator, dynamic-protobuf decoder, and Arrow bridge.
 - ✅ Differential-tier row-order perturbation of the entire conformance corpus passes.
 - ✅ Performance baselines committed for `darwin-arm64`, with regression gates (`pytest-benchmark` `--benchmark-compare-fail=median:10%`).
-- ✅ PyPI publish via Trusted Publishing (sigstore-attested wheels) — `pip install bqemulator==1.0.0` resolves from [PyPI](https://pypi.org/project/bqemulator/).
-- ✅ GHCR publish with keyless cosign signatures — `docker pull ghcr.io/jjviscomi/bqemulator:1.0.0` resolves and the image is cosign-verifiable.
+- ✅ PyPI publish via Trusted Publishing (sigstore-attested wheels) — `pip install bqemulator==1.0.1` resolves from [PyPI](https://pypi.org/project/bqemulator/).
+- ✅ GHCR publish with keyless cosign signatures — `docker pull ghcr.io/jjviscomi/bqemulator:1.0.1` resolves and the image is cosign-verifiable.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for the complete v1.0 inventory.
 

--- a/src/bqemulator/__init__.py
+++ b/src/bqemulator/__init__.py
@@ -15,4 +15,4 @@ __all__ = ["__version__"]
 
 # Single source of truth for the version; hatchling reads this via
 # `[tool.hatch.version] path = "src/bqemulator/__init__.py"`.
-__version__ = "1.0.0"
+__version__ = "1.0.1"


### PR DESCRIPTION
Cuts **v1.0.1** — first patch on the production-stable line.

## Headline change

- **Storage Read API IPC framing fix (#15)** — ``ArrowRecordBatch.serialized_record_batch`` now carries a single bare record-batch IPC message per the BigQuery wire contract (was packing a full IPC stream in v1.0.0). The canonical ``google-cloud-bigquery-storage`` reader path (``reader.to_arrow(session)``) works against bqemulator unchanged. The ``python/pyspark-bigquery`` example drops its v1.0.0 workaround. Producer-side rejection of dictionary-encoded columns (incl. nested in struct / list / map / union) with a clear ``ValueError``. See [ADR 0033](docs/adr/0033-storage-read-arrow-ipc-bare-message-contract.md) for the formal contract.

## What's in this PR (2 commits → squash)

| Commit | Scope |
|---|---|
| ``3db3b01`` | README "What works today" + "Project status" headers flipped to v1.0.1. ADR count ``32`` → ``33``. ``pip install bqemulator==1.0.0`` + ``docker pull ...:1.0.0`` references → ``1.0.1``. |
| ``e458ae2`` | **Orchestrator-generated.** ``__version__`` ``1.0.0`` → ``1.0.1``; CHANGELOG ``[Unreleased]`` → ``[1.0.1] — 2026-05-23``. SSH-signed annotated tag ``v1.0.1`` created locally on this commit. |

## v1.0.0 → v1.0.1 changes

### Fixed
- **Storage Read API IPC framing (#15)** — emit bare batch message; reject dict-encoded cols (incl. nested) at producer boundary

### Changed
- **scio example: testcontainers bump + #17 investigation notes** — ``testcontainers`` 1.19.7 → 1.20.4 for Docker 27+ compat; spec header comment documents the three Beam BQIO routing blockers found; #17 deferred to v1.0.2+ (likely path: GCS emulator integration)

### Documentation
- **ADR 0033** — Storage Read API Arrow IPC bare-message contract
- README ``Known limitations`` section retitled and statuses updated (✅ #15 closed, ⏳ #17 deferred)
- Inline CHANGELOG entries for both surface changes

## Verification

| Gate | Result |
|---|---|
| ``make verify`` (full chain inside orchestrator) | ✅ — lint + unit + property + integration + 4 docs-drift checks + docker-build + 5 client e2e suites + docs-build strict |
| Pre-commit gates (lint + unit + coverage + patch-coverage) | ✅ All four green before push |

## Post-merge operator actions

```bash
# Reconcile the local v1.0.1 tag onto the squash-merge commit on main,
# then push to fire the publish workflows.
git checkout main && git pull --ff-only
git tag -d v1.0.1
git tag -a v1.0.1 -m v1.0.1
git push origin v1.0.1
# → release.yml (PyPI Trusted Publishing) + docker.yml (GHCR + cosign)
```

## Test plan

- [ ] All CI checks green
- [ ] Squash-merge to ``main``
- [ ] Retag ``v1.0.1`` on squash-merge commit + push
- [ ] ``release.yml`` succeeds → ``pip install bqemulator==1.0.1`` resolves
- [ ] ``docker.yml`` succeeds → ``docker pull ghcr.io/jjviscomi/bqemulator:1.0.1`` resolves
- [ ] ``cosign verify ghcr.io/jjviscomi/bqemulator:1.0.1 ...`` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 1.0.1 released with official release date now properly documented in the project changelog
  * All version references updated across project documentation, README, and package metadata to reflect the new 1.0.1 release
  * Architecture Decision Records count and other key maturity indicators updated in project status section

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->