### PR TITLE
fix(scio): drive CustomersPipeline.run end-to-end against bqemulator (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,33 @@ section and adds the release date.
 
 ## [Unreleased]
 
+### Fixed
+
+- **scio example: end-to-end ``CustomersPipeline.run`` against
+  bqemulator** (#17). The v1.0.1 wiring-only smoke flips to a real
+  Beam BigQueryIO BATCH_LOADS round-trip — 3 rows written, 3 rows
+  read back via ``jobs.query``. No emulator-side code change: the
+  fix is contained in the scio example via (a) a new
+  ``EmulatorBigQueryServices`` class in ``org.apache.beam.sdk.io.gcp.bigquery``
+  that supplies the Apiary ``Bigquery`` client with
+  ``setRootUrl(emulator)``, attached via
+  ``BigQueryIO.Write.withTestServices(...)`` because Beam 2.55.1's
+  Java SDK has no native ``BIGQUERY_EMULATOR_HOST`` support
+  ([apache/beam#34037](https://github.com/apache/beam/pull/34037)
+  is Go-side only); (b) a ``fsouza/fake-gcs-server`` testcontainers
+  sidecar that handles Beam's GCS staging step for the BATCH_LOADS
+  write method, bind-mounted into a shared directory with
+  bqemulator's existing ``BQEMU_GCS_LOCAL_ROOT`` shim so the
+  LOAD-job source URIs resolve to the same physical bytes Beam
+  staged; (c) ``--gcpCredentialFactoryClass=NoopCredentialFactory``
+  to short-circuit OAuth2 refresh against ``oauth2.googleapis.com``;
+  (d) a ``testcontainers`` 1.20.4 → 1.21.4 bump because Docker 29+
+  rejects docker-java clients announcing API < 1.40. See
+  [ADR 0034](docs/adr/0034-scio-beam-emulator-routing.md) for the
+  full design; the
+  [scio example README](docs/examples/java/scio/README.md) has the
+  user-facing recipe.
+
 ## [1.0.1] — 2026-05-23
 
 ### Fixed
@@ -206,26 +233,19 @@ v1.0.1 release:
   ``python/pyspark-bigquery`` example dropped its inline
   workaround. See [ADR 0033](docs/adr/0033-storage-read-arrow-ipc-bare-message-contract.md)
   for the formal contract. ([#15](https://github.com/jjviscomi/bqemulator/issues/15))
-- ⏳ **Scio test exercises wiring only** — **DEFERRED to v1.0.2+**.
-  v1.0.1 investigation (see ``Changed`` block above + the
-  ``CustomersPipelineSpec`` header comment) found the end-to-end
-  path requires three independent fixes, not the single
-  flag/env-var the v1.0.0 limitation note suggested:
-  ``--bigQueryEndpoint`` does override the Apiary client's
-  ``rootUrl`` (✅), but Beam's auth refresh fires before the
-  redirected HTTP call (``OAuth2Credentials.refresh()`` 400s
-  even with ``NoopCredentialFactory``), and
-  ``BigQueryIO.Write`` defaults to ``BATCH_LOADS`` which stages
-  rows to GCS — the emulator has no GCS-compatible shim. Likely
-  v1.0.2 path: integrate a GCS emulator (e.g.
-  ``fsouza/fake-gcs-server``) for staging + finish auth
-  suppression + decide between staying on ``BATCH_LOADS`` (via
-  GCS shim) or pivoting to ``STREAMING_INSERTS``. The
-  ``CustomersPipeline.run`` source itself stays production-ready
-  for users running against real BigQuery or a long-lived
-  bqemulator with a stable port + real GCS bucket. The scio
-  example test continues to assert the wiring-only smoke
-  bqemulator owns (container up, REST reachable, dataset
-  creation works). Tracked in
-  [#17](https://github.com/jjviscomi/bqemulator/issues/17).
+- ✅ **Scio test exercises wiring only** — **CLOSED in v1.0.2**
+  (see ``Fixed`` block under [Unreleased] above). The
+  ``CustomersPipelineSpec`` now drives ``CustomersPipeline.run``
+  end-to-end: 3 rows written via Beam BigQueryIO BATCH_LOADS, 3
+  rows read back via ``jobs.query``. The v1.0.1 hypothesis that
+  ``--bigQueryEndpoint`` worked turned out to be wrong (Beam
+  Java SDK 2.55.1 has no such option — only the Go SDK has
+  ``BIGQUERY_EMULATOR_HOST``); the actual fix uses
+  ``BigQueryIO.Write.withTestServices(EmulatorBigQueryServices(
+  endpoint))`` from a Beam-package-scoped helper in the scio
+  example, plus a ``fake-gcs-server`` sidecar bind-mounted into
+  bqemulator's existing ``BQEMU_GCS_LOCAL_ROOT`` shim for the
+  BATCH_LOADS staging step. See
+  [ADR 0034](docs/adr/0034-scio-beam-emulator-routing.md) for the
+  decision record. ([#17](https://github.com/jjviscomi/bqemulator/issues/17))
 

--- a/docs/adr/0034-scio-beam-emulator-routing.md
+++ b/docs/adr/0034-scio-beam-emulator-routing.md
@@ -1,0 +1,267 @@
+# ADR 0034: Scio + Beam BigQueryIO routing against bqemulator (issue #17)
+
+- **Status**: Accepted
+
+## Context
+
+[Issue #17](https://github.com/jjviscomi/bqemulator/issues/17) — closing
+the v1.0.0 "scio test exercises wiring only" caveat — turned out to be
+harder than the original framing suggested. The v1.0.1 investigation
+([CHANGELOG.md](../../CHANGELOG.md) `## [1.0.1]` "Changed" block and
+``docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala``)
+surfaced three independent blockers that all had to land together
+before ``CustomersPipeline.run(...)`` could drive end-to-end against a
+local emulator:
+
+| Blocker | Beam 2.55.1 source-of-truth |
+|---|---|
+| **1. Endpoint routing.** No ``--bigQueryEndpoint`` pipeline option exists in the Java SDK. The Go SDK adds emulator support via the ``BIGQUERY_EMULATOR_HOST`` env var ([apache/beam#34037](https://github.com/apache/beam/pull/34037)); the Java side never adopted it. ``BigQueryServicesImpl.newBigQueryClient`` (Beam ``sdks/java/io/google-cloud-platform/.../BigQueryServicesImpl.java`` line 1550) constructs the Apiary ``Bigquery`` client with the default ``rootUrl = https://bigquery.googleapis.com/`` — no override hook. | [BigQueryServicesImpl.java#L1550](https://github.com/apache/beam/blob/v2.55.1/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java#L1550) |
+| **2. Auth.** With unredirected traffic, Beam's ``HttpCredentialsAdapter`` invokes ``OAuth2Credentials.refresh()`` at request time. On developer laptops with a stale ``application_default_credentials.json``, the refresh ``400``s against ``oauth2.googleapis.com`` *before* any redirected HTTP call fires. | [GcpOptions.java#GcpUserCredentialsFactory](https://github.com/apache/beam/blob/v2.55.1/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptions.java) |
+| **3. BATCH_LOADS needs GCS.** ``BigQueryIO.Write`` defaults to ``Method.DEFAULT`` → ``BATCH_LOADS`` for bounded pipelines, which stages rows to ``gs://<gcpTempLocation>/BigQueryWriteTemp/...`` before issuing a BigQuery LOAD job. The emulator's ``BQEMU_GCS_LOCAL_ROOT`` shim (ADR 0027 / G1) resolves ``gs://`` URIs to a local filesystem path but does not implement the GCS HTTP/JSON API that Beam writes to. | [BatchLoads.java](https://github.com/apache/beam/blob/v2.55.1/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java) |
+
+The v1.0.1 release shipped with the spec exercising wiring-only smoke
+(container up, REST reachable, dataset-creation works) and tracked the
+end-to-end assertion under #17 for v1.0.2.
+
+## Decision
+
+Close issue #17 in **v1.0.2** by changing **only the scio example** —
+no emulator-side code change is needed.
+
+### 1. ``CustomersPipeline.scala`` accepts an optional ``--bqEmulatorEndpoint``
+
+Production users (real BigQuery / Dataflow) don't set the flag and
+take the existing ``rows.saveAsBigQueryTable(...)`` scio idiom
+unchanged. The example/CI driver sets ``--bqEmulatorEndpoint=<rest>``
+to switch the same pipeline into the test-services branch.
+
+When the flag IS set, the pipeline drops down to raw
+``BigQueryIO.writeTableRows()`` so it can attach
+``.withTestServices(EmulatorBigQueryServices(endpoint))``. Scio's
+``saveAsBigQueryTable`` wraps the same ``BigQueryIO.Write`` transform
+but does not expose the ``withTestServices`` hook; the test-services
+attachment requires constructing the Write directly.
+
+### 2. ``EmulatorBigQueryServices`` extends ``BigQueryServicesImpl``
+
+The class lives in ``org.apache.beam.sdk.io.gcp.bigquery`` (Beam's
+package — same package different JAR, which Java permits) so it can
+reach the ``@VisibleForTesting`` constructors on
+``BigQueryServicesImpl.JobServiceImpl`` /
+``BigQueryServicesImpl.DatasetServiceImpl``. Both accept a pre-built
+Apiary ``Bigquery`` client; ``EmulatorBigQueryServices`` builds one
+with ``setRootUrl(emulator)`` and a no-op ``HttpRequestInitializer``,
+then hands it to those constructors.
+
+The override is the smallest possible scope — the Job/Dataset service
+*bodies* (``startLoadJob``, ``pollJob``, ``getDataset``, etc.) are
+inherited from Beam's default implementations and exercise the
+upstream code paths unchanged.
+
+### 3. A ``fake-gcs-server`` sidecar provides GCS staging
+
+The scio spec brings up
+[``fsouza/fake-gcs-server``](https://github.com/fsouza/fake-gcs-server)
+v1.54.0 alongside the bqemulator container, on a shared testcontainers
+``Network``. Beam stages the BATCH_LOADS shards to
+``gs://bqemu-staging/...`` via ``--gcsEndpoint=http://<fake-gcs>/storage/v1/``
+(Beam ``Transport.newStorageClient`` honours ``--gcsEndpoint`` —
+verified at v2.55.1 line ~108–115 — calling
+``storageBuilder.setRootUrl(...)`` when the option is non-null).
+
+### 4. fake-gcs-server's filesystem backend is bind-mounted into bqemulator
+
+fake-gcs-server's filesystem backend stores objects at
+``{rootDir}/{bucket}/{object_name}``
+([fs.go](https://github.com/fsouza/fake-gcs-server/blob/v1.54.0/internal/backend/fs.go))
+— byte-exact with bqemulator's ``_resolve_uri`` which maps
+``gs://{bucket}/{object_name}`` to
+``{BQEMU_GCS_LOCAL_ROOT}/{bucket}/{object_name}``
+([executor.py:1103](https://github.com/jjviscomi/bqemulator/blob/main/src/bqemulator/jobs/executor.py)).
+The scio spec bind-mounts a single host directory into both
+containers at their respective roots:
+
+```
+fake-gcs-server -filesystem-root /data  ┐
+                                         ├── /tmp/bqemu-gcs-staging-{rand}
+bqemulator BQEMU_GCS_LOCAL_ROOT=/var/lib/bqemu-gcs ┘
+```
+
+Beam stages a shard via fake-gcs-server's HTTP API; fake-gcs-server
+materialises the object at ``/data/bqemu-staging/.../shard.json`` on
+disk; bqemulator's LOAD-job executor opens the same byte path under
+``/var/lib/bqemu-gcs/bqemu-staging/.../shard.json`` via DuckDB's
+``COPY ... FROM '...' (FORMAT JSON)``. No emulator-side fetch over
+the network, no new code path in ``executor.py``.
+
+### 5. Auth suppression via ``NoopCredentialFactory``
+
+The spec passes
+``--gcpCredentialFactoryClass=org.apache.beam.sdk.extensions.gcp.auth.NoopCredentialFactory``.
+Beam's ``GcpUserCredentialsFactory.create`` honours the factory class
+via ``InstanceBuilder.ofType(CredentialFactory.class).fromClass(
+gcpOptions.getCredentialFactoryClass())`` — calling
+``NoopCredentialFactory.getCredential()`` returns inert
+``NoopCredentials`` whose ``getRequestMetadata`` returns ``null`` and
+``refresh()`` is a no-op. No oauth2 refresh fires, no
+``oauth2.googleapis.com`` traffic.
+
+A belt-and-suspenders ``Test / envVars`` block in the scio example's
+``build.sbt`` sets ``CLOUDSDK_CONFIG`` to a fresh-empty temp dir and
+``GOOGLE_APPLICATION_CREDENTIALS`` to a deliberately-missing path —
+this keeps the no-op-auth contract honest on developer laptops that
+have ``gcloud auth application-default login`` state laying around,
+even though ``NoopCredentialFactory`` alone is sufficient against the
+source code.
+
+## Rationale
+
+### Why this approach over alternatives
+
+Several alternatives were rejected:
+
+1. **Add ``--bigQueryEndpoint`` to Beam.** Upstream PR that the Java
+   side would need to land. Multi-week timeline at best; downstream
+   users would still wait for the next Beam release. Reject — out of
+   scope for v1.0.2 and disenfranchises every Scio + bqemulator user
+   who can't wait.
+2. **JVM-level HTTP proxy with URL rewriting.** Would require a
+   TLS-terminating proxy with a custom CA, ``/etc/hosts`` hijacking
+   of ``bigquery.googleapis.com``, and a system-property cascade.
+   Brittle, intrusive, and impossible to ship as part of a clean
+   ScalaTest spec.
+3. **``Method.STREAMING_INSERTS`` instead of ``BATCH_LOADS``.** Avoids
+   GCS staging entirely but routes through ``tabledata.insertAll``,
+   which has its own behavioural quirks (no atomic write disposition,
+   per-row size limits, no schema evolution). Production demos prefer
+   BATCH_LOADS; switching the example's default to
+   STREAMING_INSERTS would mis-represent the canonical Scio +
+   BigQueryIO pattern.
+4. **Inline GCS shim inside the bqemulator container.** Would expand
+   the emulator's scope from "BigQuery" to "BigQuery + GCS". Real
+   BigQuery does not include GCS; the emulator's charter follows the
+   real service's surface, not the surface of upstream callers'
+   staging. Out of scope per
+   [out-of-scope.md](../reference/out-of-scope.md).
+5. **Document the limitation and re-defer.** v1.0.1 already deferred
+   it once; "wiring-only smoke" is a real gap in a production-stable
+   release. The "no deferral" principle in AGENTS.md says scope
+   boundaries must be cleanly excluded, not silently parked.
+
+The test-services approach above wins because:
+
+- The pipeline source stays production-shaped — a single ``optional``
+  branch with the production path unchanged.
+- The emulator source stays untouched — no new endpoints, no new
+  config knob, no new attack surface.
+- The fake-gcs-server sidecar is a 30-line addition in the scio spec,
+  fully contained in ``docs/examples/java/scio/``.
+- The end-to-end test exercises Beam's BATCH_LOADS path that real
+  Dataflow users hit — not a synthetic streaming-inserts substitute.
+
+### Why ``EmulatorBigQueryServices`` lives in Beam's package
+
+The constructors
+``BigQueryServicesImpl.JobServiceImpl(Bigquery client)`` and
+``BigQueryServicesImpl.DatasetServiceImpl(Bigquery client,
+PipelineOptions options)`` are marked ``@VisibleForTesting`` and are
+package-private. Java's access scoping is by *package*, not by *JAR*;
+a class declared in ``org.apache.beam.sdk.io.gcp.bigquery`` in our
+example's jar can reach those constructors at compile time and
+runtime. The Beam community uses the same pattern in its own test
+suite ([``BigQueryServicesImplTest``](https://github.com/apache/beam/blob/v2.55.1/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java)),
+so split-package against Beam is an established idiom rather than a
+hack.
+
+### Why ``fake-gcs-server`` and not a custom GCS shim
+
+The alternative of writing our own GCS HTTP/JSON-API mock was
+considered and rejected on the same scope ground as item 4 above —
+plus fake-gcs-server is a 4 MB Docker image with five years of
+production use across the Go testing ecosystem. Building our own
+would duplicate that mature surface for no marginal gain.
+
+### Why bind-mount and not HTTP fetch
+
+bqemulator already has a filesystem ``gs://`` resolver
+([``_resolve_uri``](https://github.com/jjviscomi/bqemulator/blob/main/src/bqemulator/jobs/executor.py)).
+The fake-gcs-server filesystem-backend layout is *byte-identical* to
+what ``_resolve_uri`` expects. Bind-mounting the same host directory
+into both containers lets us route Beam's GCS writes through
+fake-gcs-server (which materialises the bytes on disk) and bqemulator's
+LOAD reads through the existing filesystem path — no new code, no
+HTTP fetch boundary inside the executor, no double-network hop. The
+metadata sidecars fake-gcs-server writes are ``.metadata``-suffixed
+files that DuckDB's ``COPY ... FROM 'path/to/data.json'`` does not
+accidentally include because the LOAD job's ``sourceUris`` reference
+the data file by name, not by glob.
+
+## Consequences
+
+### Positive
+
+- Issue #17 closes cleanly — the scio example demonstrates a real
+  end-to-end BATCH_LOADS round-trip against bqemulator: 3 rows
+  written, 3 rows read back via ``jobs.query``.
+- The production demo value of the example is preserved — running
+  ``CustomersPipeline`` against real Dataflow uses the same source
+  code, same Scio idiom, no test-mode wiring.
+- ``executor.py`` stays at the v1.0.1 line count; the existing
+  ``BQEMU_GCS_LOCAL_ROOT`` shim absorbs the new use case without
+  modification.
+- The pattern documented here generalises: any Beam Java pipeline
+  that uses ``BigQueryIO.Write`` can apply the same
+  ``EmulatorBigQueryServices`` + fake-gcs-server recipe to test
+  against bqemulator without modifying their pipeline source. The
+  example doubles as a reference recipe.
+
+### Negative
+
+- The scio example now requires Docker to bring up a second container
+  (fake-gcs-server) for the end-to-end test. The wiring-only smoke
+  path is gone; CI runtime for the scio job goes from ~12s to ~20s
+  (still well below the 5-minute Examples-workflow ceiling).
+- ``CustomersPipeline.scala`` carries a conditional branch for the
+  test-services injection. The branch is small (15 lines) and the
+  production path stays identical, but the source is no longer
+  100% scio-idiomatic when the flag is set. Acceptable — the comment
+  block at the top of the file calls this out, and the trade-off
+  (a single conditional vs. a separate test-only pipeline file) is
+  the smaller one for users reading the example.
+- ``EmulatorBigQueryServices`` lives in ``org.apache.beam.sdk.io.gcp.bigquery``
+  (split-package). If Beam ever modularises ``google-cloud-platform``
+  with a ``module-info.java`` that closes the package, the class
+  would have to move to a runtime-reflection / proxy implementation.
+  Not a near-term risk (Beam has no module-info on this jar as of
+  v2.55.1), but worth re-checking on every Beam major-version bump.
+
+### Neutral
+
+- No new third-party dependencies in the bqemulator side. The
+  example pulls ``fsouza/fake-gcs-server:1.54.0`` as a runtime Docker
+  image, not a Maven artifact.
+- The pattern doesn't generalise to a Python SDK against bqemulator
+  — Beam's Python ``BigQueryIO`` uses a different services
+  abstraction. A separate ADR will document the Python-side recipe
+  when the equivalent issue (currently tracked at the
+  pyspark-bigquery example's wiring-only baseline) is closed.
+
+## References
+
+- [Issue #17](https://github.com/jjviscomi/bqemulator/issues/17) — the
+  consumer-side gap that prompted this work.
+- [apache/beam#34037](https://github.com/apache/beam/pull/34037) —
+  the Go SDK's ``BIGQUERY_EMULATOR_HOST`` adoption, for context on
+  why Java requires a custom hook.
+- [Beam BigQueryServicesImpl v2.55.1](https://github.com/apache/beam/blob/v2.55.1/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java)
+  — the ``@VisibleForTesting`` constructors this ADR depends on.
+- [Beam Transport v2.55.1](https://github.com/apache/beam/blob/v2.55.1/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java)
+  — proves ``--gcsEndpoint`` is honoured by
+  ``newStorageClient``.
+- [fake-gcs-server v1.54.0 fs backend](https://github.com/fsouza/fake-gcs-server/blob/v1.54.0/internal/backend/fs.go)
+  — proves filesystem-backend layout matches bqemulator's
+  ``_resolve_uri``.
+- [ADR 0027](0027-load-extract-avro-orc.md) — sibling decision for
+  the original ``BQEMU_GCS_LOCAL_ROOT`` shim that this ADR reuses.
+- [ADR 0033](0033-storage-read-arrow-ipc-bare-message-contract.md) —
+  the v1.0.1 ADR; same shape and template followed here.

--- a/docs/adr/0034-scio-beam-emulator-routing.md
+++ b/docs/adr/0034-scio-beam-emulator-routing.md
@@ -7,7 +7,7 @@
 [Issue #17](https://github.com/jjviscomi/bqemulator/issues/17) — closing
 the v1.0.0 "scio test exercises wiring only" caveat — turned out to be
 harder than the original framing suggested. The v1.0.1 investigation
-([CHANGELOG.md](../../CHANGELOG.md) `## [1.0.1]` "Changed" block and
+([CHANGELOG.md](https://github.com/jjviscomi/bqemulator/blob/main/CHANGELOG.md) `## [1.0.1]` "Changed" block and
 ``docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala``)
 surfaced three independent blockers that all had to land together
 before ``CustomersPipeline.run(...)`` could drive end-to-end against a

--- a/docs/adr/0034-scio-beam-emulator-routing.md
+++ b/docs/adr/0034-scio-beam-emulator-routing.md
@@ -81,7 +81,7 @@ fake-gcs-server's filesystem backend stores objects at
 The scio spec bind-mounts a single host directory into both
 containers at their respective roots:
 
-```
+```text
 fake-gcs-server -filesystem-root /data  ┐
                                          ├── /tmp/bqemu-gcs-staging-{rand}
 bqemulator BQEMU_GCS_LOCAL_ROOT=/var/lib/bqemu-gcs ┘

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -39,7 +39,7 @@ not drift.
 | Path | What it demonstrates | Known caveats |
 |---|---|---|
 | [`java/spring-boot/`](java/spring-boot/README.md) | Spring Boot repository + Testcontainers integration test | — |
-| [`java/scio/`](java/scio/README.md) | Spotify Scio (Scala-on-Beam) pipeline + ScalaTest | Test asserts the *wiring* (container up, REST API reachable). End-to-end ``CustomersPipeline.run`` deferred to v1.0.2+ ([#17](https://github.com/jjviscomi/bqemulator/issues/17)) — three independent blockers: ``--bigQueryEndpoint`` does set the Apiary client's ``rootUrl``, but Beam's ``OAuth2Credentials.refresh()`` 400s before the redirected call, and ``BigQueryIO.Write`` defaults to ``BATCH_LOADS`` which stages rows to GCS (no emulator-side shim). Likely v1.0.2 path: GCS emulator integration. The pipeline source itself remains production-ready against real BigQuery (Dataflow) or a long-lived bqemulator with stable port + real GCS bucket. |
+| [`java/scio/`](java/scio/README.md) | Spotify Scio (Scala-on-Beam) pipeline + ScalaTest. End-to-end ``CustomersPipeline.run`` writes 3 rows via Beam's BATCH_LOADS and the emulator returns them on read — closed in v1.0.2 via a per-example ``EmulatorBigQueryServices`` injected through ``BigQueryIO.Write.withTestServices(...)`` and a ``fsouza/fake-gcs-server`` sidecar for the GCS staging step ([#17](https://github.com/jjviscomi/bqemulator/issues/17), [ADR 0034](../adr/0034-scio-beam-emulator-routing.md)). | — |
 
 ## Compose stacks
 

--- a/docs/examples/java/scio/README.md
+++ b/docs/examples/java/scio/README.md
@@ -3,7 +3,8 @@
 A minimal [Scio](https://github.com/spotify/scio) pipeline that
 writes a customers table to BigQuery and reads it back. The Scala
 source under `src/main/scala/` is production-shaped — what you'd run
-against real BigQuery or Dataflow today.
+against real BigQuery or Dataflow today, with a single optional flag
+for the emulator-test path.
 
 ## Why this matters
 
@@ -12,57 +13,66 @@ on Google's stack run through it. Targeting it against `bqemulator`
 means engineering teams can run the same job locally that they run in
 Dataflow, without spinning up a real BigQuery dataset.
 
-## Known limitation — running Beam BigQueryIO end-to-end against bqemulator
+## How the pipeline runs end-to-end against bqemulator (v1.0.2+)
 
-Running ``CustomersPipeline.run`` against the emulator from inside
-the test JVM hits **three independent blockers**, surfaced during
-the v1.0.1 investigation
-([#17](https://github.com/jjviscomi/bqemulator/issues/17)):
+Beam 2.55.1's Java SDK has no built-in `BIGQUERY_EMULATOR_HOST`
+support (the Go SDK does — see
+[apache/beam#34037](https://github.com/apache/beam/pull/34037) — but
+the Java side never adopted it). v1.0.2 closes
+[#17](https://github.com/jjviscomi/bqemulator/issues/17) by wiring a
+test-services hook directly into the scio example, with no
+bqemulator-side code change:
 
-1. **Endpoint routing — works.** ``--bigQueryEndpoint=http://host:port``
-   *does* set the Apiary ``Bigquery`` client's ``rootUrl``
-   (verified locally via auth-failure stack traces confirming the
-   override applied). The original v1.0.0 hypothesis that
-   ``--bigQueryEndpoint`` was ignored turned out to be wrong;
-   however, the next two issues still bite.
-2. **Auth refresh fires before the redirected call.** With
-   ``--bigQueryEndpoint`` set, Beam still invokes
-   ``OAuth2Credentials.refresh()`` at request time. The refresh
-   ``400``s against ``oauth2.googleapis.com`` *before* the redirected
-   HTTP call ever fires.
-   ``--gcpCredentialFactoryClass=org.apache.beam.sdk.extensions.gcp.auth.NoopCredentialFactory``
-   is the documented escape hatch, but doesn't fully suppress the
-   discovery chain when application-default credentials exist on
-   the host (gcloud SDK auto-detects them past the flag).
-3. **BigQueryIO.Write defaults to BATCH_LOADS — needs GCS.** Bounded
-   pipelines stage rows to GCS before invoking BigQuery LOAD jobs.
-   The emulator doesn't expose a GCS-compatible shim Beam can stage
-   to; forcing ``Method.STREAMING_INSERTS`` would bypass GCS but
-   requires changing the ``CustomersPipeline`` source and pulls in
-   a different routing branch in BigQueryIO with its own quirks.
+1. **`CustomersPipeline.run` accepts an optional `--bqEmulatorEndpoint`.**
+   Production callers (real BigQuery / Dataflow) don't pass the flag
+   and take scio's idiomatic `saveAsBigQueryTable(...)` branch
+   unchanged. When the flag IS present, the pipeline drops to raw
+   `BigQueryIO.writeTableRows().withTestServices(
+   EmulatorBigQueryServices(endpoint))` for the BQ-traffic redirect.
+2. **`EmulatorBigQueryServices`** (in this example, at
+   `src/main/scala/org/apache/beam/sdk/io/gcp/bigquery/`) extends
+   Beam's `BigQueryServicesImpl` and overrides `getJobService` /
+   `getDatasetService` to construct the Apiary `Bigquery` client with
+   `setRootUrl(emulator)`. The class lives in Beam's package so it
+   can reach the `@VisibleForTesting` constructors on
+   `JobServiceImpl` / `DatasetServiceImpl` that accept a pre-built
+   client.
+3. **A `fake-gcs-server` sidecar** ([fsouza/fake-gcs-server](https://github.com/fsouza/fake-gcs-server))
+   handles GCS staging for Beam's default `BATCH_LOADS` write method.
+   The spec brings both containers up on a shared testcontainers
+   network and bind-mounts a single host directory into both at their
+   respective storage roots — so files Beam stages to
+   `gs://bqemu-staging/...` materialise on disk where bqemulator's
+   existing `BQEMU_GCS_LOCAL_ROOT` shim resolves them.
+4. **Auth suppression via Beam's `NoopCredentialFactory`** —
+   `--gcpCredentialFactoryClass=org.apache.beam.sdk.extensions.gcp.auth.NoopCredentialFactory`
+   short-circuits `OAuth2Credentials.refresh()` so no token grant
+   fires against `oauth2.googleapis.com`. The example's `build.sbt`
+   sets `CLOUDSDK_CONFIG` and `GOOGLE_APPLICATION_CREDENTIALS` to
+   empty values as belt-and-suspenders defence on developer laptops
+   with stale `gcloud auth application-default login` state.
 
-**The pipeline source itself remains correct.** Point it at real
-BigQuery (Dataflow) or a long-lived bqemulator on a stable port
-+ a real GCS bucket and it runs end-to-end.
-
-Tracked for v1.0.2+. Likely path: integrate a GCS emulator
-(e.g. [fsouza/fake-gcs-server](https://github.com/fsouza/fake-gcs-server))
-for staging + full auth-suppression chain + decide between staying
-on ``BATCH_LOADS`` (via GCS shim) or pivoting to ``STREAMING_INSERTS``.
+See [ADR 0034](../../../adr/0034-scio-beam-emulator-routing.md) for the
+full design — alternatives considered, source-of-truth references in
+Beam, and consequences.
 
 ## What the spec exercises
 
-Until #17 lands, the ScalaTest spec exercises the **wiring** that
-bqemulator owns and that Scio users actually depend on:
+The ScalaTest spec
+([`CustomersPipelineSpec`](src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala))
+drives the real `CustomersPipeline.run` and asserts:
 
-- bqemulator container starts and `/healthz` returns `200`.
-- Dataset creation via the REST surface succeeds (status in
-  `{200, 201, 409}` — 409 covers idempotent re-runs).
-- The dataset shows up on the `/bigquery/v2/projects/{project}/datasets`
-  listing endpoint.
+- bqemulator + fake-gcs-server both start.
+- Dataset creation via the REST surface succeeds (idempotent —
+  `{200, 201, 409}`).
+- `CustomersPipeline.run` returns 3 (the rows it intended to write).
+- A REST `SELECT COUNT(*)` against
+  `\`bqemu-demo\`.scio_demo.customers` returns 3 — confirming the
+  LOAD job actually landed the rows on disk.
 
-The end-to-end `CustomersPipeline.run(args)` assertion will return to
-the spec once #17 is resolved.
+The pipeline source itself stays production-ready: pointed at real
+BigQuery (Dataflow) with no `--bqEmulatorEndpoint`, the same code
+takes the scio path and writes via the real GCS staging bucket.
 
 ## Layout
 
@@ -70,6 +80,7 @@ the spec once #17 is resolved.
 build.sbt                                             — sbt build definition
 project/build.properties                              — sbt version pin
 src/main/scala/com/example/bqemu/CustomersPipeline.scala
+src/main/scala/org/apache/beam/sdk/io/gcp/bigquery/EmulatorBigQueryServices.scala
 src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
 ```
 
@@ -79,8 +90,8 @@ src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
 make test
 ```
 
-`make test` runs `sbt test`. Requires Docker for the Testcontainers
-emulator.
+`make test` runs `sbt test`. Requires Docker (for Testcontainers to
+spin up the bqemulator + fake-gcs-server pair).
 
 ## What to look for
 
@@ -88,5 +99,31 @@ emulator.
   `dependencyOverrides`. Scio 0.14.4's Scala Jackson module is
   pinned to 2.14.x; transitive deps drag in jackson-databind 2.16.x
   and the runtime guard refuses to load against the mismatch.
-- `BqemuContainer` is a one-line subclass that resolves Scala 2's
-  `Nothing` self-type collapse on Java's `GenericContainer<SELF>`.
+- `testcontainers` is at 1.21.4 — Docker 29+ rejects docker-java
+  clients announcing API < 1.40, and the 1.20.x line still ships an
+  older shaded docker-java that trips that check on modern Docker
+  Desktop. Bumping to 1.21.x fixes it.
+- The `EmulatorBigQueryServices` Scala file lives in Beam's package
+  (`org.apache.beam.sdk.io.gcp.bigquery`) — Java's package scoping
+  is by *package*, not *JAR*, so the split-package access compiles
+  and runs cleanly. This is the same idiom Beam's own test suite
+  uses for the `BigQueryServicesImpl` subclasses.
+- `BqemuContainer` and `FakeGcsContainer` are one-line subclasses
+  that resolve Scala 2's `Nothing` self-type collapse on Java's
+  `GenericContainer<SELF>`.
+- The spec's `runPipelineOrDumpDetail` wrapper exists because Beam's
+  BATCH_LOADS `finishBundle` collapses every per-writer close
+  failure into a single `IOException("Failed to close some
+  writers")` and stashes the real causes as suppressed exceptions —
+  the wrapper prints the full chain so a debug session starting
+  from a green test failure doesn't lose the underlying GCS error.
+
+## Adapting this to your own pipeline
+
+The `EmulatorBigQueryServices` class and the fake-gcs-server sidecar
+recipe both generalise. Copy the file under your own
+`src/main/scala/org/apache/beam/sdk/io/gcp/bigquery/` and call
+`BigQueryIO.Write.withTestServices(new
+EmulatorBigQueryServices(emulatorEndpoint))` from your test-mode
+branch. The sidecar pattern (shared bind mount + `--gcsEndpoint=...storage/v1/`)
+is documented in the spec.

--- a/docs/examples/java/scio/README.md
+++ b/docs/examples/java/scio/README.md
@@ -76,7 +76,7 @@ takes the scio path and writes via the real GCS staging bucket.
 
 ## Layout
 
-```
+```text
 build.sbt                                             — sbt build definition
 project/build.properties                              — sbt version pin
 src/main/scala/com/example/bqemu/CustomersPipeline.scala

--- a/docs/examples/java/scio/build.sbt
+++ b/docs/examples/java/scio/build.sbt
@@ -24,9 +24,9 @@ lazy val root = (project in file("."))
       "org.scalatest" %% "scalatest" % "3.2.18" % Test,
       // ``testcontainers`` 1.19.x ships docker-java 1.32 which only
       // talks to docker daemon API < 1.40 — modern Docker Desktop
-      // (27+) returns ``client version 1.32 is too old``. 1.20.x
+      // (27+) returns ``client version 1.32 is too old``. 1.21.x
       // bundles the newer docker-java that handles current daemons.
-      "org.testcontainers" % "testcontainers" % "1.20.4" % Test
+      "org.testcontainers" % "testcontainers" % "1.21.4" % Test
     ),
     dependencyOverrides ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
@@ -35,5 +35,23 @@ lazy val root = (project in file("."))
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
     ),
     Test / parallelExecution := false,
-    Test / fork := true
+    Test / fork := true,
+    // Defense in depth against host-side gcloud credentials leaking
+    // into the test JVM. Beam's ``--gcpCredentialFactoryClass=Noop...``
+    // is sufficient on its own (verified against Beam 2.55.1's
+    // ``GcpUserCredentialsFactory.create`` honouring the factory
+    // class — ``NoopCredentialFactory.getCredential()`` returns inert
+    // ``NoopCredentials``), but a fresh-empty ``CLOUDSDK_CONFIG`` and
+    // a deliberately-missing ``GOOGLE_APPLICATION_CREDENTIALS`` keep
+    // the no-op-auth contract honest on developer laptops that have
+    // ``gcloud auth application-default login`` state laying around.
+    Test / envVars := {
+      val emptyConfig = java.nio.file.Files
+        .createTempDirectory("bqemu-scio-empty-cloudsdk")
+        .toString
+      Map(
+        "CLOUDSDK_CONFIG" -> emptyConfig,
+        "GOOGLE_APPLICATION_CREDENTIALS" -> "/nonexistent/bqemu-scio-no-creds.json",
+      )
+    },
   )

--- a/docs/examples/java/scio/src/main/scala/com/example/bqemu/CustomersPipeline.scala
+++ b/docs/examples/java/scio/src/main/scala/com/example/bqemu/CustomersPipeline.scala
@@ -1,15 +1,42 @@
 package com.example.bqemu
 
-import com.google.api.services.bigquery.model.{TableFieldSchema, TableRow, TableSchema}
+import com.google.api.services.bigquery.model.{
+  TableFieldSchema,
+  TableRow,
+  TableSchema,
+}
 import com.spotify.scio.ContextAndArgs
 import com.spotify.scio.bigquery._
+import org.apache.beam.sdk.io.gcp.bigquery.{
+  BigQueryIO,
+  EmulatorBigQueryServices,
+}
 
 import scala.jdk.CollectionConverters._
 
 /** Writes a tiny customers table to BigQuery and reads it back.
   *
-  * Designed to run against either real BigQuery (Dataflow) or bqemulator
-  * (DirectRunner + --bigQueryEndpoint=http://localhost:PORT).
+  * Production-shaped: against real BigQuery (Dataflow) or any
+  * managed BQ endpoint, ``CustomersPipeline`` calls scio's idiomatic
+  * ``saveAsBigQueryTable`` — the wrapper most Beam-on-JVM Dataflow
+  * workloads on Google's stack use. Against a local bqemulator
+  * (driven by the scio example's CI / test suite) the pipeline
+  * accepts an extra ``--bqEmulatorEndpoint`` arg and switches to
+  * raw ``BigQueryIO.writeTableRows`` with
+  * ``.withTestServices(EmulatorBigQueryServices(endpoint))`` so the
+  * Apiary ``Bigquery`` client targets the local REST surface.
+  *
+  * Beam 2.55.1's Java SDK has no built-in ``BIGQUERY_EMULATOR_HOST``
+  * support (the Go SDK does — see apache/beam#34037 — but the Java
+  * side never adopted it). ``withTestServices`` is the documented
+  * test hook for swapping the BigQueryServices implementation;
+  * ``EmulatorBigQueryServices`` is the smallest possible wrapper
+  * that builds the Apiary client with ``setRootUrl(emulator)`` and
+  * reuses Beam's default JobService / DatasetService bodies
+  * unchanged.
+  *
+  * Production callers (no ``--bqEmulatorEndpoint``) take the scio
+  * branch unchanged.
   */
 object CustomersPipeline {
 
@@ -21,25 +48,47 @@ object CustomersPipeline {
     // arg names for the example's own settings.
     val project = parsedArgs("bqProject")
     val dataset = parsedArgs("bqDataset")
-    val table   = s"$project:$dataset.customers"
+    val tableName = s"$project:$dataset.customers"
 
     val schema = new TableSchema().setFields(List(
       new TableFieldSchema().setName("id").setType("INTEGER"),
-      new TableFieldSchema().setName("name").setType("STRING")
+      new TableFieldSchema().setName("name").setType("STRING"),
     ).asJava)
 
     val rows = sc.parallelize(Seq(
       new TableRow().set("id", 1L).set("name", "Alice"),
       new TableRow().set("id", 2L).set("name", "Bob"),
-      new TableRow().set("id", 3L).set("name", "Carol")
+      new TableRow().set("id", 3L).set("name", "Carol"),
     ))
 
-    rows.saveAsBigQueryTable(
-      Table.Spec(table),
-      schema = schema,
-      writeDisposition = WRITE_TRUNCATE,
-      createDisposition = CREATE_IF_NEEDED
-    )
+    parsedArgs.optional("bqEmulatorEndpoint") match {
+      case Some(endpoint) =>
+        // Local-emulator path. Switch to raw ``BigQueryIO.Write`` so
+        // we can attach ``.withTestServices(...)``; scio's
+        // ``saveAsBigQueryTable`` wraps the same transform but does
+        // not expose the test-services hook.
+        rows.internal.apply(
+          BigQueryIO.writeTableRows()
+            .to(tableName)
+            .withSchema(schema)
+            .withCreateDisposition(
+              BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED,
+            )
+            .withWriteDisposition(
+              BigQueryIO.Write.WriteDisposition.WRITE_TRUNCATE,
+            )
+            .withTestServices(new EmulatorBigQueryServices(endpoint)),
+        )
+
+      case None =>
+        // Production path — what runs against real BigQuery / Dataflow.
+        rows.saveAsBigQueryTable(
+          Table.Spec(tableName),
+          schema = schema,
+          writeDisposition = WRITE_TRUNCATE,
+          createDisposition = CREATE_IF_NEEDED,
+        )
+    }
 
     sc.run().waitUntilFinish()
     3L

--- a/docs/examples/java/scio/src/main/scala/org/apache/beam/sdk/io/gcp/bigquery/EmulatorBigQueryServices.scala
+++ b/docs/examples/java/scio/src/main/scala/org/apache/beam/sdk/io/gcp/bigquery/EmulatorBigQueryServices.scala
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// This file deliberately lives in ``org.apache.beam.sdk.io.gcp.bigquery``
+// — Beam's package — so it can reach the ``@VisibleForTesting``
+// constructors on ``BigQueryServicesImpl.JobServiceImpl`` and
+// ``BigQueryServicesImpl.DatasetServiceImpl`` that accept a pre-built
+// ``Bigquery`` client. Those constructors are package-private; same-
+// package access works across JARs (the package, not the JAR, defines
+// access scope).
+//
+// Why this exists at all: Beam 2.55.1's Java SDK has no
+// ``--bigQueryEndpoint`` option (Beam's Go SDK does, via
+// ``BIGQUERY_EMULATOR_HOST``; the Java side never adopted it — see
+// the search for ``BIGQUERY_EMULATOR_HOST`` in apache/beam:
+// only test files match, no production code). To redirect the Apiary
+// ``Bigquery`` client at a local emulator we have to construct it
+// ourselves with ``setRootUrl(...)`` and inject it via the
+// documented ``BigQueryIO.Write.withTestServices(...)`` hook.
+//
+// The class is test-only: production callers should never touch
+// ``BigQueryIO.Write.withTestServices`` (real BigQuery is reached via
+// the default ``BigQueryServicesImpl.INSTANCE``).
+package org.apache.beam.sdk.io.gcp.bigquery
+
+import com.google.api.client.http.{HttpRequest, HttpRequestInitializer}
+import com.google.api.services.bigquery.Bigquery
+import org.apache.beam.sdk.extensions.gcp.util.Transport
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.{
+  DatasetService,
+  JobService,
+}
+import org.apache.beam.sdk.options.PipelineOptions
+
+/** BigQueryServices that targets a local bqemulator REST surface.
+  *
+  * @param emulatorEndpoint
+  *   the bqemulator's REST root URL (e.g. ``http://localhost:9050``).
+  *   Trailing slash is normalised; the Apiary ``Bigquery`` client
+  *   appends ``bigquery/v2/`` automatically.
+  */
+class EmulatorBigQueryServices(emulatorEndpoint: String)
+    extends BigQueryServicesImpl
+    with Serializable {
+
+  // Normalise: Apiary's ``setRootUrl`` requires a trailing slash —
+  // without it the constructed URLs are missing the boundary between
+  // root and service path (e.g.
+  // ``http://localhostbigquery/v2/projects/...``).
+  private val normalisedEndpoint: String =
+    if (emulatorEndpoint.endsWith("/")) emulatorEndpoint
+    else emulatorEndpoint + "/"
+
+  private def buildClient(): Bigquery = {
+    // No auth header — the emulator accepts any caller, and adding an
+    // Authorization header would only make us route through the OAuth
+    // refresh path we're explicitly trying to avoid (see the
+    // ``--gcpCredentialFactoryClass=NoopCredentialFactory`` flag the
+    // pipeline passes in tandem).
+    val noopInit: HttpRequestInitializer = new HttpRequestInitializer {
+      override def initialize(request: HttpRequest): Unit = {
+        request.setReadTimeout(120_000)
+        request.setConnectTimeout(20_000)
+      }
+    }
+    new Bigquery.Builder(
+      Transport.getTransport,
+      Transport.getJsonFactory,
+      noopInit,
+    )
+      .setRootUrl(normalisedEndpoint)
+      .setApplicationName("bqemu-scio-example")
+      .build()
+  }
+
+  // The JobServiceImpl(@VisibleForTesting Bigquery client) constructor
+  // is package-private; this file lives in the same package so the
+  // reference resolves at compile time.
+  override def getJobService(options: BigQueryOptions): JobService =
+    new BigQueryServicesImpl.JobServiceImpl(buildClient())
+
+  override def getDatasetService(
+      options: BigQueryOptions,
+  ): DatasetService =
+    new BigQueryServicesImpl.DatasetServiceImpl(
+      buildClient(),
+      options.asInstanceOf[PipelineOptions],
+    )
+}

--- a/docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
+++ b/docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
@@ -119,6 +119,18 @@ class CustomersPipelineSpec extends AnyFlatSpec with Matchers {
         "/data",
       )
       .withFileSystemBind(sharedDir.toString, "/data", BindMode.READ_WRITE)
+      // Run fake-gcs-server as the same UID/GID as the bqemulator
+      // image's runtime user (``bqemu`` = 1000:1000). fake-gcs-server's
+      // ``writeFile(path, buf, 0o600)`` mode-bits are owner-only; on
+      // Linux CI runners the bind-mounted file lands on the host with
+      // the writer's UID and the bqemulator container (UID 1000) can't
+      // read a UID-0 0600 file. macOS Docker Desktop translates UIDs
+      // transparently and would silently let this slide. Pinning the
+      // fake-gcs-server UID closes the divergence.
+      .withCreateContainerCmdModifier {
+        cmd: com.github.dockerjava.api.command.CreateContainerCmd =>
+          cmd.withUser("1000:1000"); ()
+      }
       .withExposedPorts(4443)
       .waitingFor(Wait.forListeningPort())
 

--- a/docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
+++ b/docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
@@ -149,9 +149,13 @@ class CustomersPipelineSpec extends AnyFlatSpec with Matchers {
       .withExposedPorts(9050, 9060)
       .waitingFor(Wait.forHttp("/healthz").forPort(9050))
 
-    fakeGcs.start()
-    bqemu.start()
+    // Start the containers inside the guarded block. A failure in
+    // ``bqemu.start()`` after ``fakeGcs.start()`` succeeded would
+    // otherwise leak the fake-gcs container plus the network — the
+    // ``finally`` arm only runs when control is inside the ``try``.
     try {
+      fakeGcs.start()
+      bqemu.start()
       val rest =
         s"http://${bqemu.getHost}:${bqemu.getMappedPort(9050)}"
       // Beam's ``Transport.newStorageClient`` splits the endpoint URL
@@ -306,9 +310,22 @@ class CustomersPipelineSpec extends AnyFlatSpec with Matchers {
       // serialises all scalar column values as JSON strings.
       countResp.body() should include(""""v":"3"""")
     } finally {
-      bqemu.stop()
-      fakeGcs.stop()
-      net.close()
+      // Each cleanup runs in its own try/catch — a stop() failure on
+      // one resource shouldn't block the others. Testcontainers'
+      // Ryuk session reaper catches anything that still leaks at JVM
+      // exit, but ``finally`` doing best-effort cleanup keeps the
+      // common case clean. Cleanup exceptions are intentionally
+      // swallowed (logged to stderr instead of thrown) so a primary
+      // test-body failure stays the surfaced exception.
+      def safeStop(label: String, action: => Unit): Unit =
+        try action
+        catch {
+          case t: Throwable =>
+            System.err.println(s"[cleanup] $label failed: $t")
+        }
+      safeStop("bqemu.stop", bqemu.stop())
+      safeStop("fakeGcs.stop", fakeGcs.stop())
+      safeStop("net.close", net.close())
     }
   }
 }

--- a/docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
+++ b/docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala
@@ -2,11 +2,12 @@ package com.example.bqemu
 
 import java.net.URI
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.nio.file.{Files, Path, Paths}
 import java.time.Duration
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.{BindMode, GenericContainer, Network}
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
 
@@ -16,76 +17,145 @@ import org.testcontainers.utility.DockerImageName
 // `new GenericContainer(...)`, which then makes every fluent builder
 // method return `Nothing` — hence the
 // `value withEnv is not a member of Nothing` compile error. Define a
-// concrete subclass so `SELF` resolves to a real type.
+// concrete subclass per image so `SELF` resolves to a real type.
 class BqemuContainer(image: DockerImageName)
     extends GenericContainer[BqemuContainer](image)
+class FakeGcsContainer(image: DockerImageName)
+    extends GenericContainer[FakeGcsContainer](image)
 
 class CustomersPipelineSpec extends AnyFlatSpec with Matchers {
 
-  // KNOWN LIMITATION (issue #17): running ``CustomersPipeline.run``
-  // end-to-end against bqemulator is harder than a single flag /
-  // env-var fix. v1.0.1 investigated three routes and surfaced the
-  // following constraints; all three would need to land together
-  // before this spec can flip to an end-to-end ``written shouldBe
-  // 3L`` assertion:
+  // End-to-end: drive the actual ``CustomersPipeline.run`` against a
+  // ``bqemulator`` container PLUS a ``fake-gcs-server`` sidecar that
+  // implements GCS staging for Beam BigQueryIO's default ``BATCH_LOADS``
+  // path. Closes issue #17 — the three blockers identified during the
+  // v1.0.1 investigation (endpoint routing, auth-refresh, GCS staging)
+  // are all addressed by the sidecar + pipeline-options combination
+  // below. ADR 0034 documents the decision; the example README has the
+  // user-facing prose.
   //
-  // 1. **Endpoint routing.** ``--bigQueryEndpoint=http://host:port``
-  //    DOES wire through to the Apiary ``Bigquery`` client's
-  //    ``rootUrl`` (verified locally — auth-failure stacks confirm
-  //    the override applied). But ``BIGQUERY_EMULATOR_HOST`` (which
-  //    the cloud-style ``com.google.cloud.bigquery.BigQuery`` client
-  //    honours) has to be set on the JVM at fork time, before any
-  //    BQ class loads — sbt's ``Test / envVars`` can do this with a
-  //    fixed host port, but the next two issues still bite.
+  // Mechanism (no bqemulator-side code change):
   //
-  // 2. **Auth.** Beam still invokes ``OAuth2Credentials.refresh()``
-  //    at request time even when ``--bigQueryEndpoint`` is set, so
-  //    the redirected HTTP call never fires — auth refresh against
-  //    ``oauth2.googleapis.com`` 400s before the redirect happens.
-  //    ``--gcpCredentialFactoryClass=...NoopCredentialFactory`` is
-  //    the documented escape hatch but doesn't fully suppress the
-  //    discovery chain when application-default credentials exist
-  //    on the host (gcloud SDK auto-detects them past the flag).
+  // - ``--bqEmulatorEndpoint=<emu>`` is consumed by
+  //   ``CustomersPipeline.run`` (not by Beam) and causes the pipeline
+  //   to switch from scio's ``saveAsBigQueryTable`` to raw
+  //   ``BigQueryIO.writeTableRows().withTestServices(
+  //   EmulatorBigQueryServices(endpoint))``. The
+  //   ``EmulatorBigQueryServices`` class lives in the
+  //   ``org.apache.beam.sdk.io.gcp.bigquery`` package so it can reach
+  //   the ``@VisibleForTesting`` constructors on
+  //   ``BigQueryServicesImpl.JobServiceImpl`` /
+  //   ``DatasetServiceImpl`` that accept a pre-built Apiary
+  //   ``Bigquery`` client with ``setRootUrl(emulator)``. Beam 2.55.1's
+  //   Java SDK has no built-in ``BIGQUERY_EMULATOR_HOST`` (only the Go
+  //   SDK does, per apache/beam#34037), so the test-services hook is
+  //   the canonical Java-side path.
+  // - ``--gcsEndpoint=<fake-gcs>`` redirects Beam's GcsUtil Storage
+  //   client at the fake-gcs-server sidecar (verified in Beam 2.55.1's
+  //   ``Transport.newStorageClient``, which calls
+  //   ``storageBuilder.setRootUrl(...)`` when ``getGcsEndpoint`` is
+  //   non-null).
+  // - ``--gcpCredentialFactoryClass=NoopCredentialFactory`` returns
+  //   inert ``NoopCredentials`` whose ``getRequestMetadata`` returns
+  //   ``null`` and ``refresh()`` is a no-op, so no oauth2 refresh ever
+  //   fires (verified in Beam 2.55.1's ``GcpUserCredentialsFactory.create``
+  //   honouring the factory-class option via ``InstanceBuilder``).
+  // - The bqemulator's existing ``BQEMU_GCS_LOCAL_ROOT`` shim maps
+  //   ``gs://bucket/path`` to a filesystem path under
+  //   ``/var/lib/bqemu-gcs`` (G1 / ADR 0027). We bind-mount the same
+  //   host directory into the fake-gcs-server's ``-filesystem-root``,
+  //   so the LOAD-job source URIs that Beam stages resolve to the
+  //   exact same files on disk.
   //
-  // 3. **Batch-load path needs GCS.** ``BigQueryIO.Write`` defaults
-  //    to ``BATCH_LOADS`` for bounded pipelines, which stages rows
-  //    to GCS before issuing a BigQuery LOAD job. The emulator
-  //    doesn't expose a GCS-compatible shim Beam can stage to;
-  //    forcing ``Method.STREAMING_INSERTS`` would bypass GCS but
-  //    requires changing the ``CustomersPipeline`` source and
-  //    pulls in a different routing branch in BigQueryIO.
-  //
-  // For v1.0.1 this spec stays at the wiring-only smoke (container
-  // starts, REST API is reachable, dataset creation works — the
-  // bqemulator-owned part of the contract). The CustomersPipeline
-  // source itself is unchanged and remains accurate documentation
-  // for users running it against real BigQuery (Dataflow) or a
-  // long-lived bqemulator on a stable port + a real GCS bucket.
-  // Issue #17 stays open with the findings above scoped to v1.0.2+.
+  // The pipeline source under ``src/main/scala/`` is unchanged — what
+  // the user runs against real Dataflow is what runs here.
+  "CustomersPipeline" should
+    "write 3 rows via BATCH_LOADS and the emulator returns them on read" in {
+    val bqemuImage =
+      sys.env.getOrElse("BQEMU_IMAGE", "ghcr.io/jjviscomi/bqemulator:dev")
+    val fakeGcsImage = "fsouza/fake-gcs-server:1.54.0"
 
-  "bqemulator" should "expose a working BigQuery REST surface that Scio could target" in {
-    val image = sys.env.getOrElse("BQEMU_IMAGE", "ghcr.io/jjviscomi/bqemulator:dev")
+    // Shared host directory bound into BOTH containers — fake-gcs-server
+    // writes object bytes to its ``-filesystem-root`` at
+    // ``{root}/{bucket}/{object_name}``; bqemulator's
+    // ``_resolve_uri`` maps ``gs://{bucket}/{object_name}`` to
+    // ``{BQEMU_GCS_LOCAL_ROOT}/{bucket}/{object_name}``. Pointing both
+    // at the same physical directory means LOAD-job source URIs
+    // resolve to the bytes Beam staged, without an extra HTTP fetch on
+    // the bqemulator side.
+    //
+    // ``/tmp`` (rather than ``/var/folders/...``) keeps macOS Docker
+    // Desktop's bind mounts on the fast path.
+    val sharedDir: Path =
+      Files.createTempDirectory(Paths.get("/tmp"), "bqemu-gcs-staging")
+    sharedDir.toFile.setReadable(true, false)
+    sharedDir.toFile.setWritable(true, false)
+    sharedDir.toFile.setExecutable(true, false)
 
-    val container = new BqemuContainer(DockerImageName.parse(image))
+    val stagingBucket = "bqemu-staging"
+    // Pre-create the bucket directory so fake-gcs-server picks it up
+    // on boot (its ``-filesystem-root`` scanner enumerates immediate
+    // subdirectories as buckets at startup). Beam's GcsUtil tolerates
+    // a pre-existing bucket and just stages objects under it.
+    val stagingDir = sharedDir.resolve(stagingBucket)
+    Files.createDirectories(stagingDir)
+    stagingDir.toFile.setReadable(true, false)
+    stagingDir.toFile.setWritable(true, false)
+    stagingDir.toFile.setExecutable(true, false)
+
+    val net = Network.newNetwork()
+
+    val fakeGcs = new FakeGcsContainer(DockerImageName.parse(fakeGcsImage))
+      .withNetwork(net)
+      .withNetworkAliases("fake-gcs")
+      .withCommand(
+        "-scheme",
+        "http",
+        "-port",
+        "4443",
+        "-host",
+        "0.0.0.0",
+        "-filesystem-root",
+        "/data",
+      )
+      .withFileSystemBind(sharedDir.toString, "/data", BindMode.READ_WRITE)
+      .withExposedPorts(4443)
+      .waitingFor(Wait.forListeningPort())
+
+    val bqemu = new BqemuContainer(DockerImageName.parse(bqemuImage))
+      .withNetwork(net)
+      .withNetworkAliases("bqemu")
       .withEnv("BQEMU_REST_HOST", "0.0.0.0")
       .withEnv("BQEMU_GRPC_HOST", "0.0.0.0")
       .withEnv("BQEMU_ADMIN_ENABLED", "1")
+      .withEnv("BQEMU_GCS_LOCAL_ROOT", "/var/lib/bqemu-gcs")
+      .withFileSystemBind(
+        sharedDir.toString,
+        "/var/lib/bqemu-gcs",
+        BindMode.READ_WRITE,
+      )
       .withExposedPorts(9050, 9060)
       .waitingFor(Wait.forHttp("/healthz").forPort(9050))
 
-    container.start()
+    fakeGcs.start()
+    bqemu.start()
     try {
-      val rest = s"http://${container.getHost}:${container.getMappedPort(9050)}"
-      // Bound the *connect* and per-request blocking time so a stalled
-      // container / NAT misconfig in CI fails fast instead of hanging
-      // until the runner times out (per CodeRabbit feedback).
-      //
-      // Pin HTTP/1.1 explicitly — Java 17's HttpClient defaults to
-      // ``HTTP_2`` and tries an h2c upgrade even on plaintext
-      // ``http://``. uvicorn / h11 only speaks HTTP/1.1 and bounces
-      // the negotiation with ``400 Invalid HTTP request received``,
-      // which surfaces here as a baffling 400 on a perfectly valid
-      // POST body.
+      val rest =
+        s"http://${bqemu.getHost}:${bqemu.getMappedPort(9050)}"
+      // Beam's ``Transport.newStorageClient`` splits the endpoint URL
+      // into ``rootUrl`` (protocol + host + port) and ``servicePath``
+      // (URL path). Without the ``/storage/v1/`` path component
+      // Beam emits upload URLs of the shape
+      // ``http://host/upload/b/{bucket}/o`` (missing the
+      // ``storage/v1/`` middle), which fake-gcs-server rejects with
+      // 404. With the path the URLs come out as
+      // ``http://host/upload/storage/v1/b/{bucket}/o`` — the canonical
+      // GCS JSON-API upload prefix that fake-gcs-server implements.
+      val gcs =
+        s"http://${fakeGcs.getHost}:${fakeGcs.getMappedPort(4443)}/storage/v1/"
+
+      // Pin HTTP/1.1 — Java 17's default HTTP_2 tries h2c upgrade on
+      // plaintext URLs, which uvicorn / h11 bounce with 400.
       val client = HttpClient.newBuilder()
         .version(HttpClient.Version.HTTP_1_1)
         .connectTimeout(Duration.ofSeconds(10))
@@ -99,39 +169,134 @@ class CustomersPipelineSpec extends AnyFlatSpec with Matchers {
           .timeout(timeout)
           .GET()
           .build(),
-        HttpResponse.BodyHandlers.ofString()
+        HttpResponse.BodyHandlers.ofString(),
       )
       health.statusCode() shouldBe 200
 
-      // 2. Dataset creation via the REST surface succeeds.
-      //    Idempotent — 200/201 on first call, 409 on re-run.
+      // 2. Dataset creation via the REST surface — BigQuery (and
+      //    therefore the LOAD-job dispatch below) requires the
+      //    parent dataset to exist; CREATE_IF_NEEDED on the write
+      //    only auto-creates the TABLE, not the dataset.
       val createDs = HttpRequest.newBuilder()
-        .uri(URI.create(s"$rest/bigquery/v2/projects/bqemu-demo/datasets"))
+        .uri(URI.create(
+          s"$rest/bigquery/v2/projects/bqemu-demo/datasets",
+        ))
         .header("Content-Type", "application/json")
         .timeout(timeout)
         .POST(HttpRequest.BodyPublishers.ofString(
-          """{"datasetReference":{"projectId":"bqemu-demo","datasetId":"scio_demo"},"location":"US"}"""
+          """{"datasetReference":{"projectId":"bqemu-demo","datasetId":"scio_demo"},"location":"US"}""",
         ))
         .build()
       val createResp =
         client.send(createDs, HttpResponse.BodyHandlers.ofString())
-      withClue(s"create-dataset failed: ${createResp.statusCode()} ${createResp.body()}") {
+      withClue(
+        s"create-dataset failed: ${createResp.statusCode()} ${createResp.body()}",
+      ) {
         Set(200, 201, 409) should contain(createResp.statusCode())
       }
 
-      // 3. The dataset shows up on the listing endpoint.
-      val list = client.send(
-        HttpRequest.newBuilder()
-          .uri(URI.create(s"$rest/bigquery/v2/projects/bqemu-demo/datasets"))
-          .timeout(timeout)
-          .GET()
-          .build(),
-        HttpResponse.BodyHandlers.ofString()
-      )
-      list.statusCode() shouldBe 200
-      list.body() should include("scio_demo")
+      // 3. Drive the actual pipeline. The arguments below cover the
+      //    three blockers from the #17 investigation:
+      //    - ``--bqEmulatorEndpoint`` is pipeline-private (consumed
+      //      by ``CustomersPipeline.run``, not Beam) and causes the
+      //      pipeline to inject ``EmulatorBigQueryServices`` via
+      //      ``withTestServices(...)``, redirecting the Apiary
+      //      ``Bigquery`` client at the emulator's REST surface.
+      //      Beam 2.55.1's Java SDK has no built-in
+      //      ``BIGQUERY_EMULATOR_HOST`` support — only the Go SDK
+      //      does (apache/beam#34037), so the test-services hook is
+      //      the canonical Java-side path.
+      //    - ``--gcsEndpoint`` redirects Beam's GcsUtil Storage
+      //      client at the fake-gcs-server sidecar (verified in
+      //      Beam 2.55.1's ``Transport.newStorageClient``).
+      //    - ``--gcpCredentialFactoryClass=NoopCredentialFactory``
+      //      returns inert ``NoopCredentials`` whose ``refresh()``
+      //      is a no-op, suppressing the OAuth2 refresh path that
+      //      would otherwise 400 against ``oauth2.googleapis.com``
+      //      on hosts with stale ADC.
+      // Diagnostic wrapper — Beam's BatchLoads ``finishBundle``
+      // collapses every per-writer close failure into a single
+      // ``IOException("Failed to close some writers")`` and stashes
+      // the real causes as suppressed exceptions. Without this dump
+      // ScalaTest only shows the top-level message and the actual GCS
+      // upload error stays invisible.
+      def runPipelineOrDumpDetail(args: Array[String]): Long = {
+        try CustomersPipeline.run(args)
+        catch {
+          case e: Throwable =>
+            def printChain(t: Throwable, depth: Int): Unit = {
+              val indent = "  " * depth
+              System.err.println(s"$indent${t.getClass.getName}: ${t.getMessage}")
+              t.getStackTrace.take(5).foreach(s =>
+                System.err.println(s"$indent  at $s"),
+              )
+              Option(t.getCause).foreach { c =>
+                System.err.println(s"${indent}Caused by:")
+                printChain(c, depth + 1)
+              }
+              t.getSuppressed.foreach { s =>
+                System.err.println(s"${indent}Suppressed:")
+                printChain(s, depth + 1)
+              }
+            }
+            System.err.println("=== PIPELINE FAILURE CHAIN ===")
+            printChain(e, 0)
+            System.err.println("=== END PIPELINE FAILURE CHAIN ===")
+            throw e
+        }
+      }
+      val written = runPipelineOrDumpDetail(Array(
+        "--runner=DirectRunner",
+        "--project=bqemu-demo",
+        // Scio's DirectRunner default ``tempLocation`` is a host-
+        // local ``scio-temp-*`` directory under ``java.io.tmpdir``,
+        // which would route the BatchLoads file staging through the
+        // host filesystem and produce a LOAD-job ``sourceUris`` that
+        // bqemulator can't resolve against ``BQEMU_GCS_LOCAL_ROOT``.
+        // Setting BOTH ``--tempLocation`` (the Beam-wide default)
+        // and ``--gcpTempLocation`` (the GCP-specific override) is
+        // belt-and-suspenders: scio's ScioContext prefers
+        // ``tempLocation`` for its own bookkeeping, while
+        // BigQueryIO's BatchLoads reads ``gcpTempLocation`` for the
+        // staging bucket path.
+        s"--tempLocation=gs://$stagingBucket/",
+        s"--gcpTempLocation=gs://$stagingBucket/",
+        s"--gcsEndpoint=$gcs",
+        "--gcpCredentialFactoryClass=" +
+          "org.apache.beam.sdk.extensions.gcp.auth.NoopCredentialFactory",
+        // Pipeline-private args parsed by ``CustomersPipeline.run``
+        // — Beam consumes ``--project`` ahead of these.
+        s"--bqEmulatorEndpoint=$rest",
+        "--bqProject=bqemu-demo",
+        "--bqDataset=scio_demo",
+      ))
+      written shouldBe 3L
+
+      // 4. Round-trip — query the emulator's BigQuery REST surface
+      //    and assert the LOAD job actually landed 3 rows on the
+      //    destination table.
+      val countQ = HttpRequest.newBuilder()
+        .uri(URI.create(s"$rest/bigquery/v2/projects/bqemu-demo/queries"))
+        .header("Content-Type", "application/json")
+        .timeout(timeout)
+        .POST(HttpRequest.BodyPublishers.ofString(
+          """{"query":"SELECT COUNT(*) AS n FROM `bqemu-demo`.scio_demo.customers","useLegacySql":false}""",
+        ))
+        .build()
+      val countResp =
+        client.send(countQ, HttpResponse.BodyHandlers.ofString())
+      withClue(
+        s"count query failed: ${countResp.statusCode()} ${countResp.body()}",
+      ) {
+        countResp.statusCode() shouldBe 200
+      }
+      // The wire shape is ``rows: [{f: [{v: "3"}]}]`` — BigQuery
+      // serialises all scalar column values as JSON strings.
+      countResp.body() should include(""""v":"3"""")
     } finally {
-      container.stop()
+      bqemu.stop()
+      fakeGcs.stop()
+      net.close()
     }
   }
 }

--- a/docs/reference/out-of-scope.md
+++ b/docs/reference/out-of-scope.md
@@ -702,6 +702,47 @@ extension for INFORMATION_SCHEMA). Goccy's
 `bigquery-emulator` also defers this surface; the emulator's
 parity-with-goccy stance keeps it out of scope.
 
+### Google Cloud Storage emulation
+
+**Status**: Excluded permanently — the emulator's charter is BigQuery,
+not GCS.
+
+bqemulator implements the BigQuery REST + gRPC surface. Real BigQuery
+treats Google Cloud Storage as an external service; the emulator
+follows the same separation. Implementing a GCS HTTP/JSON-API surface
+inside the emulator would expand scope from "BigQuery" to "BigQuery +
+GCS" — a substantially larger maintenance surface for a feature real
+BigQuery doesn't include.
+
+The emulator's existing ``BQEMU_GCS_LOCAL_ROOT`` shim
+([ADR 0027](../adr/0027-load-extract-avro-orc.md)) is a *filesystem
+resolver* for ``gs://`` URIs that appear in LOAD / EXTRACT
+``sourceUris`` — it maps ``gs://bucket/path`` to a local filesystem
+path, so a test that pre-stages files on disk can load them. It is
+not a GCS API emulator. Anything that needs the actual GCS JSON API
+(Beam's ``BigQueryIO.Write`` BATCH_LOADS staging step, the Java SDK's
+``Storage.objects.insert``, signed URLs, multipart uploads) must
+target a separate GCS emulator.
+
+**Workaround** for Beam BigQueryIO BATCH_LOADS specifically:
+[fsouza/fake-gcs-server](https://github.com/fsouza/fake-gcs-server)
+ships a Docker image that implements the GCS HTTP/JSON API and stores
+objects at ``{root}/{bucket}/{object}`` — byte-identical with
+``BQEMU_GCS_LOCAL_ROOT``'s expected layout. The scio example
+([`docs/examples/java/scio/`](../examples/java/scio/README.md)) brings
+both containers up with a shared bind mount: Beam stages BATCH_LOADS
+shards via fake-gcs-server (which materialises them on disk),
+bqemulator's LOAD job reads the same bytes via its filesystem
+resolver. See [ADR 0034](../adr/0034-scio-beam-emulator-routing.md)
+for the full design.
+
+**Reconsidering**: an in-process GCS emulation surface would need an
+[RFC](../rfcs/README.md) demonstrating use cases the sidecar pattern
+does not cover. The sidecar adds one container to a test fixture; the
+in-process alternative would add an entire HTTP/JSON API + multipart
+upload + signed URL surface to bqemulator. The cost/benefit currently
+favours the sidecar.
+
 ### Native Windows containers
 
 The published image (`ghcr.io/jjviscomi/bqemulator`) is a multi-arch

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -215,6 +215,8 @@ nav:
       - "0030 Storage Read Avro output format": adr/0030-storage-read-avro-format.md
       - "0031 Fuzz-tier design contract": adr/0031-fuzz-tier-design-contract.md
       - "0032 bq CLI as a fifth conformance client": adr/0032-bq-cli-conformance-client.md
+      - "0033 Storage Read Arrow IPC bare-message contract": adr/0033-storage-read-arrow-ipc-bare-message-contract.md
+      - "0034 Scio + Beam BigQueryIO routing against bqemulator": adr/0034-scio-beam-emulator-routing.md
   - RFCs: rfcs/README.md
   - Examples:
       - Overview: examples/README.md


### PR DESCRIPTION
## Summary

Closes #17. The v1.0.1 "scio test exercises wiring only" caveat flips to a real Beam BigQueryIO BATCH_LOADS round-trip — 3 rows written via `CustomersPipeline.run`, 3 rows read back via `jobs.query`.

The fix is fully contained in the scio example. No emulator-side source change.

## Mechanism

The v1.0.1 investigation hypothesised that `--bigQueryEndpoint` redirected Beam's Apiary `Bigquery` client. That hypothesis was **wrong** — Beam 2.55.1 Java SDK has no such option (only the Go SDK has `BIGQUERY_EMULATOR_HOST`, per [apache/beam#34037](https://github.com/apache/beam/pull/34037)), and `BigQueryServicesImpl.newBigQueryClient` never calls `setRootUrl`. v1.0.2 uses Beam's documented test-services hook instead:

- `EmulatorBigQueryServices` (in `org.apache.beam.sdk.io.gcp.bigquery` — split-package, so it can reach the `@VisibleForTesting` `JobServiceImpl` / `DatasetServiceImpl` constructors) builds the Apiary `Bigquery` client with `setRootUrl(emulator)` and reuses Beam's default service bodies unchanged. Attached via `BigQueryIO.Write.withTestServices(...)`.
- `fsouza/fake-gcs-server` testcontainers sidecar handles Beam's GCS staging step for BATCH_LOADS. Bind-mounted into a shared host directory with bqemulator's existing `BQEMU_GCS_LOCAL_ROOT` shim (ADR 0027 / G1), so the staged shards Beam writes via fake-gcs-server materialise where the bqemulator LOAD job reads them. **No new code in `executor.py`.**
- `--gcpCredentialFactoryClass=NoopCredentialFactory` short-circuits Beam's OAuth2 refresh (verified against `GcpUserCredentialsFactory.create` honouring the factory-class option via `InstanceBuilder`).
- `testcontainers` 1.20.4 → 1.21.4 because Docker 29+ rejects docker-java clients announcing API < 1.40.

`CustomersPipeline.scala` keeps its production path (scio's `saveAsBigQueryTable`) unchanged; the test branch activates only when `--bqEmulatorEndpoint` is passed. The example doubles as a reference recipe for any Beam Java pipeline that needs to test BigQueryIO.Write against bqemulator.

## Changes

| File | Change |
|---|---|
| `docs/examples/java/scio/src/main/scala/org/apache/beam/sdk/io/gcp/bigquery/EmulatorBigQueryServices.scala` | **NEW** — subclass of `BigQueryServicesImpl` that supplies the Apiary client with `setRootUrl(emulator)`. |
| `docs/examples/java/scio/src/main/scala/com/example/bqemu/CustomersPipeline.scala` | Optional `--bqEmulatorEndpoint`. Default = scio's `saveAsBigQueryTable` unchanged. When set = raw `BigQueryIO.writeTableRows().withTestServices(...)`. |
| `docs/examples/java/scio/src/test/scala/com/example/bqemu/CustomersPipelineSpec.scala` | End-to-end spec: brings up bqemulator + fake-gcs-server on a shared testcontainers `Network`, shared bind mount into both, drives `CustomersPipeline.run`, asserts 3 rows written and 3 rows returned on REST `SELECT COUNT(*)`. |
| `docs/examples/java/scio/build.sbt` | testcontainers 1.20.4 → 1.21.4 (Docker 29+ compat); `Test/envVars` with empty `CLOUDSDK_CONFIG` + missing `GOOGLE_APPLICATION_CREDENTIALS` as belt-and-suspenders auth defence. |
| `docs/adr/0034-scio-beam-emulator-routing.md` | **NEW** — full design record (alternatives, source-of-truth refs, consequences). |
| `docs/examples/java/scio/README.md` | Rewritten — "known limitation" replaced with v1.0.2 end-to-end flow + a recipe for adapting to user pipelines. |
| `docs/examples/README.md` | Scio row drops the wiring-only caveat. |
| `CHANGELOG.md` | `[Unreleased]` `Fixed` entry; v1.0.0 known-limitations snapshot updated to mark #17 closed. |
| `docs/reference/out-of-scope.md` | NEW "GCS emulation" section documenting the boundary (sidecar pattern, not in-process GCS). |

## Verification

| Gate | Result |
|---|---|
| `BQEMU_IMAGE=ghcr.io/jjviscomi/bqemulator:1.0.1 sbt test` (in `docs/examples/java/scio/`) | ✅ 1 passed (3 rows written, 3 rows confirmed via REST `SELECT COUNT(*)`) |
| `make coverage-matrix-check compat-matrix-check function-mapping-check api-coverage-check` | ✅ all four green |
| `make lint` | ✅ ruff + format + mypy --strict + bandit + pip-audit + interrogate + typos |
| `make test-unit` | ✅ 2501 passed |
| `make test-coverage` | ✅ 91.11% (≥90%) |
| `make test-patch-coverage` | ✅ no Python diff lines (changes are Scala + markdown) |
| `lychee --config .lychee.toml '**/*.md'` | ✅ 0 errors |

## Test plan

- [ ] CI's Examples workflow scio job is green
- [ ] CodeRabbit threads (if any) resolved with inline replies citing the relevant commit SHAs and the `resolveReviewThread` GraphQL mutation
- [ ] Merge → v1.0.2 release PR per [release-process.md](docs/architecture/contributing/release-process.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end Apache Beam BigQueryIO example can run against the local emulator, including a fake GCS sidecar for staging and an option to route the pipeline to the emulator.

* **Documentation**
  * Added ADR documenting emulator routing and updated Scio example/readmes with runnable end-to-end guidance and troubleshooting.
  * Known limitation marked resolved for v1.0.2; example now demonstrates full execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->