### PR TITLE
release: bump to v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ section and adds the release date.
 
 ## [Unreleased]
 
+## [1.0.2] — 2026-05-23
+
 ### Fixed
 
 - **scio example: end-to-end ``CustomersPipeline.run`` against

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ DuckDB-backed, SQLGlot-powered, and tested against the real service. Point the o
 [![E2E](https://github.com/jjviscomi/bqemulator/actions/workflows/e2e.yml/badge.svg)](https://github.com/jjviscomi/bqemulator/actions/workflows/e2e.yml)
 [![Conformance](https://github.com/jjviscomi/bqemulator/actions/workflows/conformance.yml/badge.svg)](https://github.com/jjviscomi/bqemulator/actions/workflows/conformance.yml)
 [![Docs](https://github.com/jjviscomi/bqemulator/actions/workflows/docs.yml/badge.svg)](https://jjviscomi.github.io/bqemulator/)
-[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg?cacheSeconds=120&v=1.0.1)](https://pypi.org/project/bqemulator/)
-[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg?cacheSeconds=120&v=1.0.1)](https://pypi.org/project/bqemulator/)
+[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg?cacheSeconds=120&v=1.0.2)](https://pypi.org/project/bqemulator/)
+[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg?cacheSeconds=120&v=1.0.2)](https://pypi.org/project/bqemulator/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
@@ -200,7 +200,7 @@ See the [`docker-compose/full-stack`](docs/examples/docker-compose/full-stack/) 
 
 ## What works today
 
-`bqemulator` is at **v1.0.1** — first patch on the production-stable
+`bqemulator` is at **v1.0.2** — second patch on the production-stable
 line. SemVer applies: breaking changes ship only in MAJOR,
 deprecations live ≥2 MINOR or 6 months. The [compatibility matrix](https://jjviscomi.github.io/bqemulator/latest/reference/compatibility-matrix/) is auto-generated from the conformance corpus on every CI run; the [conformance coverage matrix](https://jjviscomi.github.io/bqemulator/latest/reference/conformance-coverage-matrix/) breaks down support by surface item.
 
@@ -245,7 +245,7 @@ The full documentation lives at **[jjviscomi.github.io/bqemulator](https://jjvis
 - [**Guides**](https://jjviscomi.github.io/bqemulator/latest/guides/loading-data/) — loading data, querying, streaming inserts, Storage API, UDFs, scripting, partitioning, time travel, materialized views, row access policies, dbt, Airflow, Spark, the `bq` CLI, observability, and more.
 - [**Reference**](https://jjviscomi.github.io/bqemulator/latest/reference/configuration/) — configuration, CLI, REST coverage, SQL function mapping, compatibility matrix, conformance coverage matrix, out-of-scope catalogue, troubleshooting.
 - [**Architecture**](https://jjviscomi.github.io/bqemulator/latest/architecture/overview/) — hexagonal architecture, storage model, SQL translation, jobs lifecycle, Storage Read/Write API design, scripting, UDFs, versioning, row access, specialized types, observability, testing strategy, conformance tier.
-- [**ADRs**](https://jjviscomi.github.io/bqemulator/latest/adr/0001-use-duckdb/) — 33 Architecture Decision Records documenting every non-obvious design choice.
+- [**ADRs**](https://jjviscomi.github.io/bqemulator/latest/adr/0001-use-duckdb/) — 34 Architecture Decision Records documenting every non-obvious design choice.
 
 ## Examples
 
@@ -270,14 +270,14 @@ Every example under [`docs/examples/`](docs/examples/) is a complete, runnable p
 
 ## Project status
 
-`bqemulator` is at **v1.0.1** — first patch on the production-stable
+`bqemulator` is at **v1.0.2** — second patch on the production-stable
 line. SemVer applies: breaking changes ship only in MAJOR
 versions, preceded by ≥1 MINOR with deprecation warnings;
 deprecated APIs remain for ≥2 MINOR versions or 6 months.
 
 Maturity signals:
 
-- ✅ 33 Architecture Decision Records covering every non-obvious design choice (`docs/adr/0001`–`0033`).
+- ✅ 34 Architecture Decision Records covering every non-obvious design choice (`docs/adr/0001`–`0034`).
 - ✅ ≥90% line + branch coverage gated by CI (`make verify`).
 - ✅ 7 test tiers passing (unit + property + integration + conformance + e2e + perf + chaos).
 - ✅ 5-client e2e matrix (Python · Node.js · Go · Java · `bq` CLI).
@@ -285,8 +285,8 @@ Maturity signals:
 - ✅ Fuzz-tier (`Atheris`) harnesses on the SQL translator, dynamic-protobuf decoder, and Arrow bridge.
 - ✅ Differential-tier row-order perturbation of the entire conformance corpus passes.
 - ✅ Performance baselines committed for `darwin-arm64`, with regression gates (`pytest-benchmark` `--benchmark-compare-fail=median:10%`).
-- ✅ PyPI publish via Trusted Publishing (sigstore-attested wheels) — `pip install bqemulator==1.0.1` resolves from [PyPI](https://pypi.org/project/bqemulator/).
-- ✅ GHCR publish with keyless cosign signatures — `docker pull ghcr.io/jjviscomi/bqemulator:1.0.1` resolves and the image is cosign-verifiable.
+- ✅ PyPI publish via Trusted Publishing (sigstore-attested wheels) — `pip install bqemulator==1.0.2` resolves from [PyPI](https://pypi.org/project/bqemulator/).
+- ✅ GHCR publish with keyless cosign signatures — `docker pull ghcr.io/jjviscomi/bqemulator:1.0.2` resolves and the image is cosign-verifiable.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for the complete v1.0 inventory.
 

--- a/src/bqemulator/__init__.py
+++ b/src/bqemulator/__init__.py
@@ -15,4 +15,4 @@ __all__ = ["__version__"]
 
 # Single source of truth for the version; hatchling reads this via
 # `[tool.hatch.version] path = "src/bqemulator/__init__.py"`.
-__version__ = "1.0.1"
+__version__ = "1.0.2"


### PR DESCRIPTION
## Summary

Cuts v1.0.2 — second patch on the production-stable line. Closes the v1.0.1 scio "wiring-only" caveat (issue #17) with a sidecar-based end-to-end test against bqemulator. No new emulator-side surface or breaking changes.

## Changes (this branch)

| File | Change |
|---|---|
| `README.md` | "Project status" v1.0.1 → v1.0.2, ADR count 33 → 34, badge cache-bust + `pip install` / `docker pull` example version bumps. |
| `src/bqemulator/__init__.py` | `__version__ = "1.0.2"` (via `scripts/bump_version.py`). |
| `CHANGELOG.md` | `[Unreleased]` block promoted to `## [1.0.2] — 2026-05-23` (via `scripts/changelog.py`). |

The actual fix landing in v1.0.2 (the scio end-to-end work) was merged in PR #42 — this PR is purely the release-process plumbing: README flip + version bump + CHANGELOG date promotion.

## Verification

| Gate | Result |
|---|---|
| `make release-dry-run NEXT=patch` (full `make verify` chain — lint + unit + property + integration + docker + e2e + docs) | ✅ |
| `make release NEXT=patch` (re-runs verify; bumps + finalises + commits + signed-tags) | ✅ |
| `git tag -l v1.0.2` SSH-signed | ✅ |

## Test plan

- [ ] CI green on this branch (lint + matrix + e2e + examples + conformance + docs-drift + lychee).
- [ ] Squash-merge to `main`. The squash collapses the README-flip + bump-commit into one commit on main.
- [ ] Retag dance per `docs/architecture/contributing/release-process.md` step 9:
  ```
  git checkout main && git pull --ff-only
  git tag -d v1.0.2
  git tag -a v1.0.2 -m v1.0.2
  git push origin v1.0.2
  ```
- [ ] Tag push fires `release.yml` (PyPI Trusted Publishing + sigstore attestation) and `docker.yml` (multi-arch GHCR + cosign keyless).
- [ ] Smoke-test post-release:
  ```
  pip install bqemulator==1.0.2
  docker pull ghcr.io/jjviscomi/bqemulator:1.0.2
  cosign verify ghcr.io/jjviscomi/bqemulator:1.0.2 \
      --certificate-identity-regexp='https://github.com/jjviscomi/bqemulator/.*' \
      --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released v1.0.2.

* **Documentation**
  * Updated version references, badges, and release metadata throughout documentation to reflect v1.0.2.
  * Added formal changelog entry for v1.0.2 (dated 2026-05-23).
  * Incremented documented architecture decision records from 33 to 34.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->