### PR TITLE
feat(quality): non-blocking complexity / duplication / dead-code gates

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,97 @@
+name: Code quality
+
+# Non-blocking quality gates: cyclomatic complexity (xenon), DRY /
+# duplication (jscpd), dead code (vulture). Wired per ADR 0035.
+#
+# Every step uses ``continue-on-error: true`` for now — the gate is
+# informational. Promotion-to-required is a separate follow-up PR
+# once thresholds + baselines have a cycle on main to settle.
+#
+# Triggers match the rest of the repo's per-PR + nightly pattern:
+# - Pull requests touching code or quality config.
+# - Pushes to main (so the baseline run stays current).
+# - Nightly schedule so threshold drift surfaces even in a quiet week.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".vulture_whitelist.py"
+      - ".jscpd.json"
+      - "Makefile"
+      - ".github/workflows/code-quality.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".vulture_whitelist.py"
+      - ".jscpd.json"
+      - "Makefile"
+      - ".github/workflows/code-quality.yml"
+  schedule:
+    - cron: "13 7 * * *"  # 07:13 UTC — off the hour to avoid contention
+  workflow_dispatch:
+
+concurrency:
+  group: code-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Quality gates (non-blocking)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+      - name: Install dev deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Cyclomatic complexity (xenon)
+        id: complexity
+        continue-on-error: true
+        run: make quality-complexity
+
+      - name: Cross-file duplication (jscpd)
+        id: duplication
+        continue-on-error: true
+        run: make quality-duplication
+
+      - name: Dead code (vulture)
+        id: dead-code
+        continue-on-error: true
+        run: make quality-dead-code
+
+      - name: Summarise outcomes
+        # Aggregated visibility — without this step the per-step
+        # ``continue-on-error: true`` would hide which gate actually
+        # tripped. The workflow itself still exits 0; the step
+        # outcomes go into the GitHub Actions summary.
+        run: |
+          {
+            echo "## Non-blocking quality-gate outcomes"
+            echo ""
+            echo "| Gate | Outcome |"
+            echo "|---|---|"
+            echo "| Cyclomatic complexity (xenon) | ${{ steps.complexity.outcome }} |"
+            echo "| Cross-file duplication (jscpd) | ${{ steps.duplication.outcome }} |"
+            echo "| Dead code (vulture) | ${{ steps.dead-code.outcome }} |"
+            echo ""
+            echo "These gates are non-blocking. Promotion to required check"
+            echo "is tracked as a follow-up — see ADR 0035."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,32 @@
+{
+  "_comment": [
+    "jscpd cross-file duplicate-code detection.",
+    "Wired by docs/adr/0035-code-quality-gates.md — DRY gate.",
+    "",
+    "Thresholds chosen against the v1.0.2 baseline:",
+    "  Project-wide duplication: 0.36% (7 clones, 112 lines).",
+    "  All current clones are <25 lines and structurally template-like",
+    "  (paired streaming strategies, route-handler CRUD shapes, etc.) —",
+    "  refactoring would introduce premature abstraction. Threshold set",
+    "  at 1% so today's baseline passes; regression that pushes the",
+    "  ratio above 1% fails the gate.",
+    "",
+    "min-lines 10 / min-tokens 70 are conservative for Python: catches",
+    "real copy-paste while ignoring trivially-similar imports / stubs.",
+    "Lower thresholds (5/40) generate too many template-shape hits."
+  ],
+  "pattern": "src/bqemulator/**/*.py",
+  "ignore": [
+    "**/tests/**",
+    "**/conformance/**",
+    "**/__pycache__/**",
+    "**/site/**",
+    "**/build/**"
+  ],
+  "reporters": ["consoleFull"],
+  "absolute": true,
+  "gitignore": true,
+  "min-lines": 10,
+  "min-tokens": 70,
+  "threshold": 1.0
+}

--- a/.vulture_whitelist.py
+++ b/.vulture_whitelist.py
@@ -1,0 +1,13 @@
+# Vulture whitelist — intentionally-retained names that vulture would
+# otherwise flag as dead code.
+#
+# Each entry needs a one-line justification linking back to the
+# source comment that documents the intent. New entries land via PR
+# review only — drift here is what the gate exists to catch.
+
+# bqemulator.jobs.executor.execute_query_job: ``use_cache`` is a
+# reserved kwarg for future query-cache integration. The source
+# already has ``# noqa: ARG001`` next to it documenting the intent;
+# vulture's "unused variable" check fires independently of ruff's
+# unused-argument rule, so the name needs to be referenced here too.
+use_cache  # noqa: F821, B018 - vulture whitelist sentinel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,43 @@ section and adds the release date.
 
 ## [Unreleased]
 
+### Added
+
+- **Non-blocking code-quality gates: complexity, duplication, dead code.**
+  Three concerns that the existing pre-commit chain (ruff + mypy +
+  bandit + pip-audit + interrogate + typos) doesn't meaningfully
+  enforce today now have observable CI signal:
+  - **`radon` + `xenon`** for per-function cyclomatic complexity
+    (`make quality-complexity`). Baseline thresholds picked against
+    the v1.0.2 codebase — `--max-absolute E --max-modules C --max-average A` —
+    so today's code passes; regression past those tiers fails. Fills
+    the gap left by ruff's intentionally-suppressed ``C901`` /
+    ``PLR0911`` / ``PLR0912`` / ``PLR0913`` (type-dispatch functions
+    are naturally branchy; xenon caps the worst case absolutely
+    without requiring per-function `noqa`).
+  - **`jscpd`** for cross-file DRY violations
+    (`make quality-duplication`). The one category nothing in the
+    stack covered. Threshold 1.0% — v1.0.2 baseline 0.36% (7 clones,
+    112 lines, all 11–22 lines and structurally template-shaped).
+    Wired via `npx -y jscpd` so the Python project takes on no
+    permanent JS dep.
+  - **`vulture`** wired into the new `make quality-dead-code`
+    target. The dev-dep + `[tool.vulture]` config already existed;
+    it was never invoked. New `.vulture_whitelist.py` documents the
+    one current false positive (the reserved `use_cache` kwarg on
+    `execute_query_job`). Each future whitelist entry lands via PR
+    review only — that's the contract that keeps the gate
+    trustworthy.
+
+  All three run via a single `make quality` umbrella and the new
+  `.github/workflows/code-quality.yml` workflow (per-PR + push-to-main
+  + nightly + manual). Every step uses `continue-on-error: true` —
+  the gates are **non-blocking by design** for this PR. `make verify`
+  is unchanged. Promote-to-required is a separate follow-up PR once
+  the thresholds settle against `main`. See
+  [ADR 0035](docs/adr/0035-code-quality-gates.md) for the full design,
+  baselines, and follow-up checklist.
+
 ## [1.0.2] — 2026-05-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ section and adds the release date.
     (`make quality-duplication`). The one category nothing in the
     stack covered. Threshold 1.0% — v1.0.2 baseline 0.36% (7 clones,
     112 lines, all 11–22 lines and structurally template-shaped).
-    Wired via `npx -y jscpd` so the Python project takes on no
-    permanent JS dep.
+    Wired via `npx -y jscpd@4` (major-version pin for reproducibility)
+    so the Python project takes on no permanent JS dep.
   - **`vulture`** wired into the new `make quality-dead-code`
     target. The dev-dep + `[tool.vulture]` config already existed;
     it was never invoked. New `.vulture_whitelist.py` documents the

--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,10 @@ quality-complexity: ## Cyclomatic-complexity ceiling via xenon (non-blocking)
 .PHONY: quality-duplication
 quality-duplication: ## Cross-file DRY check via jscpd (non-blocking)
 	# Requires ``npx`` on PATH (node/npm). ``-y`` auto-confirms the
-	# jscpd download on first run.
-	npx -y jscpd --config .jscpd.json
+	# jscpd download on first run; ``@4`` pins the major version so
+	# the gate is reproducible (ADR 0035 documents the choice — a
+	# jscpd 5.x release can break our config / threshold semantics).
+	npx -y jscpd@4 --config .jscpd.json
 
 .PHONY: quality-dead-code
 quality-dead-code: ## Dead-name detection via vulture (non-blocking)

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,55 @@ lint: ## Lint + typecheck + security scan
 	typos .
 
 # ---------------------------------------------------------------------------
+# Quality gates (non-blocking; see ADR 0035)
+# ---------------------------------------------------------------------------
+#
+# Three gates that ``ruff`` and the standard ``make lint`` chain don't
+# meaningfully enforce today:
+#
+#   - quality-complexity: xenon (radon wrapper) checks per-function
+#     cyclomatic-complexity rank. ruff's C901 / PLR0911 / PLR0912 /
+#     PLR0913 are all in pyproject's ignore list ("type-dispatch is
+#     naturally branchy"); xenon provides an absolute-rank ceiling
+#     without per-function noqa annotations.
+#
+#   - quality-duplication: jscpd (cross-file DRY). Nothing in the
+#     standard chain catches this — pylint's duplicate-code is the
+#     only other Python-native option and it's slower with weaker
+#     output. Requires node/npm for ``npx``; CI installs both.
+#
+#   - quality-dead-code: vulture, configured in pyproject.toml but
+#     previously unwired. Surfaces names not referenced anywhere.
+#
+# Wired non-blocking in CI (.github/workflows/code-quality.yml,
+# continue-on-error: true). Not part of ``make verify`` — that gate
+# stays the strict pre-merge contract. Promote-to-required is a
+# separate follow-up PR once thresholds + baselines are stable.
+
+.PHONY: quality-complexity
+quality-complexity: ## Cyclomatic-complexity ceiling via xenon (non-blocking)
+	# Baseline thresholds match the v1.0.2 codebase: project-wide
+	# average A (3.44), worst module C, worst function E (39 — the
+	# arrow_bridge ``_format_bq_value`` value-coercion switch). Any
+	# regression past these tiers fails the gate; today's code passes.
+	xenon --max-absolute E --max-modules C --max-average A src/bqemulator
+
+.PHONY: quality-duplication
+quality-duplication: ## Cross-file DRY check via jscpd (non-blocking)
+	# Requires ``npx`` on PATH (node/npm). ``-y`` auto-confirms the
+	# jscpd download on first run.
+	npx -y jscpd --config .jscpd.json
+
+.PHONY: quality-dead-code
+quality-dead-code: ## Dead-name detection via vulture (non-blocking)
+	# Config + whitelist live in pyproject.toml [tool.vulture] and
+	# .vulture_whitelist.py.
+	vulture
+
+.PHONY: quality
+quality: quality-complexity quality-duplication quality-dead-code ## Run all non-blocking quality gates
+
+# ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
 

--- a/docs/adr/0035-code-quality-gates.md
+++ b/docs/adr/0035-code-quality-gates.md
@@ -159,7 +159,7 @@ ignore_names = ["*Command", "*Request", "*Response"]
 | Surface | Where |
 |---|---|
 | `make quality-complexity` | `xenon ...` |
-| `make quality-duplication` | `npx -y jscpd --config .jscpd.json` |
+| `make quality-duplication` | `npx -y jscpd@4 --config .jscpd.json` |
 | `make quality-dead-code` | `vulture` (reads `[tool.vulture]`) |
 | `make quality` | Umbrella over all three |
 | `.github/workflows/code-quality.yml` | Per-PR + push-to-main + nightly + manual; each step has `continue-on-error: true`; aggregated outcomes in `$GITHUB_STEP_SUMMARY` |
@@ -220,7 +220,7 @@ codebase. Output quality: jscpd's `consoleFull` reporter prints
 the actual cloned line ranges side-by-side; pylint's
 duplicate-code reporter is more terse and less actionable.
 
-### Why `npx -y jscpd` rather than installing it
+### Why `npx -y jscpd@4` rather than installing it
 
 The Python project has no other JS deps. Pinning jscpd through a
 package-lock here would add a permanent maintenance surface (renovate
@@ -228,7 +228,10 @@ PRs, audit warnings on lockfile vulnerabilities) for a single
 non-blocking gate. `npx -y` pulls the published package on demand;
 CI's `actions/setup-node@v6` cache makes subsequent runs sub-second.
 The local dev experience matches: any developer with node already
-has npx.
+has npx. The `@4` major-version pin keeps the gate reproducible
+without a lockfile: jscpd 4.x is stable; a future 5.x release that
+breaks our config schema or threshold semantics requires a deliberate
+opt-in bump.
 
 ### Why preserve the existing vulture config rather than reset it
 

--- a/docs/adr/0035-code-quality-gates.md
+++ b/docs/adr/0035-code-quality-gates.md
@@ -1,0 +1,313 @@
+# ADR 0035: Non-blocking code-quality gates — complexity, duplication, dead code
+
+- **Status**: Accepted
+
+## Context
+
+The current pre-commit gate chain (`make lint` →
+ruff + mypy --strict + bandit + pip-audit + interrogate + typos, plus
+`test-unit` / `test-coverage` / `test-patch-coverage`) is dense but
+leaves three holes:
+
+| Concern | Current coverage | Gap |
+|---|---|---|
+| **Cyclomatic complexity** | ruff has the [mccabe `C901`](https://docs.astral.sh/ruff/rules/complex-structure/) rule plus [`PLR0911`](https://docs.astral.sh/ruff/rules/too-many-return-statements/), [`PLR0912`](https://docs.astral.sh/ruff/rules/too-many-branches/), [`PLR0913`](https://docs.astral.sh/ruff/rules/too-many-arguments/), [`PLR0915`](https://docs.astral.sh/ruff/rules/too-many-statements/). All four of the first set are deliberately **ignored** in `pyproject.toml` — the rationale is that type-dispatch and route-handler signatures are naturally branchy and adding per-function `noqa` is noise. Only `PLR0915` (50-statement ceiling) actively enforces anything. | No per-function rank ceiling; a function can climb to complexity 30+ without surfacing. |
+| **Code duplication / DRY violations** | None. CodeQL doesn't catch it, ruff doesn't detect cross-file clones, Codecov doesn't model it. | A whole category — "this should've been a helper" — is invisible. |
+| **Dead code (unused names)** | `vulture>=2.11` is in the dev-deps and `[tool.vulture]` config exists, but the tool is **not** invoked anywhere — not in `make lint`, not in any CI workflow. Dormant. | Same surface, but worse: the dependency is paid for without any return. |
+
+The user concern that prompted this ADR was specifically "tools we have do
+not do a good job at catching cyclomatic complexity, bad patterns, or
+DRY violations across the codebase." Verified against the actual
+`pyproject.toml` ignore list, which confirms the gap.
+
+SonarCloud was considered explicitly and declined — the existing stack
+(ruff + bandit + CodeQL + Codecov + CodeRabbit + the seven-tier test
+pyramid) already covers most of what SonarCloud catches; the
+marginal value over what the three targeted tools below provide is
+mostly dashboard convenience, not bug-catching.
+
+## Decision
+
+Add three external gates, wired as **non-blocking** quality checks
+behind a single `make quality` umbrella target and a dedicated
+`.github/workflows/code-quality.yml` workflow. None of the three
+become part of `make verify` in this ADR — that gate stays the strict
+pre-merge contract. Promote-to-required is a separate follow-up PR
+once a baseline cycle on `main` confirms the thresholds.
+
+### 1. Cyclomatic complexity → `radon` + `xenon`
+
+`xenon` wraps `radon`'s per-function complexity scoring with hard
+threshold flags suitable for CI. It assigns each block a rank A–F
+where the bands are:
+
+| Rank | Cyclomatic complexity |
+|---|---|
+| A | 1–5 |
+| B | 6–10 |
+| C | 11–20 |
+| D | 21–30 |
+| E | 31–40 |
+| F | ≥41 |
+
+Baseline measured against the v1.0.2 codebase (1,531 blocks):
+
+| Metric | Value |
+|---|---|
+| Project-wide average complexity | A (3.44) |
+| Worst-ranked module average | C (`storage/arrow_bridge.py`, `versioning/time_travel.py`, `sql/rewriter/unnest_offset.py`, `sql/rewriter/timestamp_iso_helpers.py`) |
+| Worst-ranked single function | E (39) — `storage/arrow_bridge._format_bq_value` |
+| Blocks at rank ≥ C | 65 / 1,531 (4.2%) |
+| Blocks at rank ≥ D | 10 / 1,531 (0.7%) |
+| Blocks at rank ≥ E | 3 / 1,531 (0.2%) |
+
+Thresholds chosen against that baseline so the gate passes today but
+catches regression:
+
+```make
+xenon --max-absolute E --max-modules C --max-average A src/bqemulator
+```
+
+- `--max-absolute E` — no function above rank E (a new F-rank function
+  fails).
+- `--max-modules C` — no module averaging above rank C (a new high-
+  complexity module fails even if no single function trips the absolute
+  ceiling).
+- `--max-average A` — project-wide average must stay rank A. Today's
+  number is 3.44 — comfortable headroom before the A/B boundary at 5.
+
+These are the **first-PR baseline**. The follow-up promote-to-required
+PR will tune them downward once we see the noise floor on `main`.
+
+`xenon` provides what the ignored ruff rules (`C901` / `PLR0911` /
+`PLR0912`) can't: a per-function ceiling without requiring
+per-occurrence `noqa`. The existing ruff ignores stay — they exist
+because the type-dispatch pattern is structurally branchy, and that
+pattern is exactly what produces D-rank functions today. The xenon
+ceiling caps the worst case while leaving the pattern itself
+unflagged.
+
+### 2. Code duplication → `jscpd`
+
+`jscpd` is the only Python-capable cross-file clone detector with
+mature CI ergonomics. The Python-native alternative
+(`pylint --disable=all --enable=duplicate-code`) is slower, has
+weaker reporting, and runs against an already-loaded ruff/mypy
+toolchain that does not include pylint.
+
+`jscpd` is JS-based — wired via `npx -y jscpd@4` so the gate adds
+zero permanent JS deps to the Python project. CI installs node 20
+alongside Python via `actions/setup-node@v6`.
+
+Baseline (v1.0.2, default thresholds 10 lines / 70 tokens):
+
+| Metric | Value |
+|---|---|
+| Total clones | 7 (when grouped pair-wise) — `consoleFull` reporter expands to 19 fragment-level pairs |
+| Duplicated lines | 112 |
+| Project duplication ratio | 0.36% |
+
+All seven baseline clones are 11–22 lines, structurally
+template-shaped (paired streaming strategies, route-handler CRUD
+shapes, paired SQL-rule helpers). Refactoring would introduce
+premature abstraction — the structural-similarity-but-semantic-
+distinctness is intentional. The threshold is set to **1.0%** —
+today passes (0.36%), but any meaningful regression fails.
+
+Config lives at `.jscpd.json`:
+
+```json
+{
+  "pattern": "src/bqemulator/**/*.py",
+  "ignore": ["**/tests/**", "**/conformance/**", ...],
+  "min-lines": 10,
+  "min-tokens": 70,
+  "threshold": 1.0
+}
+```
+
+### 3. Dead code → `vulture`
+
+`vulture` is already a dev-dep with `[tool.vulture]` config in
+`pyproject.toml` — but it was never wired into any target. This ADR
+flips that on.
+
+Baseline: **1 finding** at `min_confidence = 80` —
+`jobs/executor.py:251: unused variable 'use_cache'`. The variable is
+a reserved kwarg for future query-cache integration, documented
+inline with `# noqa: ARG001`. vulture's "unused variable" check
+fires independently of ruff's unused-argument suppression, so the
+existing config doesn't catch it.
+
+A new `.vulture_whitelist.py` lists the name with an inline
+justification linked back to the source comment. Each future
+whitelist entry lands via PR review only — that's the contract that
+keeps the gate trustworthy.
+
+The whitelist file is added to `[tool.vulture] paths`:
+
+```toml
+[tool.vulture]
+paths = ["src/bqemulator", ".vulture_whitelist.py"]
+min_confidence = 80
+ignore_decorators = ["@app.*", "@router.*", "@pytest.fixture"]
+ignore_names = ["*Command", "*Request", "*Response"]
+```
+
+### Wiring
+
+| Surface | Where |
+|---|---|
+| `make quality-complexity` | `xenon ...` |
+| `make quality-duplication` | `npx -y jscpd --config .jscpd.json` |
+| `make quality-dead-code` | `vulture` (reads `[tool.vulture]`) |
+| `make quality` | Umbrella over all three |
+| `.github/workflows/code-quality.yml` | Per-PR + push-to-main + nightly + manual; each step has `continue-on-error: true`; aggregated outcomes in `$GITHUB_STEP_SUMMARY` |
+| `make verify` | **Unchanged**. The three gates are non-blocking — they don't gate releases yet. |
+
+### Why non-blocking first
+
+Per the v1.0 charter the project follows a **no-deferral principle**
+on feature scope, but introducing new gates is operationally
+different: a gate that fires on every PR without justification
+trains developers to ignore it. The non-blocking phase exists to
+let the thresholds settle against `main` over several normal
+merges and to surface noise (false positives, structural-pattern
+hits) before a regression starts blocking merges.
+
+The follow-up promote-to-required PR will:
+
+1. Tighten thresholds based on observed noise (e.g. drop
+   `--max-absolute E` to `--max-absolute D` if no D-rank function
+   merged in the meantime).
+2. Add the relevant `make quality-*` step to `make verify`.
+3. Add the check name to the branch protection ruleset's required
+   list (`gh api repos/jjviscomi/bqemulator/rulesets/...`).
+4. Re-confirm against the cycle's main HEAD.
+
+## Rationale
+
+### Why three separate tools, not one
+
+The three concerns are independent. SonarQube / SonarCloud bundle
+all three into one dashboard, but the marginal value over three
+focused tools is low and the operational cost (SaaS billing,
+token management, another bot reviewer) is non-trivial. The user
+explicitly declined SonarCloud during the design discussion.
+
+### Why xenon over relaxing the ignored ruff rules
+
+The ignored rules (`C901` / `PLR0911` / `PLR0912` / `PLR0913`) are
+**per-function** checks. Their failure mode is "this function
+crosses threshold X" with no escape hatch except `# noqa: <rule>` on
+the offending function. The current ignore list captures the
+project-wide judgement that type-dispatch functions earn the
+branch budget; surfacing them as warnings on every PR would
+require landing dozens of `noqa` annotations across the rule
+registry alone.
+
+xenon's `--max-absolute E` instead caps the **worst case** in the
+whole codebase — a D-rank type-dispatch function still passes; only
+a brand-new function at F-rank (≥41 complexity) fails. Different
+contract, more usable.
+
+### Why jscpd over pylint --enable=duplicate-code
+
+Performance: pylint loads the whole project's AST and runs ~100
+other checks before reaching duplicate-code. jscpd is a focused
+clone detector that finishes the same scan in <1s on this
+codebase. Output quality: jscpd's `consoleFull` reporter prints
+the actual cloned line ranges side-by-side; pylint's
+duplicate-code reporter is more terse and less actionable.
+
+### Why `npx -y jscpd` rather than installing it
+
+The Python project has no other JS deps. Pinning jscpd through a
+package-lock here would add a permanent maintenance surface (renovate
+PRs, audit warnings on lockfile vulnerabilities) for a single
+non-blocking gate. `npx -y` pulls the published package on demand;
+CI's `actions/setup-node@v6` cache makes subsequent runs sub-second.
+The local dev experience matches: any developer with node already
+has npx.
+
+### Why preserve the existing vulture config rather than reset it
+
+The existing `ignore_decorators` / `ignore_names` patterns
+(`@app.*`, `@router.*`, `@pytest.fixture`, `*Command` / `*Request` /
+`*Response`) reflect actual project conventions — the decorators
+mark FastAPI endpoint registrations (referenced reflectively), the
+suffix patterns mark command/transport DTO classes that pydantic
+serializes. Resetting them would generate false positives that the
+whitelist would then have to absorb. Keep the suppressions, add
+the missing whitelist for the one new finding.
+
+## Consequences
+
+### Positive
+
+- Three real categories of code-quality drift now have an observable
+  signal — promoted-to-required in a follow-up they'll have a
+  preventive signal too.
+- The user concern that prompted this work has a documented answer:
+  `make quality` reports complexity / duplication / dead code; CI
+  surfaces the same on every PR.
+- vulture stops being a dev-dep that costs install bandwidth but
+  produces nothing.
+- The three tools' configs are independent — promoting any one
+  alone to required doesn't depend on the others.
+
+### Negative
+
+- Three more tools to keep current. radon / xenon / vulture all
+  follow the standard pip update cadence; jscpd is fetched fresh
+  by npx every CI run so it tracks upstream automatically (and
+  can therefore break on a major-version jscpd release — pin via
+  `jscpd@4` if that becomes a problem).
+- node + npm installed in the code-quality CI job — adds ~10-15s
+  to that job's runtime. Acceptable: the workflow is non-blocking
+  and not on the release path.
+- The three baselines (xenon thresholds, jscpd 1.0%, vulture
+  whitelist) capture a snapshot of v1.0.2. Each will need a
+  revisit pass after some commits land on `main` — the promote-
+  to-required PR is when that revisit happens.
+
+### Neutral
+
+- The Vulture whitelist file (`.vulture_whitelist.py`) is real
+  Python source — it imports nothing and references names as
+  bare statements. Ruff's S101/B018 fires on it without
+  in-file suppressions; the file already carries the right
+  `# noqa: F821, B018` annotations.
+
+## Alternatives considered
+
+1. **SonarQube / SonarCloud.** Dashboards + bundled checks, but
+   overlaps with existing stack. Declined by the project owner
+   during the design discussion.
+2. **Add C901 / PLR0911 / PLR0912 / PLR0913 back to ruff with
+   per-function `noqa` waivers.** Higher friction per regression
+   (every type-dispatch function needs an inline annotation);
+   doesn't give a project-wide ceiling. Rejected.
+3. **Promote the gates to required in the same PR as adding them.**
+   Locks in baselines that haven't seen a cycle on `main` yet —
+   any noise we miss now would block PRs immediately. The
+   prompt-design intent (the user task that drove this ADR)
+   explicitly called for non-blocking-first.
+4. **pylint full run for everything.** Slow, redundant with ruff
+   for the rules ruff already covers, and the bits ruff doesn't
+   (`duplicate-code`) are weaker than `jscpd`. Rejected.
+5. **SonarCloud (free for OSS) + community quality-gate badge.**
+   Same overlap argument as #1; the marginal value is dashboard
+   convenience, not bug-catching. Re-openable via RFC.
+
+## References
+
+- [Issue #17 closure / v1.0.2 (PR #42)](https://github.com/jjviscomi/bqemulator/pull/42) — the release this ADR sequences after.
+- [ADR 0033](0033-storage-read-arrow-ipc-bare-message-contract.md) and
+  [ADR 0034](0034-scio-beam-emulator-routing.md) — the template/shape this ADR follows.
+- [`radon` docs](https://radon.readthedocs.io/en/latest/) — rank tier definitions.
+- [`xenon` docs](https://xenon.readthedocs.io/en/latest/) — CLI thresholds.
+- [`jscpd` docs](https://github.com/kucherenko/jscpd) — config schema.
+- [`vulture` docs](https://github.com/jendrikseipp/vulture) — whitelist semantics.
+- AGENTS.md "Pre-commit gate (mandatory)" — the contract this ADR
+  carefully **doesn't** extend yet.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -217,6 +217,7 @@ nav:
       - "0032 bq CLI as a fifth conformance client": adr/0032-bq-cli-conformance-client.md
       - "0033 Storage Read Arrow IPC bare-message contract": adr/0033-storage-read-arrow-ipc-bare-message-contract.md
       - "0034 Scio + Beam BigQueryIO routing against bqemulator": adr/0034-scio-beam-emulator-routing.md
+      - "0035 Non-blocking code-quality gates (complexity / duplication / dead code)": adr/0035-code-quality-gates.md
   - RFCs: rfcs/README.md
   - Examples:
       - Overview: examples/README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,16 @@ dev = [
     # mirrors Codecov's ``patch`` status so patch-coverage drops
     # are caught **before** push, not after CI fails.
     "diff-cover>=9.0",
+    # Non-blocking quality gates (ADR 0035): radon measures per-function
+    # cyclomatic complexity + maintainability index; xenon wraps radon
+    # with hard-threshold rank gates (``A``..``F``) suitable for CI.
+    # Filling the gap left by ruff's intentionally-suppressed ``C901``,
+    # ``PLR0911``, ``PLR0912``, ``PLR0913`` — those rules ignore "type-
+    # dispatch is naturally branchy" cases per-call; xenon enforces
+    # an absolute-rank ceiling instead, which doesn't need per-function
+    # noqa annotations.
+    "radon>=6.0",
+    "xenon>=0.9",
 ]
 
 [project.urls]
@@ -581,7 +591,12 @@ skips = [
 # ---------------------------------------------------------------------------
 
 [tool.vulture]
-paths = ["src/bqemulator"]
+# The whitelist file lists names that vulture would otherwise flag as
+# dead but that are intentionally retained — each entry there has an
+# inline rationale comment. New whitelist entries land via PR review
+# only; that's the contract that lets us trust ``make quality-dead-code``
+# as a real signal once it's promoted to a required gate.
+paths = ["src/bqemulator", ".vulture_whitelist.py"]
 min_confidence = 80
 ignore_decorators = ["@app.*", "@router.*", "@pytest.fixture"]
 ignore_names = ["*Command", "*Request", "*Response"]


### PR DESCRIPTION
## Summary

Add three non-blocking quality gates the existing stack doesn't cover:

- **`make quality-complexity`** — `xenon` per-function complexity ceiling (fills the gap left by ruff's intentionally-ignored `C901` / `PLR0911` / `PLR0912` / `PLR0913`).
- **`make quality-duplication`** — `jscpd` cross-file DRY. Nothing in the current stack catches this.
- **`make quality-dead-code`** — `vulture`, which has been a dev-dep + `[tool.vulture]` config in `pyproject.toml` since pre-1.0 but was never wired into any target.

Wired via `.github/workflows/code-quality.yml` (per-PR + push-to-main + nightly + manual). Every step uses `continue-on-error: true` — **gates are non-blocking by design** for this PR. `make verify` is unchanged. Promote-to-required is a separate follow-up PR once thresholds + baselines settle against `main`.

ADR 0035 documents the design, baselines, and follow-up.

## Step 1 audit — what ruff covers today

| Concern | Rule | State |
|---|---|---|
| Too-complex function | `C901` (mccabe) | ❌ in `pyproject.toml` `ignore` list — "suppressed per-function with noqa where justified" |
| Too many return statements | `PLR0911` | ❌ ignored — "type-dispatch functions are naturally branchy" |
| Too many branches | `PLR0912` | ❌ ignored — "type-dispatch and route config pass-through" |
| Too many arguments | `PLR0913` | ❌ ignored — "pydantic / FastAPI signatures often exceed" |
| Too many statements | `PLR0915` | ✅ enforced (default 50-stmt ceiling) |
| `[tool.ruff.lint.mccabe]` `max-complexity` | — | not set (default 10, but `C901` is ignored anyway) |
| `vulture` dead-code | — | ⚠️ configured in `[tool.vulture]` + dev-dep, but **never invoked anywhere** |
| `radon` / `xenon` | — | ❌ not present |
| `jscpd` / pylint `duplicate-code` | — | ❌ not present |

So today: only `PLR0915` actively enforces any per-function structural budget; `vulture` pays the install cost but reports nothing; DRY is uncovered.

## Baselines (v1.0.2 codebase)

| Tool | Metric | Value |
|---|---|---|
| `radon cc` | Total blocks analyzed | 1,531 |
| `radon cc` | Project-wide avg complexity | A (3.44) |
| `radon cc` | Blocks ≥ rank C | 65 (4.2%) |
| `radon cc` | Blocks ≥ rank D | 10 (0.7%) |
| `radon cc` | Blocks ≥ rank E | 3 (0.2%) — worst is `arrow_bridge._format_bq_value` at 39 |
| `radon cc` | Worst module avg | C (4 modules at rank C) |
| `jscpd` | Total clones | 7 (19 pair-fragments in `consoleFull`) |
| `jscpd` | Duplicated lines | 112 |
| `jscpd` | Duplication ratio | 0.36% |
| `vulture` | Findings at `min_confidence=80` | 1 (false positive: `use_cache` reserved kwarg — whitelisted) |

## Thresholds picked

| Gate | Threshold | Rationale |
|---|---|---|
| `xenon --max-absolute` | E | No F-rank function (≥41) allowed. Current worst is 39 (E). |
| `xenon --max-modules` | C | No module averaging worse than C. Current worst is C. |
| `xenon --max-average` | A | Project-wide avg must stay A. Current 3.44, comfortable headroom. |
| `jscpd --threshold` | 1.0% | Current 0.36%. Threshold catches regression without forcing premature abstraction on the 7 template-shaped clones. |
| `vulture --min-confidence` | 80 (existing config preserved) | Plus new `.vulture_whitelist.py` with 1 entry. |

## Changes

| File | Change |
|---|---|
| `docs/adr/0035-code-quality-gates.md` | **NEW** — full design (baselines, alternatives considered including SonarCloud, follow-up promote-to-required checklist). |
| `.github/workflows/code-quality.yml` | **NEW** — non-blocking workflow; per-PR + push-to-main + nightly + manual. Aggregated outcomes via `$GITHUB_STEP_SUMMARY`. |
| `.jscpd.json` | **NEW** — config + thresholds + ignore globs. |
| `.vulture_whitelist.py` | **NEW** — single entry for the `use_cache` reserved kwarg false positive. |
| `Makefile` | **+45 lines** — new `quality`, `quality-complexity`, `quality-duplication`, `quality-dead-code` targets. `lint` / `verify` / `test-*` untouched. |
| `pyproject.toml` | `radon>=6.0` + `xenon>=0.9` added to `dev`; `[tool.vulture]` `paths` extended to include the new whitelist file (config otherwise preserved). |
| `mkdocs.yml` | ADR 0035 added to nav. |
| `CHANGELOG.md` | `[Unreleased] / Added` entry. |

## Verification

| Gate | Result |
|---|---|
| `make coverage-matrix-check compat-matrix-check function-mapping-check api-coverage-check` | ✅ all four green |
| `make lint` | ✅ |
| `make test-unit` | ✅ 2,501 passed |
| `make test-coverage` | ✅ 91.11% (≥90%) |
| `make test-patch-coverage` | ✅ no Python diff to cover (changes are tooling + YAML + markdown + Makefile + pyproject) |
| `make quality` (the new chain) | ✅ all three pass against baseline |
| `lychee --config .lychee.toml` | ✅ 0 errors |
| `make docs-build` (`mkdocs build --strict`) | ✅ |

## Follow-up — promote-to-required PR checklist

Once this lands and `main` has had a cycle to confirm the baselines hold:

- [ ] Re-baseline against current `main` (the numbers may shift as commits accumulate).
- [ ] Tighten thresholds based on observed noise floor:
  - [ ] If no D-rank functions merged: drop `--max-absolute` E → D.
  - [ ] If the duplication ratio drifted down: drop `--threshold` 1.0 → 0.5.
- [ ] Add `make quality-complexity`, `make quality-duplication`, `make quality-dead-code` to `make verify` (the umbrella `make quality` target is already there).
- [ ] Add the three job names to the branch-protection ruleset's required-checks list (`gh api repos/jjviscomi/bqemulator/rulesets/...`).
- [ ] Drop `continue-on-error: true` from `.github/workflows/code-quality.yml`.
- [ ] Re-confirm `make verify` end-to-end on the head of `main` post-promote.
- [ ] CHANGELOG `[Unreleased] / Changed` entry documenting the promotion.

## Out of scope (deliberate)

- SonarQube / SonarCloud — explicitly declined earlier in the design discussion; ADR 0035 documents the rejection rationale.
- Refactoring any existing code the new tools flag — baseline-ignore first, refactor in separate PRs.
- Touching mutation / property / fuzz / chaos / differential tiers — those are orthogonal quality concerns and out of scope here.
- README ADR-count bump (currently shows 34) — per the v1.0.2 release pattern, README ADR counts are bumped at release time, not at ADR-merge time. The next release will sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added non-blocking CI quality gates (complexity, duplication, dead‑code) for PRs, pushes to main, nightly and manual runs; results are reported per run but won’t block merges.

* **Documentation**
  * Recorded the decision in ADRs and updated the changelog.

* **Chores**
  * Added CI workflow, make targets, tooling configs, a dead‑code whitelist, and updated dev dependencies for quality tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->