### PR TITLE
chore(ci): bump lychee retry budget to absorb GitHub blob 502s

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -22,10 +22,18 @@ timeout = 20
 # Don't follow more than 5 redirects (catches infinite-loop CDNs).
 max_redirects = 5
 
-# Retry failed URLs once before reporting them broken — a single
-# transient network blip shouldn't fail a PR.
-max_retries = 2
-retry_wait_time = 3
+# Retry failed URLs on transient errors. Calibrated against the
+# v1.0.2 release CI cycle (PR #43, 2026-05-23) where lychee hit
+# repeated ``502 Bad Gateway`` from ``github.com/.../blob/main/...``
+# source-tree pages — GitHub.com itself briefly choking on existing
+# files. Two retries with a 3-second wait covered ~6 seconds total;
+# the 502 window outlasted that. Four retries × 10s give a ~40-second
+# total budget per failing URL, which absorbs the typical 30-60s
+# blob-render transient without masking real outages (the alternative
+# of adding ``502`` to the ``accept`` list was rejected — a renamed
+# repo would 502 persistently and we want to know).
+max_retries = 4
+retry_wait_time = 10
 
 # Run requests in parallel (default is fast enough; capping at 16
 # avoids tripping rate limits on github.com).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ section and adds the release date.
 
 ## [Unreleased]
 
+### Changed
+
+- **lychee retry budget bumped** in `.lychee.toml` — `max_retries` 2→4,
+  `retry_wait_time` 3s→10s. Calibrated against the v1.0.2 release CI
+  cycle (PR #43, 2026-05-23) where lychee hit repeated `502 Bad Gateway`
+  from `github.com/.../blob/main/...` source-tree URLs and the
+  prior 2×3s retry budget couldn't outlast the transient window.
+  Four retries × 10s give a ~40-second total budget per failing URL,
+  which absorbs the typical 30-60s blob-render transient without
+  masking real outages (adding `502` to the `accept` list was
+  rejected — a renamed repo would 502 persistently and we want to
+  know).
+
 ## [1.0.2] — 2026-05-23
 
 ### Fixed


### PR DESCRIPTION
## Summary

PR #43's CI cycle (2026-05-23 release of v1.0.2) hit repeated `502 Bad Gateway` from lychee against `github.com/.../blob/main/tests/conformance/...` source-tree URLs. The targets exist in the repo — GitHub.com itself was briefly choking on rendering those blob pages. lychee retried twice with a 3-second wait (6 seconds total), the 502 window outlasted that budget, the Link check job failed and PR #43 needed a manual rerun.

This bumps `.lychee.toml` so the next transient blob 502 doesn't repeat the same failure mode.

## Change

```diff
-# Retry failed URLs once before reporting them broken — a single
-# transient network blip shouldn't fail a PR.
-max_retries = 2
-retry_wait_time = 3
+# Retry failed URLs on transient errors. Calibrated against the
+# v1.0.2 release CI cycle (PR #43, 2026-05-23) where lychee hit
+# repeated ``502 Bad Gateway`` from ``github.com/.../blob/main/...``
+# source-tree pages — GitHub.com itself briefly choking on existing
+# files. Two retries with a 3-second wait covered ~6 seconds total;
+# the 502 window outlasted that. Four retries × 10s give a ~40-second
+# total budget per failing URL, which absorbs the typical 30-60s
+# blob-render transient without masking real outages (the alternative
+# of adding ``502`` to the ``accept`` list was rejected — a renamed
+# repo would 502 persistently and we want to know).
+max_retries = 4
+retry_wait_time = 10
```

Plus a one-line `CHANGELOG.md` `[Unreleased]` / `Changed` entry documenting the rationale.

## Why not add 502 to the accept list

The cheaper alternative (`accept = [..., 502]`) was explicitly rejected during the design discussion. It would mask real outages — e.g. a repo getting renamed out from under us would 502 persistently and we'd want to know. The retry bump is the calibrated fix: enough budget to outlast a transient, but anything persisting beyond ~40 seconds still fails the gate.

## Verification

| Gate | Result |
|---|---|
| `lychee --no-progress --cache --max-cache-age 1d --config .lychee.toml '**/*.md'` | ✅ 0 errors / 2,257 OK / 36 excluded |
| `make coverage-matrix-check compat-matrix-check function-mapping-check api-coverage-check` | ✅ |
| `make lint` | ✅ |
| `make test-unit` | ✅ 2,501 passed |
| `make test-coverage` | ✅ |
| `make test-patch-coverage` | ✅ no Python diff |

## Out of scope

- Adding `502` to the `accept` list (rejected — masks real outages).
- Restructuring `.lychee.toml` or moving to a different link-checker. Just bump the two values.