### PR TITLE
chore(release): automate README badge cache-bust on bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,23 @@ section and adds the release date.
   audit table, per-function refactor results, and the bucket-A /
   bucket-B refactor patterns.
 
+- **`scripts/bump_version.py` now bumps the README's shields.io
+  PyPI / Python-versions badge cache-bust suffix in lockstep with
+  `__version__`.** The two badge URLs in `README.md` carry a
+  `?cacheSeconds=120&v=X.Y.Z` query param — the `v=` portion is
+  ignored by shields.io but is the cache key GitHub camo (the image
+  proxy) uses, so bumping it forces readers' browsers to refetch the
+  fresh PyPI version on release. Previously that bump was a manual
+  README edit on the release branch (see PR #41, where v1.0.1 → 1.0.1
+  cache-bust was hand-applied); now both `python scripts/bump_version.py
+  X.Y.Z` and the orchestrator `scripts/release.py --apply` rewrite the
+  badges idempotently. New `bump.update_readme_text` /
+  `bump.write_readme_badges` helpers plus `--readme` CLI flag for
+  test isolation; `scripts/release.py --dry-run` previews the badge
+  diff alongside the `__init__.py` bump. Idempotent (silent no-op
+  when README is missing or already at the target version). Closes
+  follow-up "automate README badges + OpenSSF Scorecard" — PR A.
+
 ### Fixed
 
 - **`_coerce_arrow_binary` (REST `tabledata.insertAll` BYTES path):

--- a/docs/architecture/contributing/release-process.md
+++ b/docs/architecture/contributing/release-process.md
@@ -17,7 +17,7 @@ Three Python scripts back the release flow:
 
 | Script | Responsibility |
 |---|---|
-| [`scripts/bump_version.py`](https://github.com/jjviscomi/bqemulator/blob/main/scripts/bump_version.py) | Update `__version__` in `src/bqemulator/__init__.py`. Validates the new version is strictly greater than the current. |
+| [`scripts/bump_version.py`](https://github.com/jjviscomi/bqemulator/blob/main/scripts/bump_version.py) | Update `__version__` in `src/bqemulator/__init__.py` **and** the `?cacheSeconds=N&v=X.Y.Z` cache-bust suffix on the README's shields.io PyPI / Python-versions badges (`README.md`). The README rewrite is idempotent and silent when the pattern is absent. Validates the new version is strictly greater than the current. |
 | [`scripts/changelog.py`](https://github.com/jjviscomi/bqemulator/blob/main/scripts/changelog.py) | Move the `## [Unreleased]` body into a new `## [X.Y.Z] — YYYY-MM-DD` section. Refuses to finalise an empty `Unreleased` section by default. |
 | [`scripts/release.py`](https://github.com/jjviscomi/bqemulator/blob/main/scripts/release.py) | Orchestrator. Runs `make verify`, calls the two scripts above, and creates the release commit + tag. Default mode is `--dry-run`; pass `--apply` to mutate state. |
 
@@ -74,10 +74,11 @@ a dedicated exit code):
    `Security`).
 
 2. **Pre-release doc sweep.** The release orchestrator only mutates
-   `src/bqemulator/__version__` (via `bump_version.py`) and
-   `CHANGELOG.md` (via `changelog.py`). Every other version- or
-   maturity-bearing string is **manual** and must be checked once per
-   release. The audit:
+   three surfaces: `src/bqemulator/__version__` and the README
+   shields.io badge cache-bust query parameter (both via
+   `bump_version.py`), plus `CHANGELOG.md` (via `changelog.py`).
+   Every other version- or maturity-bearing string is **manual** and
+   must be checked once per release. The audit:
 
    | File | What to update at a MAJOR / first-stable cut |
    |---|---|

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -5,8 +5,14 @@ P4.c (2026-05-21) — first leg of the release-tooling triad (P5
 prerequisite). The version lives in a single source of truth at
 [`src/bqemulator/__init__.py`](../src/bqemulator/__init__.py) — hatchling
 re-uses it through `[tool.hatch.version] path = ...` in
-[`pyproject.toml`](../pyproject.toml), so this script touches one file
-only.
+[`pyproject.toml`](../pyproject.toml), so the canonical bump touches one
+file. A secondary in-place rewrite on
+[`README.md`](../README.md) keeps the shields.io PyPI / Python-versions
+badges' ``?cacheSeconds=120&v=X.Y.Z`` cache-bust query parameter in
+sync — that suffix changes GitHub camo's cache key so README readers
+see the new wheel without waiting ~24 h for the proxy to expire. The
+README rewrite is idempotent (no-op when the badges are already at the
+new version) and silent when the pattern is absent.
 
 Usage::
 
@@ -40,6 +46,15 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 #: this file. Hard-coding the path keeps the script self-contained.
 VERSION_FILE = _REPO_ROOT / "src" / "bqemulator" / "__init__.py"
 
+#: README that hosts the shields.io PyPI + Python-versions badges
+#: bumped in lockstep with ``__version__``. The badge URL pattern
+#: matched by :data:`_README_BADGE_RE` carries a
+#: ``?cacheSeconds=120&v=X.Y.Z`` suffix; ``v=`` is a cache-bust query
+#: parameter the shields.io endpoint ignores but GitHub camo (the
+#: image proxy) keys its cache on, so changing it forces readers'
+#: browsers to fetch the fresh PyPI version immediately on release.
+README_FILE = _REPO_ROOT / "README.md"
+
 #: Match ``__version__ = "X.Y.Z"`` exactly (single or double quotes).
 #: The trailing group captures the canonical ``MAJOR.MINOR.PATCH`` form;
 #: prerelease + build-metadata suffixes are intentionally rejected.
@@ -51,6 +66,13 @@ _VERSION_LINE_RE = re.compile(
 #: Strict ``X.Y.Z`` regex used by :func:`parse_version`. Rejects pre-
 #: releases and build metadata so the tag namespace stays flat.
 _VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+#: Match the cache-bust suffix on README badge URLs. Group 1 captures
+#: the constant ``?cacheSeconds=<n>&v=`` prefix; the trailing triple is
+#: the version we replace. ``\d+`` on cacheSeconds avoids hard-coding
+#: the current ``120`` value — a future tuning of the camo TTL won't
+#: silently de-match the regex.
+_README_BADGE_RE = re.compile(r"(\?cacheSeconds=\d+&v=)\d+\.\d+\.\d+")
 
 #: Bump kinds accepted on the CLI as ``--next <kind>``. Order matters
 #: for argparse's ``choices`` display.
@@ -150,6 +172,45 @@ def write_new(new: Version, file: Path = VERSION_FILE) -> Version:
     return old
 
 
+def update_readme_text(text: str, new: Version) -> tuple[str, int]:
+    """Rewrite every cache-bust badge URL in ``text`` to point at ``new``.
+
+    Pure (no I/O): returns the rewritten body and the number of badges
+    rewritten. ``count == 0`` means the README had no matching
+    ``?cacheSeconds=...&v=X.Y.Z`` suffix; ``count == n`` for the same
+    version is still idempotent (the substituted bytes equal the
+    originals). Callers use the count purely for operator-facing
+    reporting — a missing badge pattern is not an error.
+    """
+    return _README_BADGE_RE.subn(rf"\g<1>{new}", text)
+
+
+def write_readme_badges(new: Version, file: Path = README_FILE) -> int:
+    """Update the README cache-bust badges to ``new``. Return # replaced.
+
+    The contract is intentionally tolerant: a missing README returns
+    ``0`` (it's a hand-edited file, not a build artefact, so silent
+    no-op is friendlier than ``FileNotFoundError``). Same for a README
+    that contains no cache-bust badges — returns ``0`` and writes
+    nothing. The only failure mode is permission / I/O against an
+    existing file, which propagates as ``OSError`` to the caller.
+
+    Idempotent: re-running with the same ``new`` against a README
+    already at that version performs the substitution (which is a
+    no-op byte-for-byte) and skips the write. The skip matters for
+    file-modification-time sensitive build systems and for the
+    operator's mental model of "this script bumped nothing".
+    """
+    if not file.exists():
+        return 0
+    text = file.read_text(encoding="utf-8")
+    updated, count = update_readme_text(text, new)
+    if count == 0 or updated == text:
+        return count
+    file.write_text(updated, encoding="utf-8")
+    return count
+
+
 def resolve_target(
     current: Version,
     *,
@@ -240,6 +301,17 @@ def main(argv: list[str] | None = None) -> int:
         default=VERSION_FILE,
         help=f"Version file path (default: {VERSION_FILE.relative_to(_REPO_ROOT)}).",
     )
+    parser.add_argument(
+        "--readme",
+        type=Path,
+        default=README_FILE,
+        help=(
+            "README path whose ``?cacheSeconds=N&v=X.Y.Z`` badge query "
+            f"params are bumped alongside ``__version__`` (default: "
+            f"{README_FILE.relative_to(_REPO_ROOT)}). Pass a non-existent "
+            "path to skip the README rewrite (useful for tests)."
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -274,6 +346,9 @@ def main(argv: list[str] | None = None) -> int:
 
     write_new(target, args.file)
     print(f"Bumped {current} -> {target} in {args.file}")
+    readme_count = write_readme_badges(target, args.readme)
+    if readme_count:
+        print(f"Updated {readme_count} README badge(s) in {args.readme}")
     return EXIT_OK
 
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -186,27 +186,32 @@ def update_readme_text(text: str, new: Version) -> tuple[str, int]:
 
 
 def write_readme_badges(new: Version, file: Path = README_FILE) -> int:
-    """Update the README cache-bust badges to ``new``. Return # replaced.
+    """Update the README cache-bust badges to ``new``. Return # **written**.
 
-    The contract is intentionally tolerant: a missing README returns
-    ``0`` (it's a hand-edited file, not a build artefact, so silent
-    no-op is friendlier than ``FileNotFoundError``). Same for a README
-    that contains no cache-bust badges — returns ``0`` and writes
-    nothing. The only failure mode is permission / I/O against an
-    existing file, which propagates as ``OSError`` to the caller.
+    The return value counts badges whose **bytes actually changed on disk**,
+    not regex matches. That distinction matters because ``main()`` and
+    the orchestrator emit "Updated N README badge(s)" / "bumped N README
+    badge(s)" only when the count is truthy — printing those messages
+    after a no-op write would mislead the operator into thinking the
+    file mutated.
 
-    Idempotent: re-running with the same ``new`` against a README
-    already at that version performs the substitution (which is a
-    no-op byte-for-byte) and skips the write. The skip matters for
-    file-modification-time sensitive build systems and for the
-    operator's mental model of "this script bumped nothing".
+    Three branches all return ``0`` (no write, no message):
+
+    * The README file does not exist (hand-edited, may be renamed).
+    * The README exists but contains no ``?cacheSeconds=N&v=X.Y.Z``
+      badges — regex matches nothing.
+    * The README is already at ``new`` — regex matches, but the
+      substituted bytes equal the originals (idempotent no-op).
+
+    The only failure mode is permission / I/O against an existing
+    file, which propagates as ``OSError`` to the caller.
     """
     if not file.exists():
         return 0
     text = file.read_text(encoding="utf-8")
     updated, count = update_readme_text(text, new)
     if count == 0 or updated == text:
-        return count
+        return 0
     file.write_text(updated, encoding="utf-8")
     return count
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -295,12 +295,27 @@ def _preview_changelog(plan: ReleasePlan, opts: ReleaseOptions) -> None:
     )
 
 
-def _preview_bump(plan: ReleasePlan) -> None:
-    """Render the proposed version bump."""
+def _preview_bump(plan: ReleasePlan, opts: ReleaseOptions) -> None:
+    """Render the proposed version bump and README badge cache-bust diff."""
     _emit(
         f"would bump __version__: {plan.current} -> {plan.target}",
         prefix="[dry-run]",
     )
+    readme_path = opts.repo_root / "README.md"
+    if readme_path.exists():
+        text = readme_path.read_text(encoding="utf-8")
+        _, count = bump.update_readme_text(text, plan.target)
+        if count:
+            _emit(
+                f"would bump {count} README badge(s) in {readme_path.name}: "
+                f"?v={plan.current} -> ?v={plan.target}",
+                prefix="[dry-run]",
+            )
+        else:
+            _emit(
+                f"README has no cache-bust badges to bump in {readme_path.name}",
+                prefix="[dry-run]",
+            )
 
 
 def _preview_commit_and_tag(plan: ReleasePlan) -> None:
@@ -310,7 +325,7 @@ def _preview_commit_and_tag(plan: ReleasePlan) -> None:
 
 
 def _apply_bump(plan: ReleasePlan, opts: ReleaseOptions) -> int:
-    """Write the new version to ``__init__.py``."""
+    """Write the new version to ``__init__.py`` + bump README badge cache-bust."""
     version_file = opts.repo_root / "src" / "bqemulator" / "__init__.py"
     try:
         bump.write_new(plan.target, version_file)
@@ -318,6 +333,10 @@ def _apply_bump(plan: ReleasePlan, opts: ReleaseOptions) -> int:
         print(f"error: bump failed: {exc}", file=sys.stderr)
         return EXIT_BUMP_FAILED
     _emit(f"bumped __version__: {plan.current} -> {plan.target}")
+    readme_path = opts.repo_root / "README.md"
+    readme_count = bump.write_readme_badges(plan.target, readme_path)
+    if readme_count:
+        _emit(f"bumped {readme_count} README badge(s) in {readme_path.name}")
     return EXIT_OK
 
 
@@ -453,7 +472,7 @@ def orchestrate(opts: ReleaseOptions) -> int:
 
     # Step 5+: bump + changelog. Dry-run previews; apply mutates.
     if opts.dry_run:
-        _preview_bump(plan)
+        _preview_bump(plan, opts)
         try:
             _preview_changelog(plan, opts)
         except RuntimeError as exc:

--- a/tests/unit/scripts/test_bump_version.py
+++ b/tests/unit/scripts/test_bump_version.py
@@ -361,7 +361,12 @@ class TestWriteReadmeBadges:
         readme = _seed_readme(tmp_path, version="1.0.2")
         mtime_before = readme.stat().st_mtime_ns
         count = bump.write_readme_badges(bump.Version(1, 0, 2), readme)
-        assert count == 2  # matches found
+        # Contract: return value counts WRITTEN badges, not regex matches.
+        # The README was already at 1.0.2 → regex matches both badges but
+        # the substituted bytes equal the originals → no write → 0. This
+        # is what suppresses the misleading "Updated N README badge(s)"
+        # message in main() on idempotent re-runs.
+        assert count == 0
         # No write happened — mtime unchanged.
         assert readme.stat().st_mtime_ns == mtime_before
 

--- a/tests/unit/scripts/test_bump_version.py
+++ b/tests/unit/scripts/test_bump_version.py
@@ -45,12 +45,30 @@ __all__ = ["__version__"]
 __version__ = "0.1.0"
 '''
 
+_DEFAULT_README = """# bqemulator
+
+[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg?cacheSeconds=120&v=0.1.0)](https://pypi.org/project/bqemulator/)
+[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg?cacheSeconds=120&v=0.1.0)](https://pypi.org/project/bqemulator/)
+"""
+
 
 def _seed_init(tmp_path: Path, *, version: str = "0.1.0") -> Path:
     """Write a minimal ``__init__.py`` containing the supplied version."""
     init = tmp_path / "__init__.py"
     init.write_text(_DEFAULT_INIT.replace("0.1.0", version), encoding="utf-8")
     return init
+
+
+def _seed_readme(tmp_path: Path, *, version: str = "0.1.0") -> Path:
+    """Write a minimal ``README.md`` whose badge cache-bust matches ``version``."""
+    readme = tmp_path / "README.md"
+    readme.write_text(_DEFAULT_README.replace("0.1.0", version), encoding="utf-8")
+    return readme
+
+
+def _absent_readme(tmp_path: Path) -> Path:
+    """Return a path to a non-existent README — used to skip the badge step."""
+    return tmp_path / "no-readme.md"
 
 
 # ---------------------------------------------------------------------------
@@ -212,7 +230,7 @@ class TestCli:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         init = _seed_init(tmp_path, version="1.2.3")
-        rc = bump.main(["--print", "--file", str(init)])
+        rc = bump.main(["--print", "--file", str(init), "--readme", str(_absent_readme(tmp_path))])
         assert rc == bump.EXIT_OK
         captured = capsys.readouterr()
         assert captured.out.strip() == "1.2.3"
@@ -221,13 +239,25 @@ class TestCli:
 
     def test_check_does_not_write(self, tmp_path: Path) -> None:
         init = _seed_init(tmp_path, version="0.1.0")
-        rc = bump.main(["--next", "minor", "--check", "--file", str(init)])
+        rc = bump.main(
+            [
+                "--next",
+                "minor",
+                "--check",
+                "--file",
+                str(init),
+                "--readme",
+                str(_absent_readme(tmp_path)),
+            ],
+        )
         assert rc == bump.EXIT_OK
         assert "0.1.0" in init.read_text(encoding="utf-8")
 
     def test_apply_writes_new_version(self, tmp_path: Path) -> None:
         init = _seed_init(tmp_path, version="0.1.0")
-        rc = bump.main(["1.0.0", "--file", str(init)])
+        rc = bump.main(
+            ["1.0.0", "--file", str(init), "--readme", str(_absent_readme(tmp_path))],
+        )
         assert rc == bump.EXIT_OK
         assert '"1.0.0"' in init.read_text(encoding="utf-8")
 
@@ -237,7 +267,9 @@ class TestCli:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         init = _seed_init(tmp_path, version="0.5.0")
-        rc = bump.main(["0.1.0", "--file", str(init)])
+        rc = bump.main(
+            ["0.1.0", "--file", str(init), "--readme", str(_absent_readme(tmp_path))],
+        )
         assert rc == bump.EXIT_NOT_GREATER
         captured = capsys.readouterr()
         assert "not strictly greater" in captured.err
@@ -248,12 +280,119 @@ class TestCli:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         init = _seed_init(tmp_path, version="0.1.0")
-        rc = bump.main(["1.2.3-rc1", "--file", str(init)])
+        rc = bump.main(
+            ["1.2.3-rc1", "--file", str(init), "--readme", str(_absent_readme(tmp_path))],
+        )
         assert rc == bump.EXIT_USAGE
         captured = capsys.readouterr()
         assert "canonical X.Y.Z" in captured.err
 
     def test_missing_args_returns_usage_error(self, tmp_path: Path) -> None:
         init = _seed_init(tmp_path, version="0.1.0")
-        rc = bump.main(["--file", str(init)])
+        rc = bump.main(["--file", str(init), "--readme", str(_absent_readme(tmp_path))])
         assert rc == bump.EXIT_USAGE
+
+
+# ---------------------------------------------------------------------------
+# README badge cache-bust
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateReadmeText:
+    """Pure-function contract of the badge regex substitution.
+
+    These tests pin behaviour callers depend on: the regex rewrites every
+    matched badge in one pass; an unmatched README is returned unchanged
+    with a ``0`` count; an already-bumped README is a textual no-op.
+    """
+
+    def test_both_badges_bumped_in_single_pass(self) -> None:
+        text = (
+            "[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg"
+            "?cacheSeconds=120&v=1.0.1)](pypi)\n"
+            "[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg"
+            "?cacheSeconds=120&v=1.0.1)](pypi)\n"
+        )
+        updated, count = bump.update_readme_text(text, bump.Version(1, 0, 2))
+        assert count == 2
+        assert "v=1.0.1" not in updated
+        assert updated.count("v=1.0.2") == 2
+
+    def test_missing_pattern_is_no_op(self) -> None:
+        text = "# bqemulator\n\nNo badges here.\n"
+        updated, count = bump.update_readme_text(text, bump.Version(1, 0, 2))
+        assert count == 0
+        assert updated == text
+
+    def test_idempotent_substitution_byte_for_byte(self) -> None:
+        text = (
+            "[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg"
+            "?cacheSeconds=120&v=1.0.2)](pypi)\n"
+        )
+        updated, count = bump.update_readme_text(text, bump.Version(1, 0, 2))
+        # Substitution still runs (count == 1), but result equals input.
+        assert count == 1
+        assert updated == text
+
+    def test_alternate_cache_seconds_value_still_matches(self) -> None:
+        # The regex is on ``cacheSeconds=\d+`` not the literal ``120`` —
+        # a future tuning of the camo TTL must not silently de-match.
+        text = "?cacheSeconds=900&v=0.9.5"
+        updated, count = bump.update_readme_text(text, bump.Version(1, 0, 0))
+        assert count == 1
+        assert updated == "?cacheSeconds=900&v=1.0.0"
+
+
+class TestWriteReadmeBadges:
+    """File-IO wrapper handles the messy real-world inputs cleanly."""
+
+    def test_writes_when_badges_change(self, tmp_path: Path) -> None:
+        readme = _seed_readme(tmp_path, version="1.0.1")
+        count = bump.write_readme_badges(bump.Version(1, 0, 2), readme)
+        assert count == 2
+        body = readme.read_text(encoding="utf-8")
+        assert body.count("v=1.0.2") == 2
+        assert "v=1.0.1" not in body
+
+    def test_idempotent_skips_write_when_already_at_target(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        readme = _seed_readme(tmp_path, version="1.0.2")
+        mtime_before = readme.stat().st_mtime_ns
+        count = bump.write_readme_badges(bump.Version(1, 0, 2), readme)
+        assert count == 2  # matches found
+        # No write happened — mtime unchanged.
+        assert readme.stat().st_mtime_ns == mtime_before
+
+    def test_missing_pattern_is_silent_no_op(self, tmp_path: Path) -> None:
+        readme = tmp_path / "README.md"
+        readme.write_text("# Nothing to see here\n", encoding="utf-8")
+        mtime_before = readme.stat().st_mtime_ns
+        count = bump.write_readme_badges(bump.Version(1, 0, 2), readme)
+        assert count == 0
+        assert readme.stat().st_mtime_ns == mtime_before
+
+    def test_absent_file_returns_zero_no_raise(self, tmp_path: Path) -> None:
+        # Tolerant of a renamed/missing README — the version bump must
+        # not fail just because the badges moved out of the README.
+        count = bump.write_readme_badges(bump.Version(1, 0, 2), tmp_path / "absent.md")
+        assert count == 0
+
+    def test_cli_apply_bumps_init_and_readme_together(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # End-to-end through ``main`` — the contract released
+        # ``release.py`` callers depend on: one CLI call, both files
+        # updated.
+        init = _seed_init(tmp_path, version="1.0.1")
+        readme = _seed_readme(tmp_path, version="1.0.1")
+        rc = bump.main(["1.0.2", "--file", str(init), "--readme", str(readme)])
+        assert rc == bump.EXIT_OK
+        assert '"1.0.2"' in init.read_text(encoding="utf-8")
+        assert "v=1.0.2" in readme.read_text(encoding="utf-8")
+        captured = capsys.readouterr()
+        assert "Bumped 1.0.1 -> 1.0.2" in captured.out
+        assert "Updated 2 README badge(s)" in captured.out

--- a/tests/unit/scripts/test_release.py
+++ b/tests/unit/scripts/test_release.py
@@ -73,17 +73,28 @@ _CHANGELOG_TEMPLATE = """\
 - initial release.
 """
 
+_README_TEMPLATE = """# bqemulator
 
-def _seed_repo_files(repo: Path, *, version: str = "0.1.0") -> None:
-    """Drop a minimal source + changelog into ``repo``."""
+[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg?cacheSeconds=120&v=0.1.0)](https://pypi.org/project/bqemulator/)
+[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg?cacheSeconds=120&v=0.1.0)](https://pypi.org/project/bqemulator/)
+"""
+
+
+def _seed_repo_files(repo: Path, *, version: str = "0.1.0", with_readme: bool = False) -> None:
+    """Drop a minimal source + changelog (+ optionally README) into ``repo``."""
     (repo / "src" / "bqemulator").mkdir(parents=True, exist_ok=True)
     init = repo / "src" / "bqemulator" / "__init__.py"
     init.write_text(_INIT_TEMPLATE.replace("0.1.0", version), encoding="utf-8")
     changelog = repo / "CHANGELOG.md"
     changelog.write_text(_CHANGELOG_TEMPLATE, encoding="utf-8")
+    if with_readme:
+        (repo / "README.md").write_text(
+            _README_TEMPLATE.replace("0.1.0", version),
+            encoding="utf-8",
+        )
 
 
-def _init_repo(tmp_path: Path, *, version: str = "0.1.0") -> Path:
+def _init_repo(tmp_path: Path, *, version: str = "0.1.0", with_readme: bool = False) -> Path:
     """Create a git repo at ``tmp_path/repo`` with a clean initial commit.
 
     Returns the repo root. Uses ``-c`` config flags rather than mutating
@@ -92,7 +103,7 @@ def _init_repo(tmp_path: Path, *, version: str = "0.1.0") -> Path:
     """
     repo = tmp_path / "repo"
     repo.mkdir()
-    _seed_repo_files(repo, version=version)
+    _seed_repo_files(repo, version=version, with_readme=with_readme)
     env_cfg = [
         "-c",
         "user.email=test@example.com",
@@ -392,6 +403,107 @@ class TestApply:
         )
         rc = rel.orchestrate(_opts(repo, dry_run=False, allow_empty_changelog=True))
         assert rc == rel.EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# README badge cache-bust integration
+# ---------------------------------------------------------------------------
+
+
+class TestReadmeBadgeBump:
+    """The orchestrator bumps README cache-bust badges in lockstep with the
+    version. Both dry-run preview and apply mutation are exercised, plus the
+    no-README path that the existing tests above (with_readme=False) silently
+    cover.
+    """
+
+    def test_dry_run_previews_badge_bump(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _git_test_env(monkeypatch)
+        repo = _init_repo(tmp_path, with_readme=True)
+        readme = repo / "README.md"
+        before = readme.read_text(encoding="utf-8")
+        rc = rel.orchestrate(_opts(repo))
+        assert rc == rel.EXIT_OK
+        captured = capsys.readouterr()
+        assert "would bump 2 README badge(s)" in captured.out
+        # Dry-run is read-only — README must be unchanged.
+        assert readme.read_text(encoding="utf-8") == before
+
+    def test_dry_run_no_readme_emits_no_badge_line(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _git_test_env(monkeypatch)
+        repo = _init_repo(tmp_path, with_readme=False)
+        rc = rel.orchestrate(_opts(repo))
+        assert rc == rel.EXIT_OK
+        captured = capsys.readouterr()
+        # The orchestrator skips silently when README is absent — no
+        # "would bump N README" or "no cache-bust badges" message at all.
+        assert "README" not in captured.out
+
+    def test_dry_run_readme_without_badges_emits_no_badge_message(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _git_test_env(monkeypatch)
+        repo = _init_repo(tmp_path, with_readme=False)
+        (repo / "README.md").write_text("# Plain README\n", encoding="utf-8")
+        subprocess.run([_GIT, "add", "-A"], cwd=repo, check=True)  # noqa: S603
+        subprocess.run(  # noqa: S603
+            [_GIT, "commit", "-q", "-m", "add bare README"],
+            cwd=repo,
+            check=True,
+        )
+        rc = rel.orchestrate(_opts(repo))
+        assert rc == rel.EXIT_OK
+        captured = capsys.readouterr()
+        assert "no cache-bust badges to bump" in captured.out
+
+    def test_apply_mutates_readme_badge(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _git_test_env(monkeypatch)
+        repo = _init_repo(tmp_path, with_readme=True)
+        rc = rel.orchestrate(_opts(repo, dry_run=False))
+        assert rc == rel.EXIT_OK
+        body = (repo / "README.md").read_text(encoding="utf-8")
+        assert "v=0.1.0" not in body
+        assert body.count("v=0.2.0") == 2
+
+    def test_apply_readme_change_is_in_release_commit(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _git_test_env(monkeypatch)
+        repo = _init_repo(tmp_path, with_readme=True)
+        rc = rel.orchestrate(_opts(repo, dry_run=False))
+        assert rc == rel.EXIT_OK
+        # ``git show --stat HEAD`` must list README.md alongside __init__.py
+        # — proves the release commit captures both bumps atomically.
+        files_in_commit = subprocess.run(  # noqa: S603
+            [_GIT, "show", "--name-only", "--format=", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        names = set(files_in_commit.stdout.split())
+        assert "README.md" in names
+        assert "src/bqemulator/__init__.py" in names
+        assert "CHANGELOG.md" in names
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- ``scripts/bump_version.py`` now rewrites the ``?cacheSeconds=120&v=X.Y.Z`` cache-bust suffix on the two shields.io PyPI / Python-versions badges in ``README.md`` whenever ``__version__`` is bumped. The ``v=`` portion is the cache key GitHub camo uses (shields.io itself ignores it), so bumping it on release forces readers' browsers to refetch the fresh PyPI version without waiting on the ~24 h camo TTL.
- ``scripts/release.py`` previews the badge diff in ``--dry-run`` and rewrites the badges in ``--apply`` so the release commit captures ``__init__.py`` + ``README.md`` + ``CHANGELOG.md`` atomically.
- Until now the bump was a manual line edit on the release branch (introduced for v1.0.1 in #41 and the same dance again for v1.0.2). Move it into the orchestrator.

## Why

The release tooling's job is to leave **no manual version-bearing string** on the operator. ``bump_version.py`` already owned ``__version__``; ``changelog.py`` owned ``CHANGELOG.md``. The README badges were the one remaining "easy to forget" surface — and the v1.0.2 release flow showed exactly that: an out-of-band README commit just to nudge the badges.

## What lands

- New ``bump.update_readme_text(text, new) -> (text, count)`` pure helper for the regex substitution.
- New ``bump.write_readme_badges(new, file)`` I/O wrapper — idempotent (no-op when README is already at the target version) and silent (returns 0 when the file or pattern is absent). The orchestrator never fails just because README was renamed.
- New ``--readme PATH`` CLI flag on ``bump_version.py`` for test isolation. Existing tests pass a non-existent tmp_path so they don't pollute the real README.
- ``release.py`` extends ``_preview_bump`` + ``_apply_bump`` to handle the README path; both modes show / mutate it alongside ``__init__.py``.
- ``docs/architecture/contributing/release-process.md`` — the Release-tooling table row for ``bump_version.py`` now documents the lockstep behaviour, and the doc-sweep narrative lists README badge cache-bust as auto-bumped (not manual).
- ``CHANGELOG.md`` — new ``[Unreleased]`` Changed entry.

## Tests

- 8 new unit tests in ``tests/unit/scripts/test_bump_version.py`` covering: both-badges in one pass, missing pattern no-op, idempotent byte-for-byte substitution, alternate ``cacheSeconds=`` value (forward-compatible if we tune the camo TTL), absent-file tolerance, idempotent skip-write (mtime unchanged), and end-to-end CLI bump of both files together.
- 5 new orchestrator tests in ``tests/unit/scripts/test_release.py`` covering: dry-run preview line, no-README silent skip, no-badges-in-README friendly message, apply-mode README mutation, and ``git show --name-only HEAD`` proving README is in the release commit.
- ``73 passed`` across both files (43 in ``test_bump_version.py`` + 30 in ``test_release.py``).

## Verification

- ``make lint test-unit test-coverage test-patch-coverage`` — all green.
- ``make verify`` — all release-readiness gates passed (lint, complexity, unit, property, integration, drift checks, docker-build, e2e × 5, docs-build).
- ``lychee`` — 34 OK, 0 errors on modified markdown.

## Acceptance criteria

- [x] ``scripts/bump_version.py`` handles ``README.md``'s ``?cacheSeconds=120&v=`` badges.
- [x] New unit tests exercise bump path, idempotent re-run, missing-pattern no-op.
- [x] ``scripts/release.py --dry-run`` previews the README diff.
- [x] ``make release-dry-run NEXT=patch`` shows the README change in preview (covered by ``test_dry_run_previews_badge_bump``).
- [x] ``docs/architecture/contributing/release-process.md`` documents the lockstep behaviour.
- [x] ``CHANGELOG.md`` ``[Unreleased]`` Changed entry.

## Out of scope

- The OpenSSF Scorecard badge (api.securityscorecards.dev) doesn't take a ``?cacheSeconds=`` query param, so its cache-bust will be a separate ``?v=X.Y.Z`` suffix handled by the follow-up Scorecard PR (which extends this regex or adds a sibling one).

## Test plan

- [x] Bump path: ``test_writes_when_badges_change`` — 1.0.1 → 1.0.2 bumps both badges.
- [x] Idempotent re-run: ``test_idempotent_skips_write_when_already_at_target`` — mtime unchanged.
- [x] Missing pattern no-op: ``test_missing_pattern_is_silent_no_op``.
- [x] Absent file no-error: ``test_absent_file_returns_zero_no_raise``.
- [x] CLI atomic bump: ``test_cli_apply_bumps_init_and_readme_together``.
- [x] Orchestrator dry-run preview: ``test_dry_run_previews_badge_bump``.
- [x] Orchestrator apply: ``test_apply_mutates_readme_badge`` + ``test_apply_readme_change_is_in_release_commit``.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation to clarify version synchronization across multiple surfaces.

* **Chores**
  * Enhanced release tooling to automatically synchronize README cache-bust badges with version updates.
  * Improved dry-run preview to display README badge updates.
  * Added configuration flag for release script flexibility.
  * Expanded test coverage for release workflow and badge management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->