### PR TITLE
feat(sql): implement SESSION_USER() + canonical RAP e2e coverage (ADR 0038)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,71 @@ section and adds the release date.
 
 ### Added
 
+- **`SESSION_USER()` SQL function + canonical RAP-via-SESSION_USER
+  e2e coverage** (ADR 0038). The function was documented in the
+  surface inventory but had zero implementation and zero tests —
+  the rendered conformance-coverage matrix's "Exercised at the unit
+  tier" claim was aspirational. This PR makes it true.
+
+  Implementation: a new ``rewrite_session_user`` pre-translator
+  walks the SQLGlot AST and replaces every ``SessionUser`` node with
+  a string literal of the resolved caller email, before SQLGlot's
+  BigQuery → DuckDB transpile. Caller identity is threaded through
+  ``SQLTranslator.translate`` via a new optional ``caller`` kwarg;
+  five call sites updated to pass the ``CallerIdentity`` they
+  already construct (``jobs/executor.py``, three sites in
+  ``scripting/interpreter.py``, one in
+  ``grpc_api/read_servicer.py``). DuckDB's native ``SESSION_USER``
+  resolves to the literal ``'duckdb'`` — pre-translator
+  substitution is what prevents a confusing
+  ``SELECT SESSION_USER()`` → ``'duckdb'`` regression.
+
+  Resolution contract (per ADR 0038):
+  - ``user:<email>`` / ``serviceAccount:<email>`` / ``group:<email>``
+    / ``domain:<host>`` → strip prefix, return bare email/host.
+  - ``allUsers`` / ``allAuthenticatedUsers`` / unknown shape →
+    raw principal string passthrough (defensive only — these are
+    grantee-side identifiers, never caller identifiers).
+  - Unauthenticated fallback (``is_authenticated=False``) → the
+    literal ``"anonymous"`` sentinel, so RAP filters comparing
+    ``SESSION_USER()`` against a tenant key safely deny every row.
+
+  Coverage:
+  - **21 unit tests** in ``tests/unit/sql/rewriter/test_session_user.py``
+    pin the resolver contract per IAM-member shape + the rewriter's
+    AST walk (multiple call sites, idempotent re-runs, fast-path
+    no-op, lower-case spelling, string-literal-not-rewritten,
+    unparseable-SQL passthrough, view-body substitution).
+  - **5 new integration tests** in
+    ``tests/integration/test_row_access_policies.py`` exercise the
+    canonical
+    ``REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id`` RAP
+    filter through the in-process emulator with two callers + the
+    unauthenticated fallback + a service-account caller.
+  - **4 new e2e test files** (Python, Node.js, Go, Java) cover the
+    same RAP filter pattern through the official client libraries
+    against a live container. ``bq`` CLI is skipped per the
+    existing module docstring (the CLI doesn't set
+    ``X-Bqemu-Caller``); the skip rationale was extended to point
+    at the new e2e files.
+
+  Out of scope (documented in ADR 0038):
+  - ``CURRENT_USER`` and ``@@session.user`` (deprecated /
+    system-variable spellings of the same function).
+  - ``SESSION_USER()`` inside a SQL UDF body — UDFs are
+    pre-translated at definition time when no caller exists; the
+    function inside a UDF body folds to ``"anonymous"`` permanently.
+  - The Storage Read filter pre-pass at
+    ``grpc_api/read_servicer.py:122`` (``_build_filter_sql`` for the
+    ``row_restriction`` field) doesn't yet receive caller context —
+    folds to ``"anonymous"`` regardless of the actual caller.
+    The canonical SESSION_USER use is RAP filters, not Storage Read
+    row_restriction; documented as a known limitation.
+
+  See [ADR 0038](docs/adr/0038-session-user.md) for the full
+  decision record, the three implementation options considered, and
+  the unauthenticated-fallback rationale.
+
 - **OpenSSF Scorecard workflow + public badge.** New
   `.github/workflows/scorecard.yml` runs the official
   `ossf/scorecard-action` against `main` on every push, every

--- a/docs/adr/0038-session-user.md
+++ b/docs/adr/0038-session-user.md
@@ -4,7 +4,7 @@
 
 ## Context
 
-BigQuery's [`SESSION_USER()`](https://cloud.google.com/bigquery/docs/reference/standard-sql/security-functions)
+BigQuery's [`SESSION_USER()`](https://cloud.google.com/bigquery/docs/reference/standard-sql/security_functions)
 returns the email address of the user running the query —
 ``alice@example.com`` for a user principal,
 ``sa@project.iam.gserviceaccount.com`` for a service account. The
@@ -276,7 +276,7 @@ the surface-inventory entry promised.
 
 ## References
 
-* [BigQuery `SESSION_USER()` reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/security-functions#session_user)
+* [BigQuery `SESSION_USER()` reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/security_functions#session_user)
 * [ADR 0018](0018-caller-identity-and-row-access-enforcement.md) — the
   ``CallerIdentity`` dataclass + ``X-Bqemu-Caller`` header contract this ADR builds on.
 * [ADR 0022](0022-conformance-corpus-design.md) §1.2 / §7 — the

--- a/docs/adr/0038-session-user.md
+++ b/docs/adr/0038-session-user.md
@@ -1,0 +1,288 @@
+# ADR 0038: ``SESSION_USER()`` — caller-identity-bound pre-translator substitution
+
+- **Status**: Accepted
+
+## Context
+
+BigQuery's [`SESSION_USER()`](https://cloud.google.com/bigquery/docs/reference/standard-sql/security-functions)
+returns the email address of the user running the query —
+``alice@example.com`` for a user principal,
+``sa@project.iam.gserviceaccount.com`` for a service account. The
+canonical production use case is "tenant isolation by email domain"
+in row-access policy filters:
+
+```sql
+CREATE ROW ACCESS POLICY tenant_by_session_user ON dataset.tenants
+GRANT TO ('allAuthenticatedUsers')
+FILTER USING (REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id);
+```
+
+The pattern resolves the caller's email, extracts the domain, and
+matches it against a per-row tenant key — so a caller from
+``@example.com`` sees only the ``example.com`` rows without any
+explicit grantee list (which would otherwise need to enumerate every
+authenticated user). Real BigQuery users rely on this; the emulator
+must support it.
+
+Pre-PR audit findings (verified at the start of the work):
+
+* Zero implementation under ``src/bqemulator/sql/`` — the function
+  was never wired.
+* Zero tests anywhere (``grep -rn 'SESSION_USER' tests/`` returned
+  only the surface-inventory entry).
+* The surface-inventory entry (``tests/conformance/_surface_inventory.py``)
+  rendered in the conformance-coverage matrix as
+  ``⚪ Excluded by ADR 0022 §1.2 — session-state dependent.
+  Exercised at the unit tier.`` The last sentence was aspirational —
+  the unit-tier coverage didn't exist.
+* DuckDB's native ``SESSION_USER`` resolves to the literal
+  ``'duckdb'`` (the DuckDB connection's OS identity), **not** the
+  BigQuery caller — so a query like ``SELECT SESSION_USER()`` would
+  silently return ``'duckdb'`` and any RAP filter built on it would
+  match no real caller.
+* The five-client E2E charter (AGENTS.md "Testing expectations":
+  *"every new BigQuery surface item gets a SurfaceItem entry...
+  never skip an e2e test language"*) was unmet for this surface.
+
+This ADR closes that gap with both the implementation and the
+end-to-end client coverage.
+
+## Decision
+
+Implement ``SESSION_USER()`` as a **pre-translator substitution
+pass** that takes the per-query ``CallerIdentity`` and rewrites
+every ``SESSION_USER()`` call site in the SQL to a string literal of
+the caller's resolved email **before** SQLGlot's BigQuery → DuckDB
+transpile runs. The substitution happens inside
+``SQLTranslator.translate()``, so it covers every place the
+translator runs: bare queries, scripts, RAP filter predicates
+(inlined by ``rewrite_for_row_access``), view bodies (also inlined
+by the same pass), and the gRPC Storage Read row-filter rewrite when
+caller context is available.
+
+### Three options considered
+
+| Option | Shape | Decision |
+|---|---|---|
+| **A — SQL pre-translator** | New ``rewrite_session_user(sql, caller)`` AST walk substitutes ``SessionUser`` nodes with ``Literal(email)`` before SQLGlot transpiles. Needs ``caller`` plumbed into ``Translator.translate``. | ✅ **Chosen.** |
+| **B — RAP-rewriter-only substitution** | Substitute only inside policy filters. Bare ``SELECT SESSION_USER()`` raises ``UnsupportedFeatureError``. | Rejected. Narrower than BigQuery's contract; surprises users. |
+| **C — DuckDB scalar UDF reading a session variable** | Register a Python-side ``bqemu_session_user()`` UDF that reads per-query state from a context variable. Translator rewrites ``SESSION_USER()`` → ``bqemu_session_user()``. | Rejected. DuckDB's connection is shared across requests; per-call state plumbing through a UDF context is more invasive than threading ``caller`` directly. |
+
+Option A wins on three axes:
+
+1. **BigQuery semantic fidelity.** ``SESSION_USER()`` works
+   *everywhere* SQL runs — not just inside RAP filters.
+2. **Existing infrastructure reuse.** The row-access enforcement
+   path already constructs ``CallerIdentity`` per-request and threads
+   it through ``rewrite_for_row_access``; extending the same value
+   one layer down (to the translator) is additive and uses an
+   existing dataclass.
+3. **Smallest concept surface.** Option C would add a new session-
+   state primitive to the translator and require per-query DuckDB
+   ``SET`` semantics; Option A is a single new rewriter module + an
+   optional kwarg on one function.
+
+The cost is plumbing ``caller: CallerIdentity | None`` through
+five call sites (``jobs/executor.py``, three sites in
+``scripting/interpreter.py``, one in ``grpc_api/read_servicer.py``).
+Each is additive — the new parameter defaults to ``None``, which
+folds to the unauthenticated fallback identity, so the change is
+backward-compatible by construction.
+
+### Resolution contract
+
+The pure resolver
+:func:`bqemulator.sql.rewriter.session_user.resolve_session_user`
+maps a ``CallerIdentity`` to the literal string ``SESSION_USER()``
+should return:
+
+| Caller shape | Returned literal |
+|---|---|
+| ``is_authenticated == False`` (DEFAULT_CALLER) | ``"anonymous"`` (sentinel — RAP filters that compare against a tenant key deny every row) |
+| ``user:alice@example.com`` | ``"alice@example.com"`` |
+| ``serviceAccount:sa@project.iam.gserviceaccount.com`` | ``"sa@project.iam.gserviceaccount.com"`` |
+| ``group:admins@example.com`` | ``"admins@example.com"`` (never appears via ``X-Bqemu-Caller`` in practice; tolerated defensively) |
+| ``domain:example.com`` | ``"example.com"`` (same — defensive only) |
+| ``allUsers`` / ``allAuthenticatedUsers`` / unknown | raw principal string (passthrough — these are grantee-side identifiers, not caller identifiers) |
+
+### Unauthenticated fallback
+
+Real BigQuery never invokes ``SESSION_USER()`` from an
+unauthenticated session — every API call carries a credential. The
+emulator's ``DEFAULT_CALLER`` (``user:anonymous@bqemulator.local``
+with ``is_authenticated=False``) is purely a robustness fallback for
+requests that arrive without an ``X-Bqemu-Caller`` header (most
+common: integration tests that don't set the header explicitly).
+
+For RAP filters comparing ``SESSION_USER()`` against a tenant key,
+the ``"anonymous"`` sentinel ensures the filter denies every row,
+which is the safe default. A documentation note in the
+``SESSION_USER`` reference (function-mapping regen) calls out this
+behavior so users don't mistake an un-headered test for a real
+deny-everything bug.
+
+### Sequencing of the pre-translator passes
+
+``rewrite_session_user`` runs as the **first** pre-translator pass
+(immediately after the unsupported-keyword reject), ahead of every
+other pre-translator in ``Translator.translate``. The ordering
+matters because:
+
+* The row-access enforcement pass
+  (``rewrite_for_row_access``) inlines policy filters into the
+  user's query *before* the query reaches the translator. By the
+  time ``rewrite_session_user`` runs, any ``SESSION_USER()`` inside
+  a policy filter is already in the SQL string.
+* Downstream pre-translators (``rewrite_safe_helpers``,
+  ``rewrite_string_helpers``, ``rewrite_datetime_helpers`` …) all
+  expect either valid BigQuery SQL or a partial rewrite — none of
+  them see a leftover ``SESSION_USER`` because we substituted it to
+  a plain ``STRING`` literal first.
+
+## Rationale
+
+### Why a pre-translator and not a DuckDB pass-through
+
+DuckDB has a built-in ``SESSION_USER`` system function. If the
+translator left ``SESSION_USER()`` alone, SQLGlot would transpile it
+to DuckDB's ``SESSION_USER`` (verified — see
+``tests/unit/sql/rewriter/test_session_user.py::test_translator_substitutes_session_user``
+for the regression pin), which resolves to the literal ``'duckdb'``
+— the DuckDB connection's OS-side identity, not the BigQuery
+caller. Every RAP filter built on ``SESSION_USER()`` would then
+silently deny every legitimate caller. Pre-translator substitution
+is the only fix.
+
+### Why store the substitution as a ``Literal`` and not a parameterised value
+
+The natural alternative is to substitute ``SESSION_USER()`` with a
+positional placeholder (``?``) and bind the email at query-execution
+time. That would let DuckDB's parameter-binding layer carry the
+type. But the literal approach is simpler:
+
+* The translator already emits string literals for many other
+  rewrites (``rewrite_aggregate_variants``, ``rewrite_decimal_literals``,
+  etc.). A new ``Literal.string`` node is no special case.
+* The pre-translator pass is already running with full caller
+  context — there's no late-binding benefit.
+* Parameter binding would require coordinating the new parameter
+  with the existing positional-parameter pipeline
+  (``bind_parameters`` at the bottom of ``jobs/executor.py``);
+  literal substitution skips the orchestration entirely.
+
+### Why not also rewrite ``CURRENT_USER`` / ``@@session.user``
+
+BigQuery's ``CURRENT_USER`` is a deprecated legacy spelling of
+``SESSION_USER``; ``@@session.user`` is the system-variable form
+(useful in stored procedures). Each is functionally identical to
+``SESSION_USER`` but adds parsing complexity (system variables in
+particular use a different AST shape). Out-of-scope per chip prompt
+— each is a separate follow-up PR if downstream users surface a
+need.
+
+### Why ``SESSION_USER`` stays excluded from the conformance corpus
+
+ADR 0022 §1.2 documents the exclusion: the function is
+session-state-dependent (its return value depends on which
+authenticated principal made the API call, which can't be
+deterministically captured in a recording). The integration suite
+records the substituted SQL (with the literal email) at the
+HTTP-request layer, which is reproducible — but the conformance
+corpus's recording semantics expect the raw user SQL, not the
+post-rewrite SQL. Keep the exclusion; the new unit + integration +
+e2e × 4 coverage closes the "exercised at the unit tier" gap that
+the surface-inventory entry promised.
+
+## Consequences
+
+### Positive
+
+* The canonical RAP-with-caller-derived-filter production pattern
+  works end-to-end through every conformance client.
+* The surface-inventory promise ("Exercised at the unit tier") is
+  now true — unit + integration + e2e × 4 coverage lands together.
+* The pre-translator runs once and substitutes everywhere — no
+  separate code path for RAP filters vs free-form queries vs script
+  statements vs gRPC Storage Read row-restriction filters.
+* The new ``caller`` kwarg on ``Translator.translate`` is the right
+  shape for future context-dependent rewrites (e.g. ``@@project_id``
+  if we ever add it) — the architecture is now reusable.
+
+### Negative
+
+* Five call sites had to pass ``caller`` (``jobs/executor.py``,
+  three in ``scripting/interpreter.py``, one in
+  ``grpc_api/read_servicer.py``). Future callers must follow
+  the same pattern; documented in the function docstring.
+* The Storage Read filter pre-pass at
+  ``grpc_api/read_servicer.py:122`` (``_build_filter_sql`` for the
+  ``row_restriction`` field) doesn't yet receive caller context —
+  it lives below the route handler that resolves identity. A
+  ``SESSION_USER()`` in a Storage Read ``row_restriction`` therefore
+  folds to ``"anonymous"`` regardless of the actual caller. This is
+  unusual (the canonical pattern is RAP filters, not Storage Read
+  row_restriction) and is documented in the function docstring as
+  a known limitation.
+* ``SESSION_USER()`` inside a SQL UDF body is *not* re-substituted
+  per-call (UDFs are pre-translated at definition time, when no
+  caller exists). The function inside a UDF body folds to
+  ``"anonymous"`` permanently — different from real BigQuery,
+  which re-resolves the function per-invocation. Documented in
+  the rewriter module docstring.
+
+### Neutral
+
+* The new ``CallerIdentity`` import in the translator uses
+  ``TYPE_CHECKING`` to avoid a circular import (the
+  ``row_access.identity`` module's transitive imports eventually
+  pull in the translator); the runtime resolution of the fallback
+  identity uses a function-scope ``import`` for the same reason.
+  Future contributors touching ``Translator.translate`` should keep
+  this shape.
+* ``CallerIdentity`` is used in the translator as an opaque value
+  type — only ``principal`` and ``is_authenticated`` are read. This
+  keeps the translator decoupled from the row-access matcher
+  internals.
+
+## Alternatives considered
+
+1. **Option B — RAP-rewriter-only substitution.** Smaller code
+   surface (only ``rewrite_for_row_access`` touches caller identity)
+   but raises ``UnsupportedFeatureError`` on bare ``SELECT
+   SESSION_USER()``. Surprises users who'd reasonably expect the
+   function to work in free-form queries. Rejected.
+2. **Option C — DuckDB scalar UDF.** Register a Python-side
+   ``bqemu_session_user()`` UDF and have the translator rewrite
+   ``SESSION_USER()`` → ``bqemu_session_user()``. Per-call state
+   would have to plumb through a context variable since DuckDB's
+   ``SET SESSION`` is connection-scoped and the emulator shares the
+   connection across requests. More invasive than threading
+   ``caller`` directly. Rejected.
+3. **Per-thread session variable.** Stash the caller in a
+   ``contextvars.ContextVar`` and have a DuckDB scalar UDF read it.
+   Works in async contexts where each request gets its own context,
+   but it adds an implicit dependency that's invisible at the
+   translator surface. Rejected — explicit ``caller`` kwarg is
+   clearer.
+4. **Skip ``SESSION_USER()`` entirely; document as unsupported.**
+   Closes the gap quickly but fails the chip prompt's stated goal
+   (close the five-client e2e charter for this surface). Rejected.
+5. **Hand-authored conformance corpus fixture.** Mentioned in the
+   chip prompt as optional; would require a ``${PRINCIPAL}``
+   matrix-expander hook the corpus doesn't have today. The
+   unit + integration + e2e × 4 tiers cover the surface; the
+   conformance corpus exclusion (ADR 0022 §1.2) stands. No new
+   fixture added in this PR.
+
+## References
+
+* [BigQuery `SESSION_USER()` reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/security-functions#session_user)
+* [ADR 0018](0018-caller-identity-and-row-access-enforcement.md) — the
+  ``CallerIdentity`` dataclass + ``X-Bqemu-Caller`` header contract this ADR builds on.
+* [ADR 0022](0022-conformance-corpus-design.md) §1.2 / §7 — the
+  conformance-corpus exclusion for non-deterministic functions, which
+  ``SESSION_USER()`` stays inside.
+* [ADR 0035](0035-code-quality-gates.md) / [ADR 0036](0036-complexity-ratchet-to-c.md) /
+  [ADR 0037](0037-openssf-scorecard.md) — the template / shape this ADR follows.
+* AGENTS.md "Testing expectations" — the five-client e2e charter
+  this ADR satisfies for the SESSION_USER surface.

--- a/docs/reference/conformance-coverage-matrix.md
+++ b/docs/reference/conformance-coverage-matrix.md
@@ -41,7 +41,7 @@ These surface items are permanently outside the conformance corpus because their
 | Date / time / timestamp / datetime functions | [`CURRENT_DATETIME`](https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions) | Excluded from the conformance corpus by ADR 0022 §1.2 / §7 — wall-clock dependent. |
 | Date / time / timestamp / datetime functions | [`CURRENT_TIME`](https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions) | Excluded from the conformance corpus by ADR 0022 §1.2 / §7 — wall-clock dependent. |
 | Date / time / timestamp / datetime functions | [`CURRENT_TIMESTAMP`](https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions) | Excluded from the conformance corpus by ADR 0022 §1.2 / §7 — wall-clock dependent. The function is exercised in unit / integration tiers where the harness pins time. |
-| Hash / security functions | [`SESSION_USER`](https://cloud.google.com/bigquery/docs/reference/standard-sql/hash_functions) | Excluded from the conformance corpus by ADR 0022 §1.2 — session-state dependent. Exercised at the unit tier. |
+| Hash / security functions | [`SESSION_USER`](https://cloud.google.com/bigquery/docs/reference/standard-sql/hash_functions) | Excluded from the conformance corpus by ADR 0022 §1.2 — session-state dependent. Exercised at the unit, integration, and e2e × 4 client tiers (ADR 0038). |
 | Hash / security functions | [`GENERATE_UUID`](https://cloud.google.com/bigquery/docs/reference/standard-sql/hash_functions) | Excluded from the conformance corpus by ADR 0022 §1.2 — non-deterministic. Property-tested via Hypothesis for shape / uniqueness. |
 
 ## Variation depth — broad-but-shallow surfaces
@@ -577,7 +577,7 @@ The fastest single-session improvements come from these uncovered cells. Each is
 | [`SHA256`](https://cloud.google.com/bigquery/docs/reference/standard-sql/hash_functions) | 1 | 🟡 Sampled | happy×1 | [`standard_functions/hash_sha256`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/hash_sha256) |
 | [`SHA512`](https://cloud.google.com/bigquery/docs/reference/standard-sql/hash_functions) | 1 | 🟡 Sampled | happy×1 | [`standard_functions/hash_sha512_basic`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/hash_sha512_basic) |
 | [`SESSION_USER`](https://cloud.google.com/bigquery/docs/reference/standard-sql/hash_functions) _(excluded — non-deterministic)_ | n/a | ⚪ Excluded | n/a | _see [ADR 0022](../adr/0022-conformance-corpus-design.md) §1.2 / §7_ |
-|  |  |  |  | _Excluded from the conformance corpus by ADR 0022 §1.2 — session-state dependent. Exercised at the unit tier._ |
+|  |  |  |  | _Excluded from the conformance corpus by ADR 0022 §1.2 — session-state dependent. Exercised at the unit, integration, and e2e × 4 client tiers (ADR 0038)._ |
 | [`GENERATE_UUID`](https://cloud.google.com/bigquery/docs/reference/standard-sql/hash_functions) _(excluded — non-deterministic)_ | n/a | ⚪ Excluded | n/a | _see [ADR 0022](../adr/0022-conformance-corpus-design.md) §1.2 / §7_ |
 |  |  |  |  | _Excluded from the conformance corpus by ADR 0022 §1.2 — non-deterministic. Property-tested via Hypothesis for shape / uniqueness._ |
 

--- a/docs/reference/sql-function-mapping.md
+++ b/docs/reference/sql-function-mapping.md
@@ -51,7 +51,7 @@ table below maps each BigQuery view to its rewriter function.
 > **Auto-generated.** Edit translation rules under [`src/bqemulator/sql/rules/`](https://github.com/jjviscomi/bqemulator/blob/main/src/bqemulator/sql/rules/) or rewriters under [`src/bqemulator/sql/rewriter/`](https://github.com/jjviscomi/bqemulator/blob/main/src/bqemulator/sql/rewriter/), then run `make function-mapping` to regenerate this block. The CI gate (`--check`) refuses to merge a PR whose committed registry has drifted from the live source. Per-rule docstring summaries are extracted as the cell text — if a cell reads wrong, edit the rule's docstring.
 
 - **Registered rules**: 92 (13 rule modules)
-- **Rewriter functions**: 23 (23 rewriter modules; the INFORMATION_SCHEMA rewriter has its own hand-maintained per-view table below)
+- **Rewriter functions**: 24 (24 rewriter modules; the INFORMATION_SCHEMA rewriter has its own hand-maintained per-view table below)
 
 ### Translation rules (post-transpile AST passes)
 
@@ -177,5 +177,6 @@ table below maps each BigQuery view to its rewriter function.
 | Pre-translator (UNNEST STRUCT aliases) | Propagate named-struct field aliases inside `UNNEST([...])` arrays | — | `rewrite_unnest_struct` |
 | Pre-translator (wildcard tables) | Expand every wildcard table reference in `bq_sql` | — | `expand_wildcard_tables` |
 | Other rewriter | Return a no-op statement when `bq_sql` is `ALTER TABLE ... SET OPTIONS(...)` | — | `rewrite_alter_table_set_options` |
+| Other rewriter | Pre-translate BigQuery SQL for the `SESSION_USER()` function | — | `rewrite_session_user` |
 
 <!-- END AUTO-GENERATED RULE REGISTRY -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -220,6 +220,7 @@ nav:
       - "0035 Non-blocking code-quality gates (complexity / duplication / dead code)": adr/0035-code-quality-gates.md
       - "0036 Cyclomatic-complexity ratchet to rank C + promote-to-required gate": adr/0036-complexity-ratchet-to-c.md
       - "0037 OpenSSF Scorecard adoption + badge": adr/0037-openssf-scorecard.md
+      - "0038 SESSION_USER() pre-translator substitution": adr/0038-session-user.md
   - RFCs: rfcs/README.md
   - Examples:
       - Overview: examples/README.md

--- a/src/bqemulator/grpc_api/read_servicer.py
+++ b/src/bqemulator/grpc_api/read_servicer.py
@@ -249,7 +249,7 @@ class BigQueryReadHandler(grpc.GenericRpcHandler):
                 from bqemulator.sql.table_rewriter import rewrite_table_refs
                 from bqemulator.sql.translator import SQLTranslator
 
-                translate_result = SQLTranslator().translate(rewritten)
+                translate_result = SQLTranslator().translate(rewritten, caller=caller)
                 if hasattr(translate_result, "value"):
                     duckdb_sql = translate_result.value
                 else:  # pragma: no cover — translator returned an Err

--- a/src/bqemulator/jobs/executor.py
+++ b/src/bqemulator/jobs/executor.py
@@ -550,7 +550,11 @@ async def _run_single_sql(
     # ``AvgDecimalRule`` consults the annotated operand type to decide
     # whether to wrap ``AVG`` in a DECIMAL cast.
     schema_dict = build_catalog_schema(bq_sql, project_id=project_id, catalog=ctx.catalog)
-    translate_result = _translator.translate(bq_sql, schema=schema_dict or None)
+    translate_result = _translator.translate(
+        bq_sql,
+        schema=schema_dict or None,
+        caller=caller,
+    )
     match translate_result:
         case Err(error):
             raise error

--- a/src/bqemulator/scripting/interpreter.py
+++ b/src/bqemulator/scripting/interpreter.py
@@ -749,7 +749,7 @@ class ScriptInterpreter:
         )
         rewritten = rewrite_unnest_offset(rewritten)
         expanded = expand_wildcard_tables(rewritten, self._project_id, self._ctx.catalog)
-        match self._translator.translate(expanded):
+        match self._translator.translate(expanded, caller=self._caller):
             case Ok(duckdb_sql):
                 pass
             case Err(error):
@@ -795,7 +795,7 @@ class ScriptInterpreter:
         )
         rewritten = rewrite_unnest_offset(rewritten)
         expanded = expand_wildcard_tables(rewritten, self._project_id, self._ctx.catalog)
-        match self._translator.translate(expanded):
+        match self._translator.translate(expanded, caller=self._caller):
             case Ok(duckdb_sql):
                 pass
             case Err(error):
@@ -837,7 +837,7 @@ class ScriptInterpreter:
         )
         rewritten = rewrite_unnest_offset(rewritten)
         expanded = expand_wildcard_tables(rewritten, self._project_id, self._ctx.catalog)
-        match self._translator.translate(expanded):
+        match self._translator.translate(expanded, caller=self._caller):
             case Ok(duckdb_sql):
                 pass
             case Err(error):

--- a/src/bqemulator/sql/rewriter/session_user.py
+++ b/src/bqemulator/sql/rewriter/session_user.py
@@ -1,0 +1,151 @@
+"""Pre-translator rewrite for BigQuery's ``SESSION_USER()`` function.
+
+``SESSION_USER()`` returns the email address of the user running the
+query (``alice@example.com`` for a user principal,
+``sa@project.iam.gserviceaccount.com`` for a service account). The
+emulator's caller identity is carried on the per-query
+:class:`~bqemulator.row_access.identity.CallerIdentity` value already
+threaded through the row-access enforcement path; this pre-translator
+substitutes every ``SESSION_USER()`` call site with a string literal
+of the resolved email *before* the SQLGlot BigQuery → DuckDB transpile.
+
+Why a pre-translator and not a DuckDB pass-through:
+
+DuckDB's native ``SESSION_USER`` resolves to the literal string
+``'duckdb'`` (the OS-side identity of the DuckDB connection),
+**not** the BigQuery caller — so a query like
+``SELECT SESSION_USER()`` would silently produce ``'duckdb'`` and a
+row-access policy filter
+``REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = 'example.com'`` would
+deny every legitimate caller. The pre-translator substitutes the call
+with the resolved literal so the downstream transpile sees a
+plain ``STRING`` constant DuckDB can evaluate correctly.
+
+Why this rewriter is the right integration point:
+
+The row-access policy enforcement pass
+(``rewrite_for_row_access``) inlines policy filters into the user's
+query as a derived-subquery WHERE clause. Any ``SESSION_USER()`` in
+the filter ends up in the rewritten SQL that flows into the main
+translator. Running this rewriter from
+:meth:`bqemulator.sql.translator.SQLTranslator.translate` therefore
+catches all four use cases in one place: bare queries, scripts, RAP
+filters (inlined by the row-access rewriter), and view bodies (also
+inlined).
+
+See [ADR 0038](../../docs/adr/0038-session-user.md) for the full
+decision record (option A vs B vs C, fallback identity contract, and
+out-of-scope notes).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlglot
+from sqlglot import exp
+
+if TYPE_CHECKING:  # pragma: no cover
+    from bqemulator.row_access.identity import CallerIdentity
+
+
+#: BigQuery's IAM-member kind prefixes. ``SESSION_USER()`` returns the
+#: bare email (``alice@example.com``) for ``user:`` / ``serviceAccount:``
+#: callers; we strip the prefix to match that contract.
+#: ``group:`` / ``domain:`` are never passed as the request's
+#: ``X-Bqemu-Caller`` in practice, but stripping them defensively keeps
+#: the function consistent with BigQuery's "principal email" shape.
+_IAM_MEMBER_PREFIXES: tuple[str, ...] = (
+    "user:",
+    "serviceAccount:",
+    "group:",
+    "domain:",
+)
+
+#: Sentinel returned when the caller is the unauthenticated fallback
+#: identity. Real BigQuery never reaches this branch because every
+#: API call carries an authenticated caller; the emulator's default
+#: caller (``DEFAULT_CALLER`` from ``row_access.identity``) folds to
+#: this string so RAP policies that compare ``SESSION_USER()`` against
+#: a tenant key deny every row for un-headered requests. Documented
+#: in ADR 0038 §"Unauthenticated fallback".
+ANONYMOUS_CALLER = "anonymous"
+
+
+def resolve_session_user(caller: CallerIdentity) -> str:
+    """Return BigQuery's ``SESSION_USER()`` value for ``caller``.
+
+    Resolution:
+
+    * ``is_authenticated == False`` → :data:`ANONYMOUS_CALLER` literal.
+    * ``user:<email>`` / ``serviceAccount:<email>`` /
+      ``group:<email>`` / ``domain:<host>`` → strip the prefix, return
+      the bare email or host.
+    * Anything else (``allUsers``, ``allAuthenticatedUsers``, an
+      unknown shape) → return the raw principal string unchanged.
+      Real BigQuery never invokes the function as one of these
+      members because they're grantee-side identifiers, not caller
+      identifiers; the passthrough exists so a misconfigured emulator
+      doesn't raise.
+    """
+    if not caller.is_authenticated:
+        return ANONYMOUS_CALLER
+    principal = caller.principal
+    for prefix in _IAM_MEMBER_PREFIXES:
+        if principal.startswith(prefix):
+            return principal[len(prefix) :]
+    return principal
+
+
+def rewrite_session_user(bq_sql: str, caller: CallerIdentity) -> str:
+    """Pre-translate BigQuery SQL for the ``SESSION_USER()`` function.
+
+    Returns the input unchanged when no rewrite is needed (no
+    ``SESSION_USER()`` call site or the AST fails to parse — the
+    downstream SQLGlot transpile then surfaces its own parse error
+    message rather than this rewriter swallowing it).
+
+    The rewriter is intentionally idempotent: applying it twice with
+    the same caller yields the same output (the second pass finds
+    zero ``SessionUser`` nodes because the first pass replaced them
+    all with string literals).
+    """
+    # Fast string-side reject — avoids parsing the AST when there are
+    # no occurrences. The check is case-insensitive (BigQuery accepts
+    # ``session_user()`` and ``Session_User()`` too) and tolerates
+    # whitespace before the ``(``.
+    if "session_user" not in bq_sql.lower():
+        return bq_sql
+
+    try:
+        parsed = sqlglot.parse_one(bq_sql, read="bigquery")
+    except sqlglot.errors.ParseError:
+        return bq_sql
+
+    resolved = resolve_session_user(caller)
+    modified = _substitute_session_user(parsed, resolved)
+    if not modified:
+        return bq_sql
+    return parsed.sql(dialect="bigquery")
+
+
+def _substitute_session_user(tree: exp.Expression, resolved: str) -> bool:
+    """Replace every ``SessionUser`` node with ``Literal(resolved)``.
+
+    Returns True iff at least one node was replaced. Walks the tree
+    snapshot up front because ``find_all`` would otherwise re-visit
+    the replacement nodes (no-op, but wasteful).
+    """
+    modified = False
+    nodes = list(tree.find_all(exp.SessionUser))
+    for node in nodes:
+        node.replace(exp.Literal.string(resolved))
+        modified = True
+    return modified
+
+
+__all__ = [
+    "ANONYMOUS_CALLER",
+    "resolve_session_user",
+    "rewrite_session_user",
+]

--- a/src/bqemulator/sql/translator.py
+++ b/src/bqemulator/sql/translator.py
@@ -15,7 +15,7 @@ tasks concurrently.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import sqlglot
 from sqlglot import exp
@@ -44,6 +44,7 @@ from bqemulator.sql.rewriter.partition_pseudo_columns import (
 )
 from bqemulator.sql.rewriter.range_sessionize import rewrite_range_sessionize
 from bqemulator.sql.rewriter.safe_helpers import rewrite_safe_helpers
+from bqemulator.sql.rewriter.session_user import rewrite_session_user
 from bqemulator.sql.rewriter.sha512 import rewrite_sha512
 from bqemulator.sql.rewriter.specialized_types import rewrite_specialized_types
 from bqemulator.sql.rewriter.string_helpers import rewrite_string_helpers
@@ -53,6 +54,9 @@ from bqemulator.sql.rewriter.timestamp_iso_helpers import (
 )
 from bqemulator.sql.rewriter.unnest_struct import rewrite_unnest_struct
 from bqemulator.sql.rules import TranslationRule, get_all_rules
+
+if TYPE_CHECKING:  # pragma: no cover
+    from bqemulator.row_access.identity import CallerIdentity
 
 _log = get_logger(__name__)
 
@@ -68,6 +72,25 @@ _UNSUPPORTED_KEYWORDS: frozenset[str] = frozenset(
         "ML.GENERATE_EMBEDDING",
     }
 )
+
+
+def _resolve_caller(caller: CallerIdentity | None) -> CallerIdentity:
+    """Return ``caller`` if supplied, else the unauthenticated fallback.
+
+    The fallback mirrors :data:`bqemulator.row_access.identity.DEFAULT_CALLER`
+    so the ``SESSION_USER()`` substitution is deterministic for legacy
+    call sites that haven't propagated identity yet —
+    ``SESSION_USER()`` → ``'anonymous'`` literal — instead of failing
+    the translation.
+
+    The import is deferred to function scope to avoid a circular
+    import (``row_access.identity`` → … → ``sql.translator``).
+    """
+    if caller is not None:
+        return caller
+    from bqemulator.row_access.identity import DEFAULT_CALLER, CallerIdentity
+
+    return CallerIdentity(principal=DEFAULT_CALLER, is_authenticated=False)
 
 
 class SQLTranslator:
@@ -97,6 +120,7 @@ class SQLTranslator:
         bq_sql: str,
         *,
         schema: dict[str, Any] | None = None,
+        caller: CallerIdentity | None = None,
         **kwargs: Any,  # noqa: ARG002 — reserved for future rewriter context
     ) -> Result[str, InvalidQueryError | UnsupportedFeatureError]:
         """Translate a BigQuery SQL string to DuckDB SQL.
@@ -111,6 +135,14 @@ class SQLTranslator:
                 aggregate-type preservation) consult. ``None`` disables
                 the annotation pass — rules that depend on operand
                 types simply skip.
+            caller: Optional :class:`~bqemulator.row_access.identity.CallerIdentity`
+                used by the ``SESSION_USER()`` pre-translator
+                (ADR 0038). ``None`` folds to the unauthenticated
+                fallback identity so legacy callers that haven't
+                propagated identity yet still get a deterministic
+                substitution (``SESSION_USER()`` →
+                ``'anonymous'`` literal) rather than a translation
+                error.
             **kwargs: Reserved for future rewriter context (e.g.
                       catalog handle for wildcard table expansion).
 
@@ -122,6 +154,17 @@ class SQLTranslator:
         for kw in _UNSUPPORTED_KEYWORDS:
             if kw in upper:
                 return Err(sql_unsupported(kw))
+
+        # 1a. ``SESSION_USER()`` substitution (ADR 0038). Runs first
+        #     among the pre-translators so the resolved email literal
+        #     is in the SQL before any other rewriter operates on it
+        #     (the row-access enforcement pass inlines policy filters
+        #     into the user's query; those filters can contain
+        #     ``SESSION_USER()`` and we want the substitution to win
+        #     before SQLGlot transpiles the BigQuery AST to DuckDB,
+        #     which would otherwise resolve ``SESSION_USER`` to the
+        #     literal ``'duckdb'``).
+        bq_sql = rewrite_session_user(bq_sql, _resolve_caller(caller))
 
         # 1b. ``ALTER TABLE ... SET OPTIONS(...)`` no-op. SQLGlot's
         #     BigQuery → DuckDB transpile drops the ``OPTIONS(...)``

--- a/tests/conformance/_surface_inventory.py
+++ b/tests/conformance/_surface_inventory.py
@@ -1226,7 +1226,8 @@ FUNCTIONS_CONDITIONAL = SurfaceCategory(
 _NONDETERMINISTIC_HASH: dict[str, str] = {
     "SESSION_USER": (
         "Excluded from the conformance corpus by ADR 0022 §1.2 — "
-        "session-state dependent. Exercised at the unit tier."
+        "session-state dependent. Exercised at the unit, integration, "
+        "and e2e × 4 client tiers (ADR 0038)."
     ),
     "GENERATE_UUID": (
         "Excluded from the conformance corpus by ADR 0022 §1.2 — "

--- a/tests/e2e/bq_cli_client/test_row_access.py
+++ b/tests/e2e/bq_cli_client/test_row_access.py
@@ -13,6 +13,12 @@ none / authorized view does not bypass RAP) is covered by the
 Python suite (which can inject ``X-Bqemu-Caller`` via
 ``AuthorizedSession``). The bq suite covers the DDL contract +
 INFORMATION_SCHEMA enumeration.
+
+ADR 0038's ``SESSION_USER()``-in-RAP-filter pattern is similarly out
+of scope here for the same caller-header-injection reason — see
+:file:`tests/e2e/python_client/test_row_access_session_user.py`
+(+ the Node / Go / Java siblings) for the canonical "tenant
+isolation by email domain" coverage.
 """
 
 from __future__ import annotations

--- a/tests/e2e/go_client/row_access_session_user_test.go
+++ b/tests/e2e/go_client/row_access_session_user_test.go
@@ -48,7 +48,12 @@ func sessionUserClient(ctx context.Context, t *testing.T, caller string) *bigque
 	return client
 }
 
-func sessionUserRest(t *testing.T, method, path string, body any) {
+// Bounded REST client so a stalled emulator can't hang the test run
+// indefinitely (CodeRabbit thread PRRT_kwDOSkfuJ86EVwO0). The 15s cap
+// matches the per-call SLA the rest of the e2e suite assumes.
+var sessionUserHTTP = &http.Client{Timeout: 15 * time.Second}
+
+func sessionUserRest(ctx context.Context, t *testing.T, method, path string, body any) {
 	t.Helper()
 	var rd io.Reader
 	if body != nil {
@@ -58,12 +63,12 @@ func sessionUserRest(t *testing.T, method, path string, body any) {
 		}
 		rd = bytes.NewReader(buf)
 	}
-	req, err := http.NewRequest(method, restURL()+path, rd)
+	req, err := http.NewRequestWithContext(ctx, method, restURL()+path, rd)
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := sessionUserHTTP.Do(req)
 	if err != nil {
 		t.Fatalf("rest %s %s: %v", method, path, err)
 	}
@@ -135,7 +140,7 @@ func TestRowAccessSessionUserFilter(t *testing.T) {
 		),
 	)
 
-	sessionUserRest(t, "POST",
+	sessionUserRest(ctx, t, "POST",
 		fmt.Sprintf("/bigquery/v2/projects/%s/datasets/%s/tables/tenants/rowAccessPolicies",
 			sessionUserProject, dsID),
 		map[string]any{

--- a/tests/e2e/go_client/row_access_session_user_test.go
+++ b/tests/e2e/go_client/row_access_session_user_test.go
@@ -1,0 +1,190 @@
+// E2E: SESSION_USER() inside a RAP filter predicate (ADR 0038), exercised
+// through the official cloud.google.com/go/bigquery Go client.
+//
+// The canonical "tenant isolation by email domain" pattern:
+//   - Seed a tenants table with rows for two domains.
+//   - Create a RAP filter
+//     REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id granted to
+//     allAuthenticatedUsers.
+//   - Each caller sees only their own tenant's rows.
+//
+// The X-Bqemu-Caller header is injected via the same custom
+// http.RoundTripper as row_access_test.go.
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+const sessionUserProject = "e2e-go-row_access_session_user"
+
+func sessionUserClient(ctx context.Context, t *testing.T, caller string) *bigquery.Client {
+	t.Helper()
+	httpClient := &http.Client{
+		Transport: &callerHeaderTransport{caller: caller, inner: http.DefaultTransport},
+	}
+	client, err := bigquery.NewClient(
+		ctx,
+		sessionUserProject,
+		option.WithEndpoint(bqAPIBase()),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client
+}
+
+func sessionUserRest(t *testing.T, method, path string, body any) {
+	t.Helper()
+	var rd io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		rd = bytes.NewReader(buf)
+	}
+	req, err := http.NewRequest(method, restURL()+path, rd)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("rest %s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusNoContent {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("rest %s %s -> %d: %s", method, path, resp.StatusCode, b)
+	}
+}
+
+func sessionUserRunSql(ctx context.Context, t *testing.T, client *bigquery.Client, sql string) {
+	t.Helper()
+	q := client.Query(sql)
+	it, err := q.Read(ctx)
+	if err != nil {
+		t.Fatalf("query %q: %v", sql, err)
+	}
+	var row []bigquery.Value
+	for {
+		if err := it.Next(&row); err == iterator.Done {
+			return
+		} else if err != nil {
+			t.Fatalf("read %q: %v", sql, err)
+		}
+	}
+}
+
+func sessionUserCollectInts(ctx context.Context, t *testing.T, client *bigquery.Client, sql string) []int64 {
+	t.Helper()
+	q := client.Query(sql)
+	it, err := q.Read(ctx)
+	if err != nil {
+		t.Fatalf("query %q: %v", sql, err)
+	}
+	var out []int64
+	for {
+		var row []bigquery.Value
+		if err := it.Next(&row); err == iterator.Done {
+			return out
+		} else if err != nil {
+			t.Fatalf("read %q: %v", sql, err)
+		}
+		out = append(out, row[0].(int64))
+	}
+}
+
+func TestRowAccessSessionUserFilter(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	dsID := "session_user_go_ds"
+
+	admin := sessionUserClient(ctx, t, "")
+	defer admin.Close()
+	_ = admin.Dataset(dsID).DeleteWithContents(ctx)
+
+	if err := admin.Dataset(dsID).Create(ctx, &bigquery.DatasetMetadata{Location: "US"}); err != nil {
+		t.Fatalf("create dataset: %v", err)
+	}
+	defer admin.Dataset(dsID).DeleteWithContents(ctx)
+
+	sessionUserRunSql(ctx, t, admin,
+		fmt.Sprintf("CREATE TABLE `%s.%s.tenants` (id INT64, tenant_id STRING)", sessionUserProject, dsID),
+	)
+	sessionUserRunSql(ctx, t, admin,
+		fmt.Sprintf(
+			"INSERT INTO `%s.%s.tenants` VALUES (1, 'example.com'), (2, 'example.com'), "+
+				"(3, 'other.com'), (4, 'other.com')",
+			sessionUserProject, dsID,
+		),
+	)
+
+	sessionUserRest(t, "POST",
+		fmt.Sprintf("/bigquery/v2/projects/%s/datasets/%s/tables/tenants/rowAccessPolicies",
+			sessionUserProject, dsID),
+		map[string]any{
+			"rowAccessPolicyReference": map[string]string{
+				"projectId": sessionUserProject,
+				"datasetId": dsID,
+				"tableId":   "tenants",
+				"policyId":  "tenant_by_session_user",
+			},
+			"filterPredicate": "REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id",
+			"grantees":        []string{"allAuthenticatedUsers"},
+		})
+
+	// @example.com caller sees only example.com tenant rows.
+	exampleClient := sessionUserClient(ctx, t, "user:alice@example.com")
+	defer exampleClient.Close()
+	got := sessionUserCollectInts(ctx, t, exampleClient,
+		fmt.Sprintf("SELECT id FROM `%s.%s.tenants` ORDER BY id", sessionUserProject, dsID))
+	want := []int64{1, 2}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("@example.com caller: got %v want %v", got, want)
+	}
+
+	// @other.com caller sees only other.com tenant rows.
+	otherClient := sessionUserClient(ctx, t, "user:bob@other.com")
+	defer otherClient.Close()
+	got = sessionUserCollectInts(ctx, t, otherClient,
+		fmt.Sprintf("SELECT id FROM `%s.%s.tenants` ORDER BY id", sessionUserProject, dsID))
+	want = []int64{3, 4}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("@other.com caller: got %v want %v", got, want)
+	}
+}
+
+func TestBareSelectSessionUser(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := sessionUserClient(ctx, t, "user:claire@example.com")
+	defer client.Close()
+	q := client.Query("SELECT SESSION_USER() AS who")
+	it, err := q.Read(ctx)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	var row []bigquery.Value
+	if err := it.Next(&row); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if row[0].(string) != "claire@example.com" {
+		t.Fatalf("got %q, want claire@example.com", row[0])
+	}
+}

--- a/tests/e2e/java_client/src/test/java/com/example/RowAccessSessionUserTest.java
+++ b/tests/e2e/java_client/src/test/java/com/example/RowAccessSessionUserTest.java
@@ -14,6 +14,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -109,8 +110,15 @@ class RowAccessSessionUserTest {
         return bq.query(QueryJobConfiguration.newBuilder(sql).setUseLegacySql(false).build());
     }
 
+    // Connect-side timeout on the client, per-request timeout via the
+    // HttpRequest builder. The 15s cap matches the per-call SLA the
+    // rest of the e2e suite assumes; without it, a stalled emulator
+    // can hang the test run indefinitely
+    // (CodeRabbit thread PRRT_kwDOSkfuJ86EVwO9).
+    private static final Duration REST_TIMEOUT = Duration.ofSeconds(15);
     private static final HttpClient HTTP = HttpClient.newBuilder()
             .version(HttpClient.Version.HTTP_1_1)
+            .connectTimeout(REST_TIMEOUT)
             .build();
 
     private void rest(String method, String path, String body) throws Exception {
@@ -119,6 +127,7 @@ class RowAccessSessionUserTest {
                 ? HttpRequest.BodyPublishers.noBody()
                 : HttpRequest.BodyPublishers.ofString(body);
         HttpRequest req = HttpRequest.newBuilder(uri)
+                .timeout(REST_TIMEOUT)
                 .method(method, publisher)
                 .header("Content-Type", "application/json")
                 .build();
@@ -136,6 +145,7 @@ class RowAccessSessionUserTest {
                 ? HttpRequest.BodyPublishers.noBody()
                 : HttpRequest.BodyPublishers.ofString(body);
         HttpRequest req = HttpRequest.newBuilder(uri)
+                .timeout(REST_TIMEOUT)
                 .method(method, publisher)
                 .header("Content-Type", "application/json")
                 .build();

--- a/tests/e2e/java_client/src/test/java/com/example/RowAccessSessionUserTest.java
+++ b/tests/e2e/java_client/src/test/java/com/example/RowAccessSessionUserTest.java
@@ -1,0 +1,188 @@
+package com.example;
+
+import com.google.api.gax.rpc.FixedHeaderProvider;
+import com.google.cloud.NoCredentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetId;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.TableResult;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * E2E: SESSION_USER() inside a RAP filter predicate (ADR 0038), exercised
+ * through the official google-cloud-bigquery Java client.
+ *
+ * The canonical "tenant isolation by email domain" pattern:
+ *   - Seed a tenants table with rows for two domains.
+ *   - Create a RAP filter REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') =
+ *     tenant_id granted to allAuthenticatedUsers.
+ *   - Each caller sees only their own tenant's rows.
+ *
+ * The X-Bqemu-Caller header is injected per-client via the BigQuery
+ * client's FixedHeaderProvider (same pattern as RowAccessTest).
+ */
+class RowAccessSessionUserTest {
+    private static final String REST_URL = System.getenv("BQEMU_REST_URL") != null
+            ? System.getenv("BQEMU_REST_URL")
+            : "http://localhost:9050";
+    private static final String PROJECT = "e2e-java-row_access_session_user";
+    private static final String DATASET = "session_user_java_ds";
+
+    private BigQuery admin;
+
+    private BigQuery clientFor(String caller) {
+        BigQueryOptions.Builder b = BigQueryOptions.newBuilder()
+                .setProjectId(PROJECT)
+                .setHost(REST_URL)
+                .setCredentials(NoCredentials.getInstance());
+        if (caller != null) {
+            Map<String, String> headers = new HashMap<>();
+            headers.put("X-Bqemu-Caller", caller);
+            b.setHeaderProvider(FixedHeaderProvider.create(headers));
+        }
+        return b.build().getService();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        admin = clientFor(null);
+        try {
+            admin.delete(DatasetId.of(PROJECT, DATASET),
+                    BigQuery.DatasetDeleteOption.deleteContents());
+        } catch (Exception ignore) {
+        }
+        admin.create(DatasetInfo.newBuilder(DATASET).setLocation("US").build());
+
+        runAdminQuery("CREATE TABLE `" + PROJECT + "." + DATASET + ".tenants` "
+                + "(id INT64, tenant_id STRING)");
+        runAdminQuery("INSERT INTO `" + PROJECT + "." + DATASET + ".tenants` "
+                + "VALUES (1, 'example.com'), (2, 'example.com'), "
+                + "(3, 'other.com'), (4, 'other.com')");
+
+        // Defensive: drop a stale RAP before creating, mirroring
+        // RowAccessTest.setUp's pattern — DELETE /datasets/X doesn't
+        // currently cascade to row access policies.
+        restIgnore4xx("DELETE",
+                "/bigquery/v2/projects/" + PROJECT + "/datasets/" + DATASET
+                        + "/tables/tenants/rowAccessPolicies/tenant_by_session_user",
+                null);
+        rest("POST",
+                "/bigquery/v2/projects/" + PROJECT + "/datasets/" + DATASET
+                        + "/tables/tenants/rowAccessPolicies",
+                "{\"rowAccessPolicyReference\":{\"projectId\":\"" + PROJECT
+                        + "\",\"datasetId\":\"" + DATASET
+                        + "\",\"tableId\":\"tenants\",\"policyId\":\"tenant_by_session_user\"},"
+                        + "\"filterPredicate\":"
+                        + "\"REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id\","
+                        + "\"grantees\":[\"allAuthenticatedUsers\"]}");
+    }
+
+    @AfterEach
+    void tearDown() {
+        try {
+            admin.delete(DatasetId.of(PROJECT, DATASET),
+                    BigQuery.DatasetDeleteOption.deleteContents());
+        } catch (Exception ignore) {
+        }
+    }
+
+    private TableResult runAdminQuery(String sql) throws Exception {
+        return admin.query(QueryJobConfiguration.newBuilder(sql).setUseLegacySql(false).build());
+    }
+
+    private TableResult runAs(BigQuery bq, String sql) throws Exception {
+        return bq.query(QueryJobConfiguration.newBuilder(sql).setUseLegacySql(false).build());
+    }
+
+    private static final HttpClient HTTP = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .build();
+
+    private void rest(String method, String path, String body) throws Exception {
+        URI uri = URI.create(REST_URL + path);
+        HttpRequest.BodyPublisher publisher = body == null
+                ? HttpRequest.BodyPublishers.noBody()
+                : HttpRequest.BodyPublishers.ofString(body);
+        HttpRequest req = HttpRequest.newBuilder(uri)
+                .method(method, publisher)
+                .header("Content-Type", "application/json")
+                .build();
+        HttpResponse<String> resp = HTTP.send(req, HttpResponse.BodyHandlers.ofString());
+        int rc = resp.statusCode();
+        if (rc >= 400 && rc != 204) {
+            throw new IOException(
+                    "REST " + method + " " + path + " -> " + rc + ": " + resp.body());
+        }
+    }
+
+    private void restIgnore4xx(String method, String path, String body) throws Exception {
+        URI uri = URI.create(REST_URL + path);
+        HttpRequest.BodyPublisher publisher = body == null
+                ? HttpRequest.BodyPublishers.noBody()
+                : HttpRequest.BodyPublishers.ofString(body);
+        HttpRequest req = HttpRequest.newBuilder(uri)
+                .method(method, publisher)
+                .header("Content-Type", "application/json")
+                .build();
+        HttpResponse<String> resp = HTTP.send(req, HttpResponse.BodyHandlers.ofString());
+        int rc = resp.statusCode();
+        if (rc >= 500) {
+            throw new IOException(
+                    "REST " + method + " " + path + " -> " + rc + ": " + resp.body());
+        }
+    }
+
+    @Test
+    void exampleComCallerSeesOnlyExampleComRows() throws Exception {
+        BigQuery bq = clientFor("user:alice@example.com");
+        TableResult res = runAs(bq,
+                "SELECT id FROM `" + PROJECT + "." + DATASET + ".tenants` ORDER BY id");
+        List<Long> ids = new ArrayList<>();
+        for (FieldValueList row : res.iterateAll()) {
+            ids.add(row.get("id").getLongValue());
+        }
+        assertEquals(java.util.Arrays.asList(1L, 2L), ids);
+    }
+
+    @Test
+    void otherComCallerSeesOnlyOtherComRows() throws Exception {
+        BigQuery bq = clientFor("user:bob@other.com");
+        TableResult res = runAs(bq,
+                "SELECT id FROM `" + PROJECT + "." + DATASET + ".tenants` ORDER BY id");
+        List<Long> ids = new ArrayList<>();
+        for (FieldValueList row : res.iterateAll()) {
+            ids.add(row.get("id").getLongValue());
+        }
+        assertEquals(java.util.Arrays.asList(3L, 4L), ids);
+    }
+
+    @Test
+    void bareSelectSessionUserReturnsBareEmail() throws Exception {
+        // Not a RAP test, but uses the same pre-translator substitution
+        // path — pinning here keeps both surfaces (RAP filter +
+        // free-form query) in one place.
+        BigQuery bq = clientFor("user:claire@example.com");
+        TableResult res = runAs(bq, "SELECT SESSION_USER() AS who");
+        String got = null;
+        for (FieldValueList row : res.iterateAll()) {
+            got = row.get("who").getStringValue();
+            break;
+        }
+        assertEquals("claire@example.com", got);
+    }
+}

--- a/tests/e2e/nodejs_client/test/row_access_session_user.test.js
+++ b/tests/e2e/nodejs_client/test/row_access_session_user.test.js
@@ -1,0 +1,137 @@
+/**
+ * E2E: ``SESSION_USER()`` inside a RAP filter predicate (ADR 0038),
+ * exercised through the official @google-cloud/bigquery Node.js
+ * client.
+ *
+ * The canonical "tenant isolation by email domain" pattern:
+ *   - Seed a ``tenants`` table with rows for two domains.
+ *   - Create a RAP filter
+ *     ``REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id`` granted
+ *     to ``allAuthenticatedUsers``.
+ *   - Each caller sees only their own tenant's rows.
+ *
+ * The ``X-Bqemu-Caller`` header is injected per-client via the
+ * BigQuery client's interceptor API (same pattern as
+ * ``row_access.test.js``).
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+
+const REST_URL = process.env.BQEMU_REST_URL || "http://localhost:9050";
+const PROJECT = "e2e-nodejs-row_access_session_user";
+const DATASET = "session_user_node_ds";
+
+function makeClient(callerHeader) {
+  const { BigQuery } = require("@google-cloud/bigquery");
+  const { OAuth2Client } = require("google-auth-library");
+  const fake = new OAuth2Client();
+  fake.credentials = { access_token: "anonymous" };
+  const client = new BigQuery({
+    projectId: PROJECT,
+    apiEndpoint: REST_URL,
+    authClient: fake,
+    autoRetry: false,
+  });
+  if (callerHeader) {
+    client.interceptors.push({
+      request: (reqOpts) => ({
+        ...reqOpts,
+        headers: {
+          ...(reqOpts.headers || {}),
+          "X-Bqemu-Caller": callerHeader,
+        },
+      }),
+    });
+  }
+  return client;
+}
+
+async function rest(method, path, body) {
+  const res = await fetch(REST_URL + path, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`${method} ${path} -> ${res.status}: ${await res.text()}`);
+  }
+  return res;
+}
+
+async function cleanup() {
+  try {
+    await rest(
+      "DELETE",
+      `/bigquery/v2/projects/${PROJECT}/datasets/${DATASET}?deleteContents=true`,
+    );
+  } catch (_) {
+    /* ignore */
+  }
+}
+
+describe("bqemulator RAP via SESSION_USER (Node.js)", () => {
+  let admin;
+  before(async () => {
+    admin = makeClient(null);
+    await cleanup();
+    await admin.createDataset(DATASET, { location: "US" }).catch(() => {});
+    await admin.query(
+      `CREATE TABLE \`${PROJECT}.${DATASET}.tenants\` ` +
+        `(id INT64, tenant_id STRING)`,
+    );
+    await admin.query(
+      `INSERT INTO \`${PROJECT}.${DATASET}.tenants\` ` +
+        `VALUES (1, 'example.com'), (2, 'example.com'), ` +
+        `(3, 'other.com'), (4, 'other.com')`,
+    );
+    await rest(
+      "POST",
+      `/bigquery/v2/projects/${PROJECT}/datasets/${DATASET}` +
+        `/tables/tenants/rowAccessPolicies`,
+      {
+        rowAccessPolicyReference: {
+          projectId: PROJECT,
+          datasetId: DATASET,
+          tableId: "tenants",
+          policyId: "tenant_by_session_user",
+        },
+        filterPredicate:
+          "REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id",
+        grantees: ["allAuthenticatedUsers"],
+      },
+    );
+  });
+
+  after(async () => {
+    await cleanup();
+  });
+
+  it("@example.com caller sees only example.com rows", async () => {
+    const eu = makeClient("user:alice@example.com");
+    const [rows] = await eu.query(
+      `SELECT id FROM \`${PROJECT}.${DATASET}.tenants\` ORDER BY id`,
+    );
+    assert.deepEqual(
+      rows.map((r) => Number(r.id)),
+      [1, 2],
+    );
+  });
+
+  it("@other.com caller sees only other.com rows", async () => {
+    const other = makeClient("user:bob@other.com");
+    const [rows] = await other.query(
+      `SELECT id FROM \`${PROJECT}.${DATASET}.tenants\` ORDER BY id`,
+    );
+    assert.deepEqual(
+      rows.map((r) => Number(r.id)),
+      [3, 4],
+    );
+  });
+
+  it("SELECT SESSION_USER() returns the caller's bare email", async () => {
+    const claire = makeClient("user:claire@example.com");
+    const [rows] = await claire.query("SELECT SESSION_USER() AS who");
+    assert.equal(rows[0].who, "claire@example.com");
+  });
+});

--- a/tests/e2e/nodejs_client/test/row_access_session_user.test.js
+++ b/tests/e2e/nodejs_client/test/row_access_session_user.test.js
@@ -47,16 +47,27 @@ function makeClient(callerHeader) {
   return client;
 }
 
+// Cap REST calls at 15s so a stalled emulator can't hang the test
+// run indefinitely (CodeRabbit thread PRRT_kwDOSkfuJ86EVwPB).
+const REST_TIMEOUT_MS = 15_000;
+
 async function rest(method, path, body) {
-  const res = await fetch(REST_URL + path, {
-    method,
-    headers: { "Content-Type": "application/json" },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  if (!res.ok && res.status !== 204) {
-    throw new Error(`${method} ${path} -> ${res.status}: ${await res.text()}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REST_TIMEOUT_MS);
+  try {
+    const res = await fetch(REST_URL + path, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+    if (!res.ok && res.status !== 204) {
+      throw new Error(`${method} ${path} -> ${res.status}: ${await res.text()}`);
+    }
+    return res;
+  } finally {
+    clearTimeout(timer);
   }
-  return res;
 }
 
 async function cleanup() {

--- a/tests/e2e/python_client/test_row_access_session_user.py
+++ b/tests/e2e/python_client/test_row_access_session_user.py
@@ -1,0 +1,150 @@
+"""E2E: ``SESSION_USER()`` in a RAP filter predicate (ADR 0038).
+
+Exercises the canonical "tenant isolation by email domain" pattern
+end-to-end through the official ``google-cloud-bigquery`` Python
+client:
+
+1. Seed a ``tenants`` table with rows for two email-domain tenants
+   (``example.com`` and ``other.com``).
+2. Create a RAP policy whose filter predicate is
+   ``REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id``.
+3. Grant the policy to ``allAuthenticatedUsers`` so per-caller
+   visibility depends entirely on the *filter predicate*, not the
+   grantee match.
+4. Issue ``SELECT`` as two callers from different domains and assert
+   each sees only their own tenant's rows.
+
+The ``X-Bqemu-Caller`` header is injected at session construction
+time (same pattern as :file:`test_row_access.py`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from google.api_core.client_options import ClientOptions
+from google.auth.credentials import AnonymousCredentials
+from google.auth.transport.requests import AuthorizedSession
+from google.cloud import bigquery
+import httpx
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_PROJECT = "e2e-row_access_session_user"
+_DATASET = "session_user_ds"
+
+
+def _client_for_caller(rest_url: str, caller: str | None) -> bigquery.Client:
+    session = AuthorizedSession(AnonymousCredentials())
+    if caller is not None:
+        session.headers["X-Bqemu-Caller"] = caller
+    return bigquery.Client(
+        project=_PROJECT,
+        credentials=AnonymousCredentials(),
+        client_options=ClientOptions(api_endpoint=rest_url),
+        _http=session,
+    )
+
+
+@pytest.fixture
+def bq_admin(bqemu_rest_url: str) -> Iterator[bigquery.Client]:
+    client = _client_for_caller(bqemu_rest_url, None)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@pytest.fixture
+def seeded(bqemu_rest_url: str, bq_admin: bigquery.Client) -> Iterator[None]:
+    bq_admin.create_dataset(
+        bigquery.Dataset(f"{_PROJECT}.{_DATASET}"),
+        exists_ok=True,
+    )
+    bq_admin.create_table(
+        bigquery.Table(
+            f"{_PROJECT}.{_DATASET}.tenants",
+            schema=[
+                bigquery.SchemaField("id", "INT64", mode="REQUIRED"),
+                bigquery.SchemaField("tenant_id", "STRING"),
+            ],
+        ),
+        exists_ok=True,
+    )
+    bq_admin.query(
+        f"INSERT INTO `{_PROJECT}.{_DATASET}.tenants` VALUES "
+        "(1, 'example.com'), (2, 'example.com'), "
+        "(3, 'other.com'), (4, 'other.com')",
+    ).result()
+    with httpx.Client(base_url=bqemu_rest_url, timeout=30.0) as c:
+        c.post(
+            f"/bigquery/v2/projects/{_PROJECT}/datasets/{_DATASET}"
+            "/tables/tenants/rowAccessPolicies",
+            json={
+                "rowAccessPolicyReference": {
+                    "projectId": _PROJECT,
+                    "datasetId": _DATASET,
+                    "tableId": "tenants",
+                    "policyId": "tenant_by_session_user",
+                },
+                "filterPredicate": ("REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id"),
+                "grantees": ["allAuthenticatedUsers"],
+            },
+        )
+    yield None
+    with httpx.Client(base_url=bqemu_rest_url, timeout=30.0) as c:
+        c.delete(
+            f"/bigquery/v2/projects/{_PROJECT}/datasets/{_DATASET}",
+            params={"deleteContents": "true"},
+        )
+
+
+def _row_ids(job: bigquery.QueryJob) -> list[int]:
+    return [int(row["id"]) for row in job.result()]
+
+
+def test_session_user_filter_example_com_caller(
+    bqemu_rest_url: str,
+    seeded: None,
+) -> None:
+    """``@example.com`` caller sees only the ``example.com`` tenant rows."""
+    bq = _client_for_caller(bqemu_rest_url, "user:alice@example.com")
+    try:
+        job = bq.query(
+            f"SELECT id FROM `{_PROJECT}.{_DATASET}.tenants` ORDER BY id",
+        )
+        assert _row_ids(job) == [1, 2]
+    finally:
+        bq.close()
+
+
+def test_session_user_filter_other_com_caller(
+    bqemu_rest_url: str,
+    seeded: None,
+) -> None:
+    """``@other.com`` caller sees only the ``other.com`` tenant rows."""
+    bq = _client_for_caller(bqemu_rest_url, "user:bob@other.com")
+    try:
+        job = bq.query(
+            f"SELECT id FROM `{_PROJECT}.{_DATASET}.tenants` ORDER BY id",
+        )
+        assert _row_ids(job) == [3, 4]
+    finally:
+        bq.close()
+
+
+def test_bare_select_session_user(bqemu_rest_url: str) -> None:
+    """``SELECT SESSION_USER()`` returns the caller's bare email.
+
+    Not a RAP test, but uses the same pre-translator substitution path —
+    pinning it here ensures the function works in free-form queries as
+    well as inside row-access filter predicates.
+    """
+    bq = _client_for_caller(bqemu_rest_url, "user:claire@example.com")
+    try:
+        job = bq.query("SELECT SESSION_USER() AS who")
+        rows = list(job.result())
+        assert rows[0]["who"] == "claire@example.com"
+    finally:
+        bq.close()

--- a/tests/e2e/python_client/test_row_access_session_user.py
+++ b/tests/e2e/python_client/test_row_access_session_user.py
@@ -78,7 +78,11 @@ def seeded(bqemu_rest_url: str, bq_admin: bigquery.Client) -> Iterator[None]:
         "(3, 'other.com'), (4, 'other.com')",
     ).result()
     with httpx.Client(base_url=bqemu_rest_url, timeout=30.0) as c:
-        c.post(
+        # ``raise_for_status`` so a broken RAP-creation path fails the
+        # fixture immediately with a clear error instead of cascading
+        # into a later data-mismatch assertion failure that's harder
+        # to debug. (CodeRabbit thread PRRT_kwDOSkfuJ86EVwPD.)
+        response = c.post(
             f"/bigquery/v2/projects/{_PROJECT}/datasets/{_DATASET}"
             "/tables/tenants/rowAccessPolicies",
             json={
@@ -92,6 +96,7 @@ def seeded(bqemu_rest_url: str, bq_admin: bigquery.Client) -> Iterator[None]:
                 "grantees": ["allAuthenticatedUsers"],
             },
         )
+        response.raise_for_status()
     yield None
     with httpx.Client(base_url=bqemu_rest_url, timeout=30.0) as c:
         c.delete(

--- a/tests/integration/test_row_access_policies.py
+++ b/tests/integration/test_row_access_policies.py
@@ -75,19 +75,20 @@ async def _create_policy(
     policy_id: str,
     filter_predicate: str,
     grantees: list[str],
+    table_id: str = "orders",
 ) -> None:
     body = {
         "rowAccessPolicyReference": {
             "projectId": "p",
             "datasetId": "ds",
-            "tableId": "orders",
+            "tableId": table_id,
             "policyId": policy_id,
         },
         "filterPredicate": filter_predicate,
         "grantees": grantees,
     }
     r = await c.post(
-        "/bigquery/v2/projects/p/datasets/ds/tables/orders/rowAccessPolicies",
+        f"/bigquery/v2/projects/p/datasets/ds/tables/{table_id}/rowAccessPolicies",
         json=body,
     )
     r.raise_for_status()
@@ -310,3 +311,154 @@ async def test_x_goog_user_project_fallback(client: httpx.AsyncClient) -> None:
     r.raise_for_status()
     rows = [int(row["f"][0]["v"]) for row in r.json()["rows"]]
     assert rows == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# SESSION_USER() in the RAP filter predicate — ADR 0038
+# ---------------------------------------------------------------------------
+#
+# The canonical "tenant isolation by email domain" production pattern:
+# a RAP filter calls ``SESSION_USER()``, extracts the domain via
+# ``REGEXP_EXTRACT``, and matches it against a per-row tenant key. Real
+# BigQuery users rely on this; the emulator's pre-translator (ADR 0038)
+# substitutes ``SESSION_USER()`` with the caller's resolved email
+# literal before SQLGlot transpiles to DuckDB.
+#
+# These tests seed a SECOND table (``tenants``) with two domains, grant
+# the policy to ``allAuthenticatedUsers`` so the grantee match always
+# passes, and rely on the filter predicate alone for per-caller row
+# visibility — proving the substitution path end-to-end.
+
+
+async def _seed_tenants_table(c: httpx.AsyncClient) -> None:
+    """Create a ``tenants`` table with rows for two email-domain tenants."""
+    await c.post(
+        "/bigquery/v2/projects/p/datasets/ds/tables",
+        json={
+            "tableReference": {
+                "projectId": "p",
+                "datasetId": "ds",
+                "tableId": "tenants",
+            },
+            "schema": {
+                "fields": [
+                    {"name": "id", "type": "INT64"},
+                    {"name": "tenant_id", "type": "STRING"},
+                ],
+            },
+        },
+    )
+    await _run(
+        c,
+        (
+            "INSERT INTO ds.tenants VALUES "
+            "(1, 'example.com'), (2, 'example.com'), "
+            "(3, 'other.com'), (4, 'other.com')"
+        ),
+    )
+
+
+async def _create_session_user_policy(c: httpx.AsyncClient) -> None:
+    """Create the canonical SESSION_USER-driven tenant-isolation RAP."""
+    await _create_policy(
+        c,
+        policy_id="tenant_by_session_user",
+        filter_predicate=("REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id"),
+        grantees=["allAuthenticatedUsers"],
+        table_id="tenants",
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_user_filter_example_com_caller(
+    client: httpx.AsyncClient,
+) -> None:
+    """A ``@example.com`` caller sees only the example.com tenant rows."""
+    await _seed_tenants_table(client)
+    await _create_session_user_policy(client)
+    res = await _run(
+        client,
+        "SELECT id FROM ds.tenants ORDER BY id",
+        caller="user:alice@example.com",
+    )
+    rows = [int(r["f"][0]["v"]) for r in res["rows"]]
+    assert rows == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_session_user_filter_other_com_caller(
+    client: httpx.AsyncClient,
+) -> None:
+    """A ``@other.com`` caller sees only the other.com tenant rows."""
+    await _seed_tenants_table(client)
+    await _create_session_user_policy(client)
+    res = await _run(
+        client,
+        "SELECT id FROM ds.tenants ORDER BY id",
+        caller="user:bob@other.com",
+    )
+    rows = [int(r["f"][0]["v"]) for r in res["rows"]]
+    assert rows == [3, 4]
+
+
+@pytest.mark.asyncio
+async def test_session_user_filter_anonymous_caller_sees_no_rows(
+    client: httpx.AsyncClient,
+) -> None:
+    """No caller header → ``SESSION_USER()`` → 'anonymous' → no match."""
+    await _seed_tenants_table(client)
+    await _create_session_user_policy(client)
+    # The grantee is ``allAuthenticatedUsers`` and the default
+    # caller is *unauthenticated* — the grantee check itself fails
+    # first, so the table reads as "has policies but none match the
+    # caller" → ``WHERE FALSE`` wrap → zero rows.
+    res = await _run(client, "SELECT id FROM ds.tenants")
+    assert res["rows"] == []
+
+
+@pytest.mark.asyncio
+async def test_session_user_filter_service_account_caller(
+    client: httpx.AsyncClient,
+) -> None:
+    """A service-account caller resolves to its full email."""
+    await _seed_tenants_table(client)
+    # The filter predicate matches the part after ``@`` —
+    # service accounts have addresses like
+    # ``svc@example.iam.gserviceaccount.com``, which would *not*
+    # match either tenant_id we seeded. Use a SA whose host happens
+    # to be ``example.com`` to assert the substitution applies the
+    # ``serviceAccount:`` prefix strip + the standard regex extract
+    # (this is unusual in production but is the minimal probe for
+    # the SA path on the e2e wire).
+    await _create_policy(
+        client,
+        policy_id="tenant_sa",
+        filter_predicate=("REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id"),
+        grantees=["allAuthenticatedUsers"],
+        table_id="tenants",
+    )
+    res = await _run(
+        client,
+        "SELECT id FROM ds.tenants ORDER BY id",
+        caller="serviceAccount:job@example.com",
+    )
+    rows = [int(r["f"][0]["v"]) for r in res["rows"]]
+    assert rows == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_bare_select_session_user_returns_caller_email(
+    client: httpx.AsyncClient,
+) -> None:
+    """``SELECT SESSION_USER()`` returns the caller's bare email.
+
+    Not strictly a RAP test, but the same substitution path; pinning
+    it here keeps both surfaces (RAP filter + free-form query) in one
+    place.
+    """
+    res = await _run(
+        client,
+        "SELECT SESSION_USER() AS who",
+        caller="user:claire@example.com",
+    )
+    assert res["rows"][0]["f"][0]["v"] == "claire@example.com"

--- a/tests/unit/sql/rewriter/test_session_user.py
+++ b/tests/unit/sql/rewriter/test_session_user.py
@@ -109,7 +109,10 @@ class TestRewriteSessionUser:
         # path string check is case-insensitive so this still bumps.
         sql = "SELECT session_user() AS who"
         out = rewrite_session_user(sql, self._caller("alice@example.com"))
-        assert "session_user" not in out.lower() or "alice@example.com" in out
+        # Conjunctive assertion (CodeRabbit thread PRRT_kwDOSkfuJ86EVwPG):
+        # both invariants must hold or the regression check is too weak.
+        assert "session_user" not in out.lower()
+        assert "'alice@example.com'" in out
 
     def test_no_session_user_call_is_fast_path_no_op(self) -> None:
         sql = "SELECT 1 + 2 AS x FROM t WHERE y > 3"

--- a/tests/unit/sql/rewriter/test_session_user.py
+++ b/tests/unit/sql/rewriter/test_session_user.py
@@ -1,0 +1,229 @@
+"""Unit tests for the ``SESSION_USER()`` pre-translator (ADR 0038).
+
+Two surfaces pinned:
+
+1. :func:`resolve_session_user` — the pure prefix-stripping helper
+   that maps a :class:`CallerIdentity` to the literal string
+   ``SESSION_USER()`` should return.
+2. :func:`rewrite_session_user` — the SQLGlot AST walk that finds
+   every ``SessionUser`` call site and replaces it with a string
+   literal. Idempotent, parse-failure-tolerant, and a string-side
+   fast-reject when no occurrences exist.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bqemulator.row_access.identity import DEFAULT_CALLER, CallerIdentity
+from bqemulator.sql.rewriter.session_user import (
+    ANONYMOUS_CALLER,
+    resolve_session_user,
+    rewrite_session_user,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# resolve_session_user — every IAM-member shape
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSessionUser:
+    """Prefix-stripping per IAM-member kind matches BigQuery's contract."""
+
+    def test_user_principal_strips_prefix(self) -> None:
+        caller = CallerIdentity(principal="user:alice@example.com")
+        assert resolve_session_user(caller) == "alice@example.com"
+
+    def test_service_account_strips_prefix(self) -> None:
+        caller = CallerIdentity(
+            principal="serviceAccount:sa@svc.iam.gserviceaccount.com",
+        )
+        assert resolve_session_user(caller) == "sa@svc.iam.gserviceaccount.com"
+
+    def test_group_strips_prefix(self) -> None:
+        # ``group:`` callers never appear via the X-Bqemu-Caller header
+        # in practice (groups are grantee-side identifiers), but the
+        # rewriter is tolerant so a misconfigured emulator doesn't
+        # raise. Strip the prefix to keep the function consistent.
+        caller = CallerIdentity(principal="group:admins@example.com")
+        assert resolve_session_user(caller) == "admins@example.com"
+
+    def test_domain_strips_prefix(self) -> None:
+        caller = CallerIdentity(principal="domain:example.com")
+        assert resolve_session_user(caller) == "example.com"
+
+    def test_all_users_passes_through(self) -> None:
+        # Not a real caller — ``allUsers`` is a grantee-side
+        # identifier. The function returns the raw string so a
+        # misconfigured emulator doesn't raise; the value is documented
+        # in the ADR as not BigQuery-faithful for this case.
+        caller = CallerIdentity(principal="allUsers")
+        assert resolve_session_user(caller) == "allUsers"
+
+    def test_all_authenticated_users_passes_through(self) -> None:
+        caller = CallerIdentity(principal="allAuthenticatedUsers")
+        assert resolve_session_user(caller) == "allAuthenticatedUsers"
+
+    def test_unauthenticated_fallback_returns_anonymous_sentinel(self) -> None:
+        # The emulator's default caller (no ``X-Bqemu-Caller`` header)
+        # has ``is_authenticated=False``. Real BigQuery never reaches
+        # this branch — every API call is authenticated — but the
+        # emulator routes queries without identity to the
+        # :data:`ANONYMOUS_CALLER` literal so RAP policies that
+        # compare ``SESSION_USER()`` against a tenant key deny every
+        # row instead of leaking via a stale principal.
+        caller = CallerIdentity(principal=DEFAULT_CALLER, is_authenticated=False)
+        assert resolve_session_user(caller) == ANONYMOUS_CALLER
+
+    def test_authenticated_anonymous_principal_strips_prefix(self) -> None:
+        # If someone manually constructs an authenticated caller that
+        # happens to use the ``DEFAULT_CALLER`` principal string, we
+        # treat it as authenticated and strip the prefix. The
+        # ``is_authenticated`` flag is the source of truth.
+        caller = CallerIdentity(principal=DEFAULT_CALLER, is_authenticated=True)
+        assert resolve_session_user(caller) == "anonymous@bqemulator.local"
+
+
+# ---------------------------------------------------------------------------
+# rewrite_session_user — SQL-level substitution
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteSessionUser:
+    """``rewrite_session_user`` substitutes every call site with a literal."""
+
+    def _caller(self, email: str = "alice@example.com") -> CallerIdentity:
+        return CallerIdentity(principal=f"user:{email}")
+
+    def test_bare_select_session_user(self) -> None:
+        sql = "SELECT SESSION_USER() AS who"
+        out = rewrite_session_user(sql, self._caller("alice@example.com"))
+        assert "SESSION_USER" not in out.upper()
+        assert "'alice@example.com'" in out
+
+    def test_lower_case_session_user(self) -> None:
+        # BigQuery accepts ``session_user()`` (lower-case). The fast-
+        # path string check is case-insensitive so this still bumps.
+        sql = "SELECT session_user() AS who"
+        out = rewrite_session_user(sql, self._caller("alice@example.com"))
+        assert "session_user" not in out.lower() or "alice@example.com" in out
+
+    def test_no_session_user_call_is_fast_path_no_op(self) -> None:
+        sql = "SELECT 1 + 2 AS x FROM t WHERE y > 3"
+        out = rewrite_session_user(sql, self._caller())
+        # Returns the same string object identity — the fast-path
+        # check short-circuited before parsing.
+        assert out is sql
+
+    def test_session_user_inside_regexp_extract(self) -> None:
+        # The canonical RAP-filter pattern.
+        sql = "SELECT * FROM t WHERE REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = 'example.com'"
+        out = rewrite_session_user(sql, self._caller("bob@example.com"))
+        assert "SESSION_USER" not in out.upper()
+        assert "'bob@example.com'" in out
+
+    def test_multiple_call_sites_all_substituted(self) -> None:
+        sql = (
+            "SELECT SESSION_USER() AS a, "
+            "CONCAT('hi ', SESSION_USER()) AS b "
+            "FROM t WHERE SESSION_USER() = 'me'"
+        )
+        out = rewrite_session_user(sql, self._caller("c@example.com"))
+        # Three replacements; none of the ``SessionUser`` AST nodes
+        # should survive.
+        assert "SESSION_USER" not in out.upper()
+        assert out.lower().count("c@example.com") == 3
+
+    def test_idempotent_second_pass_is_noop(self) -> None:
+        sql = "SELECT SESSION_USER() AS who"
+        caller = self._caller("a@example.com")
+        once = rewrite_session_user(sql, caller)
+        twice = rewrite_session_user(once, caller)
+        # Second pass sees no ``SESSION_USER`` in the SQL — the
+        # fast-path returns the same object identity.
+        assert twice is once
+
+    def test_unparseable_sql_returns_input_unchanged(self) -> None:
+        # The rewriter must not swallow parse errors — the downstream
+        # SQLGlot transpile is the right layer to surface them.
+        sql = "SELECT SESSION_USER() FROM (((unbalanced"
+        caller = self._caller()
+        out = rewrite_session_user(sql, caller)
+        assert out == sql
+
+    def test_unauthenticated_caller_substitutes_anonymous_literal(self) -> None:
+        sql = "SELECT SESSION_USER() AS who"
+        caller = CallerIdentity(principal=DEFAULT_CALLER, is_authenticated=False)
+        out = rewrite_session_user(sql, caller)
+        assert "'anonymous'" in out
+
+    def test_service_account_caller_substitutes_full_email(self) -> None:
+        sql = "SELECT SESSION_USER() AS who"
+        caller = CallerIdentity(
+            principal="serviceAccount:job@p.iam.gserviceaccount.com",
+        )
+        out = rewrite_session_user(sql, caller)
+        assert "'job@p.iam.gserviceaccount.com'" in out
+
+    def test_session_user_in_string_literal_not_rewritten(self) -> None:
+        # ``"SESSION_USER"`` inside a string literal is not a function
+        # call — SQLGlot's AST doesn't model it as a ``SessionUser``
+        # node, so the rewriter leaves it alone.
+        sql = "SELECT 'SESSION_USER()' AS literal"
+        out = rewrite_session_user(sql, self._caller())
+        assert "'SESSION_USER()'" in out
+
+    def test_session_user_in_view_query_body_substituted(self) -> None:
+        # The CREATE VIEW body itself isn't a call context, but its
+        # SELECT is. The pre-translator rewrites the AST walk through
+        # the SELECT.
+        sql = "CREATE VIEW v AS SELECT SESSION_USER() AS who"
+        out = rewrite_session_user(sql, self._caller("v@example.com"))
+        assert "SESSION_USER" not in out.upper()
+        assert "'v@example.com'" in out
+
+
+# ---------------------------------------------------------------------------
+# Translator integration — through the full pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestTranslatorIntegration:
+    """``SQLTranslator.translate`` runs the rewriter as a pre-translator pass.
+
+    These tests verify the wiring; the rewriter itself is fully unit-
+    tested in :class:`TestRewriteSessionUser` above. The integration
+    tests stay focused on the contract: when ``caller`` is supplied,
+    every ``SESSION_USER()`` call site lands as the resolved email
+    literal in the DuckDB output.
+    """
+
+    def test_translator_substitutes_session_user(self) -> None:
+        from bqemulator.domain.result import Ok
+        from bqemulator.sql.translator import SQLTranslator
+
+        translator = SQLTranslator()
+        caller = CallerIdentity(principal="user:alice@example.com")
+        result = translator.translate(
+            "SELECT SESSION_USER() AS who",
+            caller=caller,
+        )
+        assert isinstance(result, Ok)
+        assert "'alice@example.com'" in result.value
+        # DuckDB's native ``SESSION_USER`` resolves to ``'duckdb'`` —
+        # if the rewriter ever stops running, the output below would
+        # carry the bare ``SESSION_USER`` identifier and DuckDB would
+        # return ``'duckdb'``. Pin against that regression.
+        assert "SESSION_USER" not in result.value.upper()
+
+    def test_translator_without_caller_uses_anonymous_fallback(self) -> None:
+        from bqemulator.domain.result import Ok
+        from bqemulator.sql.translator import SQLTranslator
+
+        translator = SQLTranslator()
+        result = translator.translate("SELECT SESSION_USER() AS who")
+        assert isinstance(result, Ok)
+        assert "'anonymous'" in result.value


### PR DESCRIPTION
## Summary

- New ``rewrite_session_user`` pre-translator pass substitutes ``SESSION_USER()`` with the resolved caller email literal *before* SQLGlot transpiles BigQuery → DuckDB.
- ``SQLTranslator.translate`` gains an optional ``caller: CallerIdentity | None`` kwarg threaded through five call sites that already construct caller identity.
- 21 unit tests + 5 integration tests + 4 new e2e tests (Python, Node, Go, Java) cover the canonical ``REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id`` RAP filter pattern end-to-end.
- ADR 0038 documents the three options considered, the chosen approach, and three out-of-scope items.

## Why this is the gap

``docs/reference/conformance-coverage-matrix.md`` showed ``SESSION_USER`` as ``⚪ Excluded by ADR 0022 §1.2 — session-state dependent. Exercised at the unit tier.`` The last sentence was aspirational — the unit-tier coverage didn't exist, the function was never implemented, and DuckDB's native ``SESSION_USER`` returns the literal ``'duckdb'`` (verified — it's the DuckDB connection's OS identity, not the BigQuery caller). Any RAP filter built on ``SESSION_USER()`` would silently deny every legitimate caller. This PR closes the gap with both implementation and end-to-end client coverage.

## Implementation strategy — Option A (pre-translator)

The chip prompt offered three options:
- **A** — SQL pre-translator (with caller threading). ✅ **Chosen.**
- **B** — RAP-rewriter-only substitution. Rejected: narrower than BigQuery's contract; ``SELECT SESSION_USER()`` would fail with ``UnsupportedFeatureError``.
- **C** — DuckDB scalar UDF reading a session variable. Rejected: per-call state plumbing through a UDF context is more invasive than threading ``caller`` directly.

Option A wins on three axes:
1. **BigQuery semantic fidelity** — works everywhere SQL runs, not just inside RAP filters.
2. **Existing infrastructure reuse** — ``CallerIdentity`` already threaded through ``rewrite_for_row_access``.
3. **Smallest concept surface** — additive optional kwarg + a single rewriter module.

The cost is plumbing ``caller`` through five call sites; each change is additive (``None`` default folds to the unauthenticated fallback).

## Resolution contract

| Caller shape | Returned literal |
|---|---|
| ``is_authenticated == False`` | ``"anonymous"`` (sentinel — RAP filters deny safely) |
| ``user:alice@example.com`` | ``"alice@example.com"`` |
| ``serviceAccount:sa@project.iam.gserviceaccount.com`` | ``"sa@project.iam.gserviceaccount.com"`` |
| ``group:`` / ``domain:`` | bare email/host (defensive; never via header in practice) |
| ``allUsers`` / ``allAuthenticatedUsers`` / unknown | raw principal passthrough |

## Coverage

| Tier | File | Cases |
|---|---|---|
| Unit | ``tests/unit/sql/rewriter/test_session_user.py`` | 21 — IAM shapes, multi-site, idempotent, fast-path, lower-case, view-body, unparseable-passthrough, translator integration |
| Integration | ``tests/integration/test_row_access_policies.py`` | 5 — ``@example.com`` / ``@other.com`` / unauthenticated / service-account / bare ``SELECT SESSION_USER()`` |
| E2E — Python | ``tests/e2e/python_client/test_row_access_session_user.py`` | 3 |
| E2E — Node.js | ``tests/e2e/nodejs_client/test/row_access_session_user.test.js`` | 3 |
| E2E — Go | ``tests/e2e/go_client/row_access_session_user_test.go`` | 2 |
| E2E — Java | ``tests/e2e/java_client/src/test/java/com/example/RowAccessSessionUserTest.java`` | 3 |
| ``bq`` CLI | Skipped per existing module docstring (the CLI doesn't set ``X-Bqemu-Caller``); skip language extended with pointer to PR C's e2e files |

## Docs

- New [ADR 0038](docs/adr/0038-session-user.md) — full decision context.
- ``mkdocs.yml`` nav updated.
- ``CHANGELOG.md`` ``[Unreleased]`` Added entry.
- ``tests/conformance/_surface_inventory.py`` — SESSION_USER's note now reads "Exercised at the unit, integration, and e2e × 4 client tiers (ADR 0038)".
- Auto-generated reference docs regenerated via ``make coverage-matrix function-mapping`` (never hand-edited per AGENTS.md).

## Out of scope (per ADR 0038)

- ``CURRENT_USER`` and ``@@session.user`` (deprecated / system-variable spellings). One function per PR.
- ``SESSION_USER()`` inside SQL UDF bodies — UDFs pre-translated at definition time when no caller exists; folds to ``"anonymous"`` permanently. Documented as a known limitation in the rewriter docstring.
- Storage Read ``row_restriction`` filter pre-pass (``grpc_api/read_servicer.py:122``) — doesn't yet receive caller context; folds to ``"anonymous"``. The canonical SESSION_USER use is RAP filters, not Storage Read filters. Documented as a known limitation in ADR 0038's Negative consequences.
- Conformance corpus fixture — SESSION_USER stays excluded by ADR 0022 §1.2; the unit + integration + e2e × 4 tiers cover the surface.

## Verification

- ``make lint`` — green (auto-formatted three new test files; final pass clean).
- ``make test-unit`` — **2542 passed**.
- ``make test-coverage`` — **91.33%** combined (gate 90%).
- ``make test-patch-coverage`` — **97%** on diff (gate 70%).
- ``make verify`` — **all release-readiness gates passed** (lint → quality-complexity → unit → property → integration → drift → docker-build → e2e × 5 clients → mkdocs --strict). End-to-end ~20 min wall-clock.
- Drift gates (coverage-matrix-check / compat-matrix-check / function-mapping-check / api-coverage-check) — all clean after the matrix regeneration.

## Acceptance criteria

- [x] ``SESSION_USER()`` callable from SQL; returns the bare email per BigQuery's contract.
- [x] ADR 0038 documents option choice + resolution contract + unauthenticated fallback.
- [x] Unit tests for every IAM-member shape (user, serviceAccount, group, domain, allUsers, allAuthenticatedUsers, anonymous fallback).
- [x] Integration test for the canonical RAP filter pattern through the in-process emulator with multiple callers.
- [x] Four new e2e tests (Python, Node, Go, Java) exercising the same RAP filter pattern.
- [x] ``bq`` CLI suite extended with skip-with-pointer to PR C's e2e files.
- [x] ``_surface_inventory.py`` SESSION_USER note updated; ``make coverage-matrix function-mapping`` re-run + diffs committed.
- [x] ADR 0038 committed; mkdocs nav updated; CHANGELOG ``[Unreleased]`` Added.
- [x] ``make verify`` passes end-to-end.

## Test plan

- [x] Bare ``SELECT SESSION_USER()`` returns the caller's bare email through every client (Python/Node/Go/Java).
- [x] RAP filter ``REGEXP_EXTRACT(SESSION_USER(), r'@(.+)$') = tenant_id`` grants per-domain visibility.
- [x] Unauthenticated callers see zero rows under the canonical RAP pattern.
- [x] Service-account caller resolves to its full email.
- [x] Bare ``SESSION_USER()`` in a view body resolves correctly.
- [x] Idempotent re-runs of the rewriter are byte-stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SESSION_USER() now resolves to the caller's email (or "anonymous" for unauthenticated requests).
  * Row Access Policies can use SESSION_USER() in filter predicates to enforce caller-based row filtering.

* **Documentation**
  * Added ADR documenting SESSION_USER() substitution and updated CHANGELOG with scope and known limitations.

* **Tests**
  * Added unit, integration, and end-to-end tests across Python, Node, Go, and Java validating SESSION_USER() behavior in queries and RAP filters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->