### PR TITLE
chore(ci): SHA-pin github/codeql-action in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,10 +23,18 @@ jobs:
         language: [python]
     steps:
       - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v4
+      # Pin ``github/codeql-action`` by commit SHA per the OpenSSF
+      # Scorecard alignment rule (AGENTS.md): only first-party
+      # ``actions/*`` may use floating major tags; everything else,
+      # including ``github/*``, gets a full SHA + trailing
+      # ``# vX.Y.Z`` comment. Dependabot already monitors
+      # ``.github/workflows/*.yml`` so this pin moves forward
+      # automatically. Bumps the Scorecard ``Pinned-Dependencies``
+      # check that PR #48 (ADR 0037) introduced.
+      - uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: /language:${{ matrix.language }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,20 @@ section and adds the release date.
 
 ### Changed
 
+- **`github/codeql-action` pinned by full commit SHA** in
+  `.github/workflows/codeql.yml`. Previously used floating
+  `@v4` major tags for `init` and `analyze`, which AGENTS.md's
+  OpenSSF-alignment rule already prohibited for non-first-party
+  actions; surfaced as pre-existing tech debt in PR #48's
+  description (ADR 0037). Now pinned to
+  `github/codeql-action/{init,analyze}@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0`
+  matching the `upload-sarif` pin the Scorecard workflow uses.
+  Bumps the OpenSSF Scorecard `Pinned-Dependencies` check on the
+  initial-publish run so the public score starts higher rather
+  than dragging in a follow-up. Dependabot already monitors
+  `.github/workflows/*.yml` so the SHA moves forward
+  automatically.
+
 - **lychee retry budget bumped** in `.lychee.toml` — `max_retries` 2→4,
   `retry_wait_time` 3s→10s. Calibrated against the v1.0.2 release CI
   cycle (PR #43, 2026-05-23) where lychee hit repeated `502 Bad Gateway`


### PR DESCRIPTION
## Summary

PR #48 (ADR 0037) surfaced this as pre-existing tech debt: ``codeql.yml`` used floating ``@v4`` major tags for ``github/codeql-action/{init,analyze}``, which AGENTS.md's OpenSSF-alignment rule already prohibited (only first-party ``actions/*`` may use major tags; ``github/*`` requires a full commit SHA + trailing ``# vX.Y.Z`` comment).

Pin both steps to v4.36.0 — the same SHA the new ``scorecard.yml`` workflow uses for ``upload-sarif``:

```yaml
- uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
- uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
```

## Why now

Lands **before v1.1.0 cuts** so the OpenSSF Scorecard ``Pinned-Dependencies`` check sees the cleaned-up workflows on its **initial public scoring run** (the Scorecard workflow was just added in PR #48; first score populates ~24-48 h after that PR merged). Without this pin, the initial public score would land lower and a follow-up PR would be needed to recover it the next scoring cycle.

## Verification

- ``make lint`` — green.
- ``python -c "import yaml; yaml.safe_load(open('.github/workflows/codeql.yml'))"`` — YAML syntactically valid.
- ``lychee CHANGELOG.md`` — 14 OK, 0 errors on the new ``[Unreleased]`` Changed entry.
- ``gh api repos/github/codeql-action/git/tags/$(gh api repos/github/codeql-action/git/refs/tags/v4.36.0 --jq '.object.sha')`` — confirmed SHA ``7211b7c8077ea37d8641b6271f6a365a22a5fbfa`` resolves to v4.36.0 commit. Same SHA already in production via ``.github/workflows/scorecard.yml``.

``make verify`` skipped per the change scope — touches only the GitHub Actions workflow YAML, which ``make verify`` doesn't exercise (the workflow itself runs on CI on this PR's HEAD, which is the actual validator).

## Dependabot

``.github/dependabot.yml`` already monitors ``.github/workflows/*.yml`` so the SHA moves forward automatically on each upstream release.

## Acceptance criteria

- [x] Both ``github/codeql-action`` steps SHA-pinned with ``# vX.Y.Z`` trailing comment matching the project-wide OpenSSF-alignment convention.
- [x] Same SHA used as ``scorecard.yml``'s ``upload-sarif`` step — single source of truth for the bump cycle.
- [x] CHANGELOG ``[Unreleased]`` Changed entry.

## Out of scope

- No ADR — this is the closure of a tech-debt note from ADR 0037, not a new architectural decision.
- No other workflows touched — all other third-party action uses in this repo are already SHA-pinned (verified earlier in the session).

## Test plan

- [x] YAML parses.
- [x] SHA resolves to v4.36.0.
- [x] CodeQL workflow runs on this PR head (CI proves the new pin works).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions CodeQL workflow configuration with pinned dependency versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->