### PR TITLE
chore(ci): widen Quality gates path filter to unblock workflow/example PRs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -27,7 +27,17 @@ on:
       - ".vulture_whitelist.py"
       - ".jscpd.json"
       - "Makefile"
-      - ".github/workflows/code-quality.yml"
+      # Run on every workflow / dependabot example change too, so the
+      # ``Quality gates`` job emits a status on PRs that only touch
+      # ``.github/workflows/*`` or ``docs/examples/**``. Without these
+      # patterns the required-check is "missing" rather than green for
+      # those PRs and even ``gh pr merge --admin`` can't bypass it
+      # (GitHub treats a never-reported required-check as unresolvable).
+      # Worst case: ~1 min of unnecessary quality-complexity run on a
+      # workflow- or dependabot-only PR — cheap relative to the
+      # never-merge blocker the prior filter caused.
+      - ".github/workflows/**"
+      - "docs/examples/**"
   push:
     branches: [main]
     paths:
@@ -37,7 +47,17 @@ on:
       - ".vulture_whitelist.py"
       - ".jscpd.json"
       - "Makefile"
-      - ".github/workflows/code-quality.yml"
+      # Run on every workflow / dependabot example change too, so the
+      # ``Quality gates`` job emits a status on PRs that only touch
+      # ``.github/workflows/*`` or ``docs/examples/**``. Without these
+      # patterns the required-check is "missing" rather than green for
+      # those PRs and even ``gh pr merge --admin`` can't bypass it
+      # (GitHub treats a never-reported required-check as unresolvable).
+      # Worst case: ~1 min of unnecessary quality-complexity run on a
+      # workflow- or dependabot-only PR — cheap relative to the
+      # never-merge blocker the prior filter caused.
+      - ".github/workflows/**"
+      - "docs/examples/**"
   schedule:
     - cron: "13 7 * * *"  # 07:13 UTC — off the hour to avoid contention
   workflow_dispatch:


### PR DESCRIPTION
## Summary

PR #49 (dependabot grpc bump in ``docs/examples/go/beam-pipeline``) and PR #51 (``codeql.yml`` SHA-pin) both hit ``mergeStateStatus: BLOCKED`` because the required ``Quality gates`` check (from ``code-quality.yml``) didn't run — the existing ``paths:`` filter only triggered on Python source / config changes, not on ``.github/workflows/**`` or ``docs/examples/**``.

**GitHub treats a never-reported required-check as unresolvable**: even ``gh pr merge --admin`` returns ``"Required status check 'Quality gates' is expected"``. The only fix is to make the workflow actually emit a status on those paths.

## What lands

``code-quality.yml`` ``paths:`` filter widens to also match:
- ``.github/workflows/**`` — so any workflow YAML change (codeql / scorecard / e2e / ci.yml family) triggers Quality gates.
- ``docs/examples/**`` — so Dependabot bumps and operator-side example tweaks trigger Quality gates.

Both blocks updated (``pull_request`` + ``push``).

## Cost

~1 minute of unnecessary xenon complexity run on a workflow- or dependabot-only PR. Source tree hasn't changed, so xenon just re-checks the existing complexity baseline. Vastly cheaper than the never-merge blocker the prior filter caused.

## Why this PR isn't itself blocked

This PR touches ``.github/workflows/code-quality.yml``, which is **already** in the existing ``paths:`` filter (line 30). So ``Quality gates`` runs on this PR.

## After merge

PR #49 and PR #51 need a small nudge to re-trigger CI against the new path filter:
1. ``gh workflow run code-quality.yml --ref <branch>`` against each PR's head branch, OR
2. Push an empty commit to each PR (``git commit --allow-empty``), OR
3. Close-and-reopen the PR (last resort; loses reviewer thread state).

Option 1 is the cleanest. The maintainer will run it after this PR merges.

## Verification

- ``python -c "import yaml; yaml.safe_load(open('.github/workflows/code-quality.yml'))"`` — YAML syntactically valid.
- ``grep`` confirms ``.github/workflows/**`` and ``docs/examples/**`` present in both ``pull_request`` and ``push`` blocks.
- This PR's own CI will exercise the path filter (modifies code-quality.yml, which is in the existing filter list).

``make verify`` skipped per the change scope — touches only a single workflow YAML file. The actual validation is the workflow run itself on this PR's HEAD.

## Out of scope

- No ADR (single workflow YAML config change).
- No CHANGELOG entry (CI-only, not user-visible behavior).
- The broader "skip-success pattern" GitHub recommends for required-but-path-filtered checks. That's the durable architectural fix; this PR is the minimal-blast fix to unblock #49 + #51.

## Acceptance criteria

- [x] ``code-quality.yml`` paths include ``.github/workflows/**`` + ``docs/examples/**`` in both trigger blocks.
- [x] YAML parses.
- [x] ``Quality gates`` runs on this PR.
- [ ] After merge: re-trigger ``code-quality.yml`` on PR #49 and PR #51's branches; both produce green ``Quality gates``; both can then be merged normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated quality gate workflow triggers to run when workflow configuration files and documentation examples are modified, in addition to existing source code and test paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->