### PR TITLE
chore(ci): broaden Quality gates filter to all docs + top-level markdown

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -37,7 +37,10 @@ on:
       # workflow- or dependabot-only PR — cheap relative to the
       # never-merge blocker the prior filter caused.
       - ".github/workflows/**"
-      - "docs/examples/**"
+      - "docs/**"
+      - "CHANGELOG.md"
+      - "README.md"
+      - "mkdocs.yml"
   push:
     branches: [main]
     paths:
@@ -57,7 +60,10 @@ on:
       # workflow- or dependabot-only PR — cheap relative to the
       # never-merge blocker the prior filter caused.
       - ".github/workflows/**"
-      - "docs/examples/**"
+      - "docs/**"
+      - "CHANGELOG.md"
+      - "README.md"
+      - "mkdocs.yml"
   schedule:
     - cron: "13 7 * * *"  # 07:13 UTC — off the hour to avoid contention
   workflow_dispatch:


### PR DESCRIPTION
Sequel to PR #53. PR #52 (TPC-DS expansion plan doc) hit the same never-reported-required-check wall because docs-only PRs that touch ``docs/architecture/**`` / ``CHANGELOG.md`` / ``mkdocs.yml`` still didn't match any path in the filter.

This PR broadens once more:
- Collapse ``docs/examples/**`` → ``docs/**`` (catches architecture / contributing / reference / examples / adr in one pattern)
- Add ``CHANGELOG.md`` (every observable PR touches this)
- Add ``README.md`` (version-bump / badge PRs)
- Add ``mkdocs.yml`` (nav additions)

After this lands, any future PR (regardless of path) triggers Quality gates and is mergeable. Worst case: ~1 min of `Quality gates` run on a docs-only PR — cheap relative to never-merge blocker.

`Quality gates` runs on this PR because it touches `.github/workflows/code-quality.yml` (in the existing filter).

After merge, I'll push empty commits to PR #51 and #52 to retrigger CI under the broader filter, then merge each in turn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions code-quality workflow configuration so checks now run when top-level documentation and project metadata files are changed, broadening the trigger scope beyond example docs. This ensures documentation or configuration edits will invoke the quality gates more reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->