### PR TITLE
feat(security): SLSA Build Provenance attestations on GitHub Release (ADR 0039)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,7 +60,7 @@ jobs:
             cosign sign --yes "${tag}@${DIGEST}"
           done
       - name: Generate SLSA attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/jjviscomi/bqemulator
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,28 @@ jobs:
         with:
           name: dist
           path: dist/
+      # Generate a SLSA Build Provenance attestation covering every
+      # file in ``dist/`` (wheel + sdist). The action signs via
+      # sigstore keyless OIDC and stores the bundle on GitHub's
+      # native attestations API. The resulting ``.intoto.jsonl``
+      # bundle is then attached to the GitHub Release alongside
+      # the artifacts so OpenSSF Scorecard's ``Signed-Releases``
+      # check sees a signature file at the standard location and
+      # marks the release as signed. See
+      # [ADR 0039](../../docs/adr/0039-artifact-attestations.md).
+      #
+      # PyPI gets its own sigstore attestations via Trusted
+      # Publishing (``attestations: true`` in the publish-pypi job
+      # above) — this attestation is the GitHub-Release-side
+      # parallel, so Scorecard's release-asset scan can see it.
+      - name: Attest build provenance for dist artifacts
+        id: attest
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: 'dist/*'
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: dist/*
+          files: |
+            dist/*
+            ${{ steps.attest.outputs.bundle-path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           attestations: true
 
@@ -76,7 +76,7 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: 'dist/*'
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       # parallel, so Scorecard's release-asset scan can see it.
       - name: Attest build provenance for dist artifacts
         id: attest
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: 'dist/*'
       - uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,33 @@ section and adds the release date.
   92-rule translator (verified against the existing 59-fixture
   subset).
 
+- **SLSA Build Provenance attestations on GitHub Release assets**
+  (ADR 0039). Closes the ``Signed-Releases`` gap OpenSSF Scorecard
+  flagged after the v1.0.2 release: the workflow now runs
+  ``actions/attest-build-provenance@a2bbfa25 # v4.1.0`` against
+  ``dist/*`` in the ``github-release`` job of
+  ``.github/workflows/release.yml``, produces a ``.intoto.jsonl``
+  SLSA v1.0 Build Provenance bundle, and uploads the bundle to the
+  GitHub Release alongside the wheel + sdist. Consumers verify
+  with ``gh attestation verify <file> --owner jjviscomi``.
+  ``.github/workflows/docker.yml``'s existing
+  ``attest-build-provenance`` call also bumped — from floating
+  ``@v1`` (SLSA v0.2 schema) to the same SHA-pinned ``@v4.1.0``
+  (SLSA v1.0 schema) for cross-workflow consistency. Both call
+  sites are now full-commit-SHA-pinned per OpenSSF Scorecard's
+  strict ``Pinned-Dependencies`` reading (Scorecard gives full
+  credit for commit-SHA even on first-party ``actions/*``;
+  AGENTS.md's relaxed-major-tag rule for ``actions/*`` was a
+  pragmatic compromise, not the ceiling). PyPI's own sigstore
+  attestations via Trusted Publishing are preserved unchanged —
+  the GitHub-Release attestation is the GitHub-visible parallel,
+  not a replacement. Expected Scorecard
+  ``Signed-Releases`` score trajectory: 0/10 today → 2/10 after
+  v1.1.0 → 10/10 after v1.1.4 (the check inspects the last 5
+  releases; tags are immutable so prior releases can't be
+  retroactively attested). Composite Scorecard score lift ~+1.5
+  immediately, ~+2.5 by v1.1.4.
+
 - **`SESSION_USER()` SQL function + canonical RAP-via-SESSION_USER
   e2e coverage** (ADR 0038). The function was documented in the
   surface inventory but had zero implementation and zero tests —

--- a/_typos.toml
+++ b/_typos.toml
@@ -52,6 +52,11 @@ ND = "ND"
 # timezone-parsing fixtures and the error-mapper's rationale comment
 # documenting how DuckDB and BigQuery diverge on this abbreviation.
 IST = "IST"
+# SLSA Build Provenance attestation files use the canonical
+# ``.intoto.jsonl`` extension (named after the in-toto framework).
+# Appears in ADR 0039 + the release.yml workflow as a filename, not
+# a typo for "in-too" or similar.
+intoto = "intoto"
 
 [default.extend-identifiers]
 STRUCTs = "STRUCTs"

--- a/docs/adr/0039-artifact-attestations.md
+++ b/docs/adr/0039-artifact-attestations.md
@@ -38,11 +38,20 @@ carry a discoverable signature.
 
 ## Decision
 
-Add ``actions/attest-build-provenance@v3`` to the ``github-release``
+Add ``actions/attest-build-provenance`` to the ``github-release``
 job in ``.github/workflows/release.yml``, run it on every file under
 ``dist/`` (the wheel + sdist), and upload the resulting
 ``.intoto.jsonl`` SLSA Build Provenance bundle to the GitHub Release
-alongside the artifacts.
+alongside the artifacts. Pin by full commit SHA + trailing
+``# vX.Y.Z`` comment per the OpenSSF-Scorecard-strict reading of
+AGENTS.md (see "SHA pinning even for actions/*" below); same pin
+applied to the existing ``docker.yml`` call site for consistency.
+
+The pinned version is
+``actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0``
+— the latest stable as of 2026-05-23, producing SLSA Build
+Provenance v1.0 schema. Dependabot already monitors
+``.github/workflows/*.yml`` so the SHA moves forward automatically.
 
 The workflow now:
 
@@ -76,9 +85,13 @@ signed.
 
 Option A wins on three axes:
 
-1. **First-party GitHub action** (``actions/*``) — major-tag pinning
-   allowed per AGENTS.md OpenSSF-alignment rule. Dependabot
-   maintains it.
+1. **First-party GitHub action** (``actions/*``) — actively
+   maintained by GitHub itself + Dependabot tracks it. Pinned by
+   full commit SHA in this PR despite AGENTS.md's relaxed
+   major-tag rule for ``actions/*``, because OpenSSF Scorecard's
+   ``Pinned-Dependencies`` check rewards commit-SHA pinning
+   regardless of action provenance (see SHA-pinning section
+   below).
 2. **SLSA v1.0 provenance** — strictly more information than a bare
    signature (includes builder identity, source repo, ref, workflow
    run URL). Future SLSA-aware tools (deps.dev, in-toto verifiers)
@@ -87,16 +100,25 @@ Option A wins on three axes:
    verify`` ships with the GitHub CLI; no separate sigstore install
    required by consumers.
 
-## Why this PR doesn't touch ``docker.yml``
+## Why this PR also touches ``docker.yml``
 
-``docker.yml`` already runs ``actions/attest-build-provenance@v1``
-against the container image digest (line 63), and Scorecard
-already credits the container image as signed. The asymmetry was
-purely on the PyPI wheel / GitHub Release side. Bumping
-``docker.yml``'s pin from v1 → v3 is a parallel improvement
-(SLSA v0.2 → v1.0 schema) but unrelated to closing the
-``Signed-Releases`` gap; it's a follow-up if the maintainer wants
-the newer schema, not a prerequisite.
+``docker.yml`` already runs ``actions/attest-build-provenance``
+against the container image digest, but at floating ``@v1`` (SLSA
+Build Provenance v0.2 schema). Two reasons to roll the bump into
+this same PR:
+
+1. **Consistency**: both call sites should target the same
+   version. Splitting them creates a window where the wheel +
+   sdist attestation uses SLSA v1.0 while the container
+   attestation still uses v0.2 — confusing for verifiers.
+2. **Single SHA pin to maintain**: Dependabot bumps a pin in N
+   files at once, so having both at the same SHA from day one
+   keeps the cycle clean.
+
+The bump moves ``docker.yml`` from floating ``@v1`` → SHA-pinned
+``@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0``. SLSA v1.0
+is a strictly richer schema than v0.2; downstream verifiers
+recognise both, so this is forward-compatible.
 
 ## Expected Scorecard impact
 
@@ -142,13 +164,30 @@ resulting ``.intoto.jsonl`` contains one statement per file (each
 with its sha256 digest). Consumers verifying any specific file get
 the same bundle; the action de-duplicates the upload step.
 
-### Why ``@v3`` (not ``@v1`` to match docker.yml)
+### SHA pinning even for ``actions/*``
 
-``actions/attest-build-provenance@v3`` produces SLSA Build
-Provenance v1.0 — the current standard schema. v1 produces SLSA
-v0.2 which is technically deprecated though Scorecard still
-recognises it. New code should target v1.0; the ``docker.yml``
-``@v1`` is pre-existing tech debt for a separate bump PR.
+AGENTS.md's OpenSSF-alignment rule allows first-party ``actions/*``
+to use floating major tags (``@v4``) on the rationale that
+Dependabot tracks them aggressively. That rule is a pragmatic
+compromise, not the ceiling. **OpenSSF Scorecard's
+``Pinned-Dependencies`` check gives full credit for commit-SHA
+pinning regardless of action provenance**; major-tag pins earn
+partial credit. For Scorecard score optimisation (which is the
+proximate driver of this PR), SHA-pinning is strictly better.
+
+Decision: SHA-pin ``actions/attest-build-provenance`` in both
+``release.yml`` and ``docker.yml``. The pre-existing
+``actions/checkout@v4`` / ``actions/setup-python@v5`` /
+``actions/upload-artifact@v8`` etc. major-tag pins are
+out-of-scope for this PR (separate sweep if we want to maximise
+the ``Pinned-Dependencies`` score).
+
+### Why v4.1.0 (the latest)
+
+v4.1.0 (released 2026-02-26) is the current stable. Earlier v3.x
+also produces SLSA v1.0 but lacks fixes for two edge cases the v4
+line addressed (multi-subject batch upload + transparency-log
+inclusion proof). No reason to pin to anything older than v4.1.0.
 
 ### Why the bump in ``softprops/action-gh-release``'s ``files:`` is
 multi-line
@@ -190,8 +229,9 @@ together.
   signatures via ``pip install`` verification flows. The
   GitHub-Release attestation is the GitHub-visible parallel — not a
   replacement.
-* ``docker.yml`` continues at ``@v1``; the parallel-v3 bump is
-  documented as out of scope.
+* ``docker.yml`` updated to the same SHA-pinned v4.1.0 as the new
+  ``release.yml`` step — both call sites are now consistent (same
+  schema, same pinned commit, same Dependabot upgrade cadence).
 
 ## Alternatives considered
 

--- a/docs/adr/0039-artifact-attestations.md
+++ b/docs/adr/0039-artifact-attestations.md
@@ -1,0 +1,219 @@
+# ADR 0039: SLSA Build Provenance attestations on GitHub Release assets
+
+- **Status**: Accepted
+
+## Context
+
+OpenSSF Scorecard (adopted by [ADR 0037](0037-openssf-scorecard.md))
+scores the project's release-signing posture via the
+``Signed-Releases`` check. The check inspects the **last 5 GitHub
+Releases** and looks for signature files attached as release assets:
+``.sig`` / ``.asc`` / ``.minisig`` / ``.sigstore`` / ``.intoto.jsonl``
+suffixes. A release counts as "signed" only when one of these files
+is attached **on the GitHub Release itself**, not on the downstream
+distribution.
+
+Pre-PR audit of the project's signing surface revealed three
+asymmetries:
+
+* ✅ **GHCR container image** — already attested via
+  ``actions/attest-build-provenance@v1`` in
+  ``.github/workflows/docker.yml``, plus a cosign keyless signature
+  via OIDC. Scorecard recognises both.
+* ✅ **PyPI wheel + sdist** — sigstore-attested via Trusted
+  Publishing (``attestations: true`` on ``pypa/gh-action-pypi-publish``
+  in ``.github/workflows/release.yml``). The attestations live on
+  PyPI's side and are visible to ``pypi`` / ``sigstore`` tooling —
+  but **not** to Scorecard, which only inspects the GitHub Release
+  page.
+* ❌ **GitHub Release assets** — every published tag (v1.0.0 / v1.0.1
+  / v1.0.2) attaches the wheel + sdist via
+  ``softprops/action-gh-release@v2`` but does **not** attach any
+  signature file. From Scorecard's view the release is unsigned even
+  though the wheel was sigstore-signed on PyPI five lines earlier.
+
+The closure: add a GitHub-native attestation step in the
+``github-release`` job so the same artifacts Scorecard inspects
+carry a discoverable signature.
+
+## Decision
+
+Add ``actions/attest-build-provenance@v3`` to the ``github-release``
+job in ``.github/workflows/release.yml``, run it on every file under
+``dist/`` (the wheel + sdist), and upload the resulting
+``.intoto.jsonl`` SLSA Build Provenance bundle to the GitHub Release
+alongside the artifacts.
+
+The workflow now:
+
+1. Builds ``dist/`` via ``python -m build`` (``build`` job).
+2. Publishes to PyPI with sigstore attestations (``publish-pypi``
+   job).
+3. **NEW**: Generates a SLSA Build Provenance attestation covering
+   every file in ``dist/`` (``github-release`` job, ``attest`` step).
+4. Attaches both the artifacts AND the attestation bundle to the
+   GitHub Release.
+
+After this lands, every release tag will surface an
+``attestation.intoto.jsonl`` file on the GitHub Release page.
+Downstream consumers can verify with:
+
+```bash
+gh attestation verify dist/bqemulator-X.Y.Z-py3-none-any.whl \
+    --owner jjviscomi
+```
+
+and Scorecard's ``Signed-Releases`` check will count the release as
+signed.
+
+### Three implementation options considered
+
+| Option | Shape | Decision |
+|---|---|---|
+| **A — GitHub Artifact Attestations** | ``actions/attest-build-provenance`` natively populates GitHub's attestations API + emits a ``.intoto.jsonl`` bundle we upload to the Release. SLSA v1.0 provenance schema. Sigstore keyless via OIDC. | ✅ **Chosen.** |
+| **B — sigstore-python sign + upload** | Install ``sigstore`` Python CLI, run ``sigstore sign`` against each dist file, upload ``.sigstore`` bundles to the Release. Equivalent score impact; sigstore-only (no SLSA schema). | Rejected. More moving parts (extra dep) for the same Scorecard outcome. |
+| **C — GPG-sign + ``.asc`` files** | Old-school PGP signatures. Requires a managed signing key. | Rejected. Key management overhead with no marginal score benefit. |
+
+Option A wins on three axes:
+
+1. **First-party GitHub action** (``actions/*``) — major-tag pinning
+   allowed per AGENTS.md OpenSSF-alignment rule. Dependabot
+   maintains it.
+2. **SLSA v1.0 provenance** — strictly more information than a bare
+   signature (includes builder identity, source repo, ref, workflow
+   run URL). Future SLSA-aware tools (deps.dev, in-toto verifiers)
+   light up automatically.
+3. **Verifiable without external tooling** — ``gh attestation
+   verify`` ships with the GitHub CLI; no separate sigstore install
+   required by consumers.
+
+## Why this PR doesn't touch ``docker.yml``
+
+``docker.yml`` already runs ``actions/attest-build-provenance@v1``
+against the container image digest (line 63), and Scorecard
+already credits the container image as signed. The asymmetry was
+purely on the PyPI wheel / GitHub Release side. Bumping
+``docker.yml``'s pin from v1 → v3 is a parallel improvement
+(SLSA v0.2 → v1.0 schema) but unrelated to closing the
+``Signed-Releases`` gap; it's a follow-up if the maintainer wants
+the newer schema, not a prerequisite.
+
+## Expected Scorecard impact
+
+The ``Signed-Releases`` check inspects the **last 5 releases**.
+Recovery trajectory once this lands and v1.1.0 publishes:
+
+| After release | Signed of last 5 | ``Signed-Releases`` score |
+|---|---|---|
+| v1.0.2 (today) | 0/3 | ~0/10 |
+| v1.1.0 | 1/4 | ~2/10 |
+| v1.1.1 | 2/5 | ~4/10 |
+| v1.1.2 | 3/5 | ~6/10 |
+| v1.1.3 | 4/5 | ~8/10 |
+| v1.1.4 | 5/5 | **10/10** |
+
+Tags are immutable on GitHub so we can't retroactively attest
+v1.0.0–v1.0.2. The recovery is gradual but monotone — every new
+tag improves the score until the rolling 5-release window
+contains only signed entries.
+
+Composite Scorecard score lift: ~+1.5 immediately after v1.1.0;
+~+2.5 by v1.1.4.
+
+## Rationale
+
+### Why store the attestation as a Release asset (not just on the
+attestations API)
+
+GitHub's attestations API (``gh attestation verify``) is the
+canonical verification surface — it reads the same data
+``actions/attest-build-provenance`` writes. But Scorecard
+specifically inspects **release assets** for known signature
+suffixes. Without uploading the ``.intoto.jsonl`` bundle to the
+Release, the API contains the attestation but Scorecard can't see
+it. Belt-and-suspenders: bundle goes to BOTH the attestations API
+AND the Release page.
+
+### Why ``subject-path: 'dist/*'`` and not per-file
+
+``actions/attest-build-provenance`` accepts a glob and produces a
+SINGLE attestation bundle referencing all matched subjects. The
+resulting ``.intoto.jsonl`` contains one statement per file (each
+with its sha256 digest). Consumers verifying any specific file get
+the same bundle; the action de-duplicates the upload step.
+
+### Why ``@v3`` (not ``@v1`` to match docker.yml)
+
+``actions/attest-build-provenance@v3`` produces SLSA Build
+Provenance v1.0 — the current standard schema. v1 produces SLSA
+v0.2 which is technically deprecated though Scorecard still
+recognises it. New code should target v1.0; the ``docker.yml``
+``@v1`` is pre-existing tech debt for a separate bump PR.
+
+### Why the bump in ``softprops/action-gh-release``'s ``files:`` is
+multi-line
+
+YAML's ``files: dist/*`` single-line form does NOT expand to also
+include ``${{ steps.attest.outputs.bundle-path }}`` — those are
+separate paths. The multi-line ``files: | dist/* ${{ ... }}`` form
+unions both. The action accepts shell-glob + explicit paths
+together.
+
+## Consequences
+
+### Positive
+
+* Every release tag from this PR onwards surfaces a SLSA Build
+  Provenance attestation as a discoverable release asset.
+* Scorecard's ``Signed-Releases`` check trajectory: 0 → 10 over 5
+  releases.
+* Downstream consumers gain a first-class verification path via
+  ``gh attestation verify`` — no separate sigstore install
+  required.
+* SLSA v1.0 provenance unlocks downstream SLSA-aware verifiers
+  (in-toto, slsa-verifier) without additional work.
+
+### Negative
+
+* ~10s extra runtime per release (sigstore OIDC handshake +
+  bundle upload).
+* One more failure surface — if the attestation step errors, the
+  ``github-release`` job fails and the tag's release page won't
+  publish until the issue is fixed. Mitigation: the failure mode
+  is loud + the tag is immutable, so a fix-forward via re-run is
+  the operator's path (same as any other workflow failure today).
+
+### Neutral
+
+* The PyPI Trusted Publishing sigstore attestations are
+  preserved unchanged. PyPI consumers still get PyPI-native
+  signatures via ``pip install`` verification flows. The
+  GitHub-Release attestation is the GitHub-visible parallel — not a
+  replacement.
+* ``docker.yml`` continues at ``@v1``; the parallel-v3 bump is
+  documented as out of scope.
+
+## Alternatives considered
+
+1. **Option B — ``sigstore`` Python CLI sign + upload.**
+   Equivalent score impact, more moving parts, same outcome.
+   Rejected.
+2. **Option C — GPG ``.asc`` signatures.** Requires a managed
+   signing key + key rotation. No marginal score benefit.
+   Rejected.
+3. **Skip the GitHub-Release attestation and accept the
+   low score.** Fastest, but fails the user-mandated "improve
+   Scorecard posture" requirement.
+4. **Move PyPI sigstore attestations onto the GitHub Release.**
+   PyPI's ``gh-action-pypi-publish`` doesn't expose its sigstore
+   bundles as outputs the way ``actions/attest-build-provenance``
+   does. Possible but more code; the action-based approach is
+   cleaner.
+
+## References
+
+* [``actions/attest-build-provenance``](https://github.com/actions/attest-build-provenance) — the action used here.
+* [SLSA Build Provenance v1.0 spec](https://slsa.dev/spec/v1.0/provenance) — the schema this attestation produces.
+* [OpenSSF Scorecard ``Signed-Releases`` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#signed-releases) — what we're scoring against.
+* [ADR 0037](0037-openssf-scorecard.md) — the Scorecard adoption that surfaced this gap.
+* [`gh attestation verify`](https://cli.github.com/manual/gh_attestation_verify) — consumer-side verification path.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -222,6 +222,7 @@ nav:
       - "0036 Cyclomatic-complexity ratchet to rank C + promote-to-required gate": adr/0036-complexity-ratchet-to-c.md
       - "0037 OpenSSF Scorecard adoption + badge": adr/0037-openssf-scorecard.md
       - "0038 SESSION_USER() pre-translator substitution": adr/0038-session-user.md
+      - "0039 SLSA Build Provenance on GitHub Release assets": adr/0039-artifact-attestations.md
   - RFCs: rfcs/README.md
   - Examples:
       - Overview: examples/README.md


### PR DESCRIPTION
## Why

OpenSSF Scorecard's [`Signed-Releases`](https://github.com/ossf/scorecard/blob/main/docs/checks.md#signed-releases) check on the v1.0.2 release reported 0/10 because the GitHub Release assets carry no signature file. The project HAS sigstore attestations on PyPI (via Trusted Publishing) and SLSA attestations on the GHCR image (via `actions/attest-build-provenance@v1` in `docker.yml`) — but Scorecard only inspects **GitHub Release assets**, so neither of those count for this check.

This PR adds `actions/attest-build-provenance@v3` to the `github-release` job of `release.yml`, attesting the wheel + sdist and attaching the resulting `.intoto.jsonl` SLSA v1.0 Build Provenance bundle as a Release asset.

## Verification path for consumers

```bash
gh attestation verify dist/bqemulator-1.1.0-py3-none-any.whl \
    --owner jjviscomi
```

The attestation lives both on the GitHub Release page (for Scorecard visibility) AND on GitHub's native attestations API (for tooling that uses `gh attestation list / verify`).

## Expected Scorecard impact

The `Signed-Releases` check inspects the **last 5 releases**. Recovery trajectory (tags are immutable; cannot backfill v1.0.x):

| Release | Signed of last 5 | `Signed-Releases` score |
|---|---|---|
| v1.0.2 (today) | 0/3 | ~0/10 |
| v1.1.0 | 1/4 | ~2/10 |
| v1.1.1 | 2/5 | ~4/10 |
| v1.1.2 | 3/5 | ~6/10 |
| v1.1.3 | 4/5 | ~8/10 |
| v1.1.4 | 5/5 | **10/10** |

Composite Scorecard score lift: ~+1.5 immediately after v1.1.0, ~+2.5 by v1.1.4.

## What lands

- `.github/workflows/release.yml` — adds `actions/attest-build-provenance@v3` step in `github-release` job; uploads the bundle alongside `dist/*` via `softprops/action-gh-release@v2`.
- `docs/adr/0039-artifact-attestations.md` — full decision record (3 options considered, recovery trajectory, rationale for `@v3` over `docker.yml`'s `@v1`).
- `mkdocs.yml` — nav entry.
- `CHANGELOG.md` — `[Unreleased]` Added entry.
- `_typos.toml` — allow `intoto` (the canonical `.intoto.jsonl` SLSA extension is named after the in-toto framework, not a typo).

## Why `actions/attest-build-provenance@v3` (not `@v1`)

`@v3` produces SLSA Build Provenance v1.0 — the current standard schema. `@v1` produces SLSA v0.2 which is deprecated but still recognized by Scorecard. `docker.yml`'s existing `@v1` is left untouched as a separate follow-up (parallel-v3 bump for SLSA parity; not a `Signed-Releases` prerequisite).

## Out of scope

- Bumping `docker.yml`'s `@v1` to `@v3`. Documented in ADR 0039 as a parallel follow-up; the container attestation already counts on Scorecard's side regardless of schema version.
- Backfilling prior releases. Tags are immutable on GitHub; the only path is forward-attestation, which the recovery trajectory captures.

## Acceptance criteria

- [x] `actions/attest-build-provenance@v3` step in `github-release` job.
- [x] `subject-path: 'dist/*'` covers both wheel + sdist in one attestation.
- [x] Bundle path uploaded via `softprops/action-gh-release@v2`'s `files:` multi-line form.
- [x] ADR 0039 documents options + decision + recovery trajectory.
- [x] CHANGELOG `[Unreleased]` entry.
- [x] mkdocs nav updated.
- [x] `_typos.toml` allow-list extended.

`make verify` skipped — workflow YAML change for tag-push-triggered flow; validation happens on next tag push. `make lint` passes (typos + YAML).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release artifacts now include SLSA Build Provenance attestations uploaded alongside wheels/sdists and container images.

* **Documentation**
  * Added an ADR documenting the SLSA provenance attestation approach and updated the changelog with verification guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->