### PR TITLE
chore(security): SHA-pin all GitHub Actions + Dockerfile (Pinned-Dependencies sweep)

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -46,8 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -58,7 +58,7 @@ jobs:
       - name: Run chaos suite
         run: |
           pytest tests/chaos -m chaos --timeout=60 --junit-xml=chaos-results.xml
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: chaos-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     name: Lint + type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -61,8 +61,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python }}
           cache: pip
@@ -80,8 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -119,8 +119,8 @@ jobs:
     # opening the PR (e.g., right after a recording session), without
     # waiting for the full CI matrix.
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -129,7 +129,7 @@ jobs:
           pip install -e ".[dev,all]"
       - name: Replay conformance corpus (offline; no BQ creds)
         run: pytest tests/conformance -m conformance --junit-xml=conformance.xml
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: conformance-results
@@ -141,8 +141,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           # Pin to the dev-environment Python so the gate stays
           # consistent with local ``make verify``. The unit matrix
@@ -189,8 +189,8 @@ jobs:
     # ``make matrix && make coverage-matrix && make function-mapping
     # && make api-coverage``, then commit the regenerated files.
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -84,12 +84,12 @@ jobs:
     name: Quality gates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
       - name: Install dev deps

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         language: [python]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       # Pin ``github/codeql-action`` by commit SHA per the OpenSSF
       # Scorecard alignment rule (AGENTS.md): only first-party
       # ``actions/*`` may use floating major tags; everything else,

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -48,8 +48,8 @@ jobs:
     name: Replay corpus against in-process emulator
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -58,7 +58,7 @@ jobs:
           pip install -e ".[dev,all]"
       - name: Run conformance corpus (offline; no BigQuery creds needed)
         run: pytest tests/conformance -m conformance --junit-xml=conformance.xml
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: conformance-results

--- a/.github/workflows/differential.yml
+++ b/.github/workflows/differential.yml
@@ -56,8 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -73,7 +73,7 @@ jobs:
           # "no such target" — that signals the workflow file is
           # ready but the runner is not implemented yet.
           make test-differential
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: differential-results

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build + publish multi-arch image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Log in to GHCR

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,10 +20,10 @@ jobs:
     name: Build + strict check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -39,10 +39,10 @@ jobs:
     needs: build
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,8 +23,8 @@ jobs:
     outputs:
       image: ${{ steps.build.outputs.image }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Build
         id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
@@ -37,7 +37,7 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Export image tarball
         run: docker save ghcr.io/jjviscomi/bqemulator:ci-${{ github.sha }} -o /tmp/bqemu.tar
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bqemu-image
           path: /tmp/bqemu.tar
@@ -48,11 +48,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bqemu-image
           path: /tmp
@@ -72,18 +72,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
           cache: npm
           cache-dependency-path: tests/e2e/nodejs_client/package-lock.json
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Install fixture-staging deps
         run: pip install fastavro pyorc
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bqemu-image
           path: /tmp
@@ -140,18 +140,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.22"
           cache: true
           cache-dependency-path: tests/e2e/go_client/go.mod
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Install fixture-staging deps
         run: pip install fastavro pyorc
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bqemu-image
           path: /tmp
@@ -200,18 +200,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Install fixture-staging deps
         run: pip install fastavro pyorc
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bqemu-image
           path: /tmp
@@ -267,11 +267,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bqemu-image
           path: /tmp

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -36,11 +36,11 @@ jobs:
     outputs:
       image: ${{ steps.tag.outputs.image }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - id: tag
         run: echo "image=ghcr.io/jjviscomi/bqemulator:ci-${{ github.sha }}" >> $GITHUB_OUTPUT
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           platforms: linux/amd64
@@ -49,7 +49,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - run: docker save ${{ steps.tag.outputs.image }} -o /tmp/bqemu.tar
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bqemu-image
           path: /tmp/bqemu.tar
@@ -60,8 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with: { python-version: "3.11" }
       - run: |
           python -m pip install --upgrade pip
@@ -76,8 +76,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with: { python-version: "3.11" }
       - run: |
           python -m pip install --upgrade pip
@@ -92,8 +92,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with: { python-version: "3.11" }
       - run: |
           python -m pip install --upgrade pip
@@ -108,10 +108,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with: { python-version: "3.11" }
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: "17"
@@ -128,11 +128,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: bqemu-image, path: /tmp }
       - run: docker load -i /tmp/bqemu.tar
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
       - name: make test
@@ -146,11 +146,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: bqemu-image, path: /tmp }
       - run: docker load -i /tmp/bqemu.tar
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "20" }
       - name: make test
         env:
@@ -163,11 +163,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: bqemu-image, path: /tmp }
       - run: docker load -i /tmp/bqemu.tar
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: "17"
@@ -183,15 +183,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: bqemu-image, path: /tmp }
       - run: docker load -i /tmp/bqemu.tar
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: "17"
-      - uses: coursier/setup-action@v3
+      - uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
         with:
           apps: sbt
       - name: make test
@@ -205,11 +205,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: bqemu-image, path: /tmp }
       - run: docker load -i /tmp/bqemu.tar
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with: { go-version: "1.22" }
       - name: make test
         env:
@@ -222,11 +222,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: bqemu-image, path: /tmp }
       - run: docker load -i /tmp/bqemu.tar
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with: { go-version: "1.22" }
       - name: make test
         env:
@@ -239,11 +239,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: bqemu-image, path: /tmp }
       - run: docker load -i /tmp/bqemu.tar
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with: { python-version: "3.11" }
       - run: pip install google-cloud-bigquery
       - name: make test
@@ -256,8 +256,8 @@ jobs:
     name: ci-recipes (meta-tests)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with: { python-version: "3.11" }
       - run: pip install PyYAML
       - name: GitHub Actions recipe

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -56,8 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           # Atheris 3.0.0 supports Python 3.11/3.12/3.13. 3.13 matches
           # the leading edge of the per-PR matrix in ci.yml; bump to
@@ -91,7 +91,7 @@ jobs:
               -max_total_time=600 \
               -artifact_prefix=fuzz-artifacts/arrow-bridge/ \
               fuzz/corpus/arrow_bridge
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           # Atheris's libFuzzer writes the reproducer input as

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -48,14 +48,14 @@ jobs:
       # fires on the scheduled trigger.
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Restore lychee cache
         # The cache key combines the .lychee.toml hash so a config
         # change invalidates the cache (we want fresh recheck of
         # newly-included URLs). Otherwise we reuse the day's prior
         # response cache to stay friendly to upstream CDNs.
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .lycheecache
           key: lychee-${{ hashFiles('.lychee.toml') }}-${{ github.run_id }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: lychee-report
           path: lychee-report.md

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -68,8 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -102,14 +102,14 @@ jobs:
           echo "Recorded new baseline. Download the \`mutation-baseline\` artefact and commit \`tests/mutation/baseline.json\` to land it."
       - name: Upload recorded baseline (dispatch-only)
         if: ${{ inputs.record-baseline == true }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mutation-baseline
           path: tests/mutation/baseline.json
           if-no-files-found: error
       - name: Upload surviving-mutant detail (always)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mutation-stats
           path: |

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -48,8 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -81,7 +81,7 @@ jobs:
               --benchmark-compare=0001_committed-baseline \
               --benchmark-compare-fail=median:10% \
               --junit-xml=perf-results.xml
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: perf-results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,16 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - run: |
           python -m pip install --upgrade pip build
           python -m build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/
@@ -37,7 +37,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/bqemulator
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-pypi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # Scorecard's hardening guidance — drops the default
           # GITHUB_TOKEN from .git/config so the subsequent
@@ -96,7 +96,7 @@ jobs:
       # debug score changes locally without trusting GitHub's
       # Security-tab UI.
       - name: Upload SARIF artefact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: scorecard-sarif
           path: results.sarif

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,10 +117,10 @@ grpc_api/ ──┘        + scripting/ + udf/ + versioning/ + types/
   cost to extending the same rule everywhere (Dependabot handles
   both alike). The exemption was removed as part of the
   Pinned-Dependencies sweep documented in
-  [CHANGELOG.md](../CHANGELOG.md)'s `[Unreleased]` section.
+  [CHANGELOG.md](CHANGELOG.md)'s `[Unreleased]` section.
 
 - **Dockerfile base-image pinning.** `FROM` lines in the
-  [`Dockerfile`](../Dockerfile) are pinned by digest
+  [`Dockerfile`](Dockerfile) are pinned by digest
   (`python:3.14-slim-bookworm@sha256:…`) in addition to the human-
   readable tag. Same rationale as the Actions pin: tags are mutable;
   digests are immutable. Dependabot's `docker` ecosystem updater

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,21 +96,35 @@ grpc_api/ ──┘        + scripting/ + udf/ + versioning/ + types/
 
 ## Conventions
 
-- **GitHub Actions pinning.** Third-party `uses:` references in
-  `.github/workflows/*.yml` are pinned to a **full-length commit SHA**
+- **GitHub Actions pinning.** **Every** `uses:` reference in
+  `.github/workflows/*.yml` is pinned to a **full-length commit SHA**
   with a trailing `# vX.Y.Z` comment that names the matching release
-  tag. SHA pinning is the
+  tag — including first-party `actions/*`. SHA pinning is the
   [GitHub Security Lab](https://github.blog/security/supply-chain-security/four-tips-to-keep-your-github-actions-workflows-secure/)
   + [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
-  recommendation — major-version tags like `@v1` are mutable and can
+  recommendation — major-version tags like `@v4` are mutable and can
   be re-pointed by the action author, which is exactly the supply-
   chain attack vector we're closing. The trailing `# vX.Y.Z` comment
   is Dependabot's canonical bump-anchor; the GHA ecosystem updater
   rewrites both the SHA and the comment together when new releases
-  ship, so reproducibility doesn't cost us upgrade hygiene. First-
-  party `actions/*` (GitHub-owned) are exempt and may use major-
-  version tags (`actions/checkout@v4`) — GitHub's own actions live
-  under a different threat model.
+  ship, so reproducibility doesn't cost us upgrade hygiene.
+
+  The earlier relaxed rule that exempted first-party `actions/*` from
+  SHA-pinning was a pragmatic compromise based on the smaller threat
+  model for GitHub-owned actions — but OpenSSF Scorecard's
+  `Pinned-Dependencies` check scores full credit only for commit-SHA
+  pins regardless of action provenance, and there's no operational
+  cost to extending the same rule everywhere (Dependabot handles
+  both alike). The exemption was removed as part of the
+  Pinned-Dependencies sweep documented in
+  [CHANGELOG.md](../CHANGELOG.md)'s `[Unreleased]` section.
+
+- **Dockerfile base-image pinning.** `FROM` lines in the
+  [`Dockerfile`](../Dockerfile) are pinned by digest
+  (`python:3.14-slim-bookworm@sha256:…`) in addition to the human-
+  readable tag. Same rationale as the Actions pin: tags are mutable;
+  digests are immutable. Dependabot's `docker` ecosystem updater
+  bumps both the tag and digest together on each upstream release.
 - **Conventional Commits** (`feat:`, `fix:`, `docs:`, `refactor:`,
   `test:`, `chore:`, `build:`, `ci:`, `perf:`, `style:`). Enforced by
   `commitlint`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,58 @@ section and adds the release date.
 
 ### Changed
 
+- **All GitHub Actions + Dockerfile base images SHA-pinned**
+  (OpenSSF Scorecard `Pinned-Dependencies` sweep). The
+  pre-sweep audit found 113 `uses:` references across 14 workflow
+  files using floating tags — first-party `actions/*` were
+  previously exempt from SHA-pinning per AGENTS.md's pragmatic
+  compromise, and a few third-party pins (``softprops/action-gh-release@v2``,
+  ``pypa/gh-action-pypi-publish@release/v1``, ``actions/cache@v4``,
+  ``docker/setup-buildx-action@v3``, ``docker/build-push-action@v7``,
+  ``coursier/setup-action@v3``) had drifted from policy. Both
+  classes now pin to the latest patch within their current major
+  version, with trailing ``# vX.Y.Z`` comments for Dependabot
+  upgrade-anchor compatibility:
+
+  - ``actions/checkout`` v4 → ``@34e11487 # v4.3.1``
+  - ``actions/setup-python`` v5 → ``@a26af69b # v5.6.0``
+  - ``actions/setup-node`` v6 → ``@48b55a01 # v6.4.0``
+  - ``actions/setup-go`` v5 → ``@40f1582b # v5.6.0``
+  - ``actions/setup-java`` v5 → ``@be666c2f # v5.2.0``
+  - ``actions/cache`` v4 → ``@0057852b # v4.3.0``
+  - ``actions/upload-artifact`` v4 → ``@ea165f8d # v4.6.2``
+  - ``actions/download-artifact`` v8 → ``@3e5f45b2 # v8.0.1``
+  - ``coursier/setup-action`` v3 → ``@fd1707a7 # v3.0.0``
+  - ``docker/setup-buildx-action`` v3 → ``@8d2750c6 # v3.12.0``
+    (consistency with the existing pin in ``docker.yml``)
+  - ``docker/build-push-action`` v7 → ``@f9f30427 # v7.2.0``
+    (same)
+
+  ``Dockerfile``'s two ``FROM python:3.14-slim-bookworm`` lines
+  also gain a ``@sha256:a9bee15510a3641…`` digest pin per the
+  OCI multi-arch index for the May 20 2026 push. Dependabot's
+  ``docker`` ecosystem updater bumps both the tag and digest
+  together on each upstream release.
+
+  ``AGENTS.md``'s "GitHub Actions pinning" section updated to
+  reflect the post-sweep policy: **every** ``uses:`` reference is
+  SHA-pinned (no first-party exemption). The relaxed-actions/*
+  rule was a pragmatic compromise based on the smaller threat
+  model for GitHub-owned actions — but Scorecard scores full
+  credit only for commit-SHA pins regardless of action provenance,
+  and there's no operational cost to extending the rule (Dependabot
+  handles both alike).
+
+  Expected Scorecard impact: ``Pinned-Dependencies`` lifts from
+  ~4-5/10 (partial credit for major-tag pins) to ~9-10/10 on next
+  weekly run. Composite score lift ~+1 point.
+
+  Three actions remain un-pinned at this commit, all covered by
+  the in-flight PR #57 (artifact attestations + SHA-pin sweep):
+  ``softprops/action-gh-release@v2``,
+  ``pypa/gh-action-pypi-publish@release/v1``,
+  ``actions/attest-build-provenance@v1`` (in ``docker.yml``).
+
 - **Python example requirements tightened to CVE-clean floors.** The
   OpenSSF Scorecard `Vulnerabilities` check (added in PR #48) reported
   ~100 historical PYSEC / GHSA IDs against the `docs/examples/python/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,7 +179,10 @@ section and adds the release date.
   ``coursier/setup-action@v3``) had drifted from policy. Both
   classes now pin to the latest patch within their current major
   version, with trailing ``# vX.Y.Z`` comments for Dependabot
-  upgrade-anchor compatibility:
+  upgrade-anchor compatibility (SHAs below are abbreviated to the
+  first 8 hex characters for readability; the actual workflow-file
+  references are full 40-character commit SHAs per the policy
+  documented in [AGENTS.md](AGENTS.md)):
 
   - ``actions/checkout`` v4 → ``@34e11487 # v4.3.1``
   - ``actions/setup-python`` v5 → ``@a26af69b # v5.6.0``

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # ---------------------------------------------------------------------------
 # Builder
 # ---------------------------------------------------------------------------
-FROM python:3.14-slim-bookworm AS builder
+FROM python:3.14-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -32,7 +32,7 @@ RUN python -m venv /opt/venv \
 # ---------------------------------------------------------------------------
 # Runtime
 # ---------------------------------------------------------------------------
-FROM python:3.14-slim-bookworm AS runtime
+FROM python:3.14-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
## TL;DR

113 ``uses:`` references across 14 workflow files audited; all non-PR-#57-overlap entries now pin to a full 40-char commit SHA + trailing ``# vX.Y.Z`` comment. ``Dockerfile``'s two ``FROM`` lines digest-pinned. ``AGENTS.md`` updated to drop the ``actions/*`` SHA-pin exemption.

Expected OpenSSF Scorecard ``Pinned-Dependencies`` lift: ~4-5/10 → ~9-10/10. Composite ~+1.

## Why now

OpenSSF Scorecard's ``Pinned-Dependencies`` check was scoring partial credit because:

1. **First-party `actions/*` exempt from SHA-pinning** — AGENTS.md's relaxed rule allowed major-tag pins (``@v4``) on the rationale that GitHub-owned actions live under a different threat model. That's a pragmatic compromise but Scorecard scores full credit only for commit-SHA pins regardless of action provenance.
2. **A handful of third-party + Docker actions** had drifted from policy (`softprops/action-gh-release@v2`, `pypa/gh-action-pypi-publish@release/v1`, `actions/cache@v4`, `docker/setup-buildx-action@v3`, `docker/build-push-action@v7`, `coursier/setup-action@v3`).

## Pin table

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v4` | `@34e11487… # v4.3.1` |
| `actions/setup-python` | `@v5` | `@a26af69b… # v5.6.0` |
| `actions/setup-node` | `@v6` | `@48b55a01… # v6.4.0` |
| `actions/setup-go` | `@v5` | `@40f1582b… # v5.6.0` |
| `actions/setup-java` | `@v5` | `@be666c2f… # v5.2.0` |
| `actions/cache` | `@v4` | `@0057852b… # v4.3.0` |
| `actions/upload-artifact` | `@v4` | `@ea165f8d… # v4.6.2` |
| `actions/download-artifact` | `@v8` | `@3e5f45b2… # v8.0.1` |
| `coursier/setup-action` | `@v3` | `@fd1707a7… # v3.0.0` |
| `docker/setup-buildx-action` | `@v3` | `@8d2750c6… # v3.12.0` |
| `docker/build-push-action` | `@v7` | `@f9f30427… # v7.2.0` |

**Strategy**: pin to latest patch within each current major (not major-bump). Zero behavioural change — only the supply-chain attack surface narrows.

## Dockerfile

```diff
- FROM python:3.14-slim-bookworm AS builder
+ FROM python:3.14-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS builder

- FROM python:3.14-slim-bookworm AS runtime
+ FROM python:3.14-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS runtime
```

Multi-arch OCI index digest for the May 20 2026 push. Dependabot's `docker` ecosystem updater bumps both tag and digest together on upstream releases.

## AGENTS.md policy update

"GitHub Actions pinning" section:
- **Before**: third-party SHA-pinned, first-party `actions/*` may use major tags.
- **After**: every `uses:` reference SHA-pinned, no exemptions. New "Dockerfile base-image pinning" section added.

## Three actions out of scope (covered by PR #57)

These three are not pinned in this PR because PR #57 is already touching them:
- `softprops/action-gh-release@v2` — PR #57 will pin to v2.6.2 SHA
- `pypa/gh-action-pypi-publish@release/v1` — PR #57 will pin to v1.14.0 SHA  
- `actions/attest-build-provenance@v1` (in `docker.yml`) — PR #57 bumps to v4.1.0 SHA

After both PRs land, **100% of `uses:` references will be SHA-pinned** across all 14 workflows.

## Verification

- All 14 workflow YAMLs parse cleanly (`python -c "import yaml; yaml.safe_load(open(f))"`).
- `make lint` passes (typos + ruff + mypy + bandit + pip-audit + interrogate).
- Post-sweep audit confirms only the three PR-#57-scoped references remain un-pinned.

## Expected Scorecard impact

| Check | Before | After (next weekly run) |
|---|---|---|
| `Pinned-Dependencies` | ~4-5/10 (partial credit for major-tag pins) | ~9-10/10 |
| Composite | 5.1 | ~6 (combined with #54 Python deps cleanup + #57 attestations + Vulnerabilities re-scan) |

`make verify` skipped — workflow YAML + Dockerfile-only changes; the validation gates that matter (YAML parse, action resolution at runtime) happen when CI itself runs against the new pins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned CI/CD actions and tooling to immutable commits and pinned container base images to digests for stronger supply-chain security and reproducible runs.
* **Documentation**
  * Updated supply-chain security guidelines to require SHA/digest pinning for actions and Docker base images.
* **Changelog**
  * Added entry documenting the pinning changes and expected security score impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->