### PR TITLE
fix(ci): lychee resolves repo-self-references locally via --remap

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -72,11 +72,24 @@ jobs:
         with:
           # Args explicitly enumerated so they're auditable inline
           # rather than buried in defaults.
+          #
+          # ``--remap``: rewrite repo-self-references
+          # (``github.com/jjviscomi/bqemulator/{blob,tree}/main/<path>``)
+          # to ``file://<workspace>/<path>`` so lychee resolves them
+          # against the PR-branch checkout instead of fetching the
+          # ``main`` branch URL over HTTP. Closes the per-PR
+          # false-failure mode where a new file referenced via an
+          # absolute github URL would 404 on the PR branch (because
+          # the file isn't on ``main`` yet) and the orthogonal
+          # github.com 502 transients on the same URLs. Full
+          # rationale in ``.lychee.toml``.
           args: >-
             --no-progress
             --cache
             --max-cache-age 1d
             --config .lychee.toml
+            --remap "https://github.com/jjviscomi/bqemulator/blob/main/(.+) file://${{ github.workspace }}/$1"
+            --remap "https://github.com/jjviscomi/bqemulator/tree/main/(.+) file://${{ github.workspace }}/$1"
             "**/*.md"
           # Fail the job on broken links (PR runs annotate inline).
           fail: true

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -88,8 +88,8 @@ jobs:
             --cache
             --max-cache-age 1d
             --config .lychee.toml
-            --remap "https://github.com/jjviscomi/bqemulator/blob/main/(.+) file://${{ github.workspace }}/$1"
-            --remap "https://github.com/jjviscomi/bqemulator/tree/main/(.+) file://${{ github.workspace }}/$1"
+            --remap "https://github.com/jjviscomi/bqemulator/blob/main/(.+) file://${{ github.workspace }}/\$1"
+            --remap "https://github.com/jjviscomi/bqemulator/tree/main/(.+) file://${{ github.workspace }}/\$1"
             "**/*.md"
           # Fail the job on broken links (PR runs annotate inline).
           fail: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -44,6 +44,61 @@ max_concurrency = 16
 include_mail = false
 
 # ---------------------------------------------------------------------------
+# URL remapping — resolve repo-self-references as local files
+# ---------------------------------------------------------------------------
+#
+# Generated docs (the coverage-matrix, the compatibility-matrix, function-
+# mapping, api-coverage, etc.) emit absolute github.com URLs for every
+# repo-internal file reference (e.g.,
+# ``[tpcds_q12](https://github.com/jjviscomi/bqemulator/blob/main/tests/
+# conformance/sql_corpus/standard_functions/tpcds_q12)``). Absolute URLs
+# are necessary for the rendered mkdocs site, where pages live at
+# different URL prefixes than the source tree and relative paths would
+# resolve to 404s. But they create a per-PR linkcheck failure mode:
+#
+# 1. A PR adds new files (e.g., a new conformance fixture directory).
+# 2. The generated doc rewrites to include
+#    ``github.com/.../blob/main/.../new_file``.
+# 3. lychee on the PR branch fetches the URL.
+# 4. GitHub returns 404 because the new file is on the PR branch, not
+#    on ``main``.
+# 5. lychee fails the build — even though the link is correct in the
+#    eventual-merge state.
+#
+# An orthogonal failure mode: github.com 502 transients on
+# ``blob/main`` URLs that re-fetch fine seconds later (observed during
+# the v1.1.0 cascade — PRs #57 / #58 / #60 all hit this).
+#
+# Fix: invoke lychee with a ``--remap`` argument that rewrites
+# ``github.com/jjviscomi/bqemulator/{blob,tree}/main/<path>`` URLs to
+# ``file://<absolute-repo-root>/<path>`` at check time. lychee then
+# resolves against the PR branch's filesystem, not a stale main
+# fetch. The remap lives in:
+#
+# * ``.github/workflows/linkcheck.yml`` — uses ``${{ github.workspace }}``
+# * ``Makefile`` ``linkcheck`` target — uses ``$$PWD``
+#
+# It can't live in this config file because lychee's ``remap`` expects
+# valid URLs, not relative paths or ``$PWD``-style env expansion, and
+# the absolute repo-root path differs between CI runners and local
+# checkouts. CLI-side remap with a templated workspace path is
+# portable; config-side ``remap`` is not.
+#
+# Behavioural envelope vs. pre-fix:
+#
+# * PR-branch new files: now pass instead of 404 (correct).
+# * github.com 502 transients on self-links: now no-op (correct).
+# * Renamed/deleted files: still caught (lychee reports "file not
+#   found" against the local checkout — same signal as the 404 was).
+# * Typos in the URL itself (``blob/maine/``, wrong-branch refs):
+#   would fail under the old behaviour (404) AND under the new
+#   behaviour (file not found locally) — both because the literal
+#   ``main`` pattern doesn't match. No coverage lost.
+#
+# The mkdocs-served public site keeps fetching the absolute github
+# URLs at render time — ``--remap`` is a lychee-only directive.
+
+# ---------------------------------------------------------------------------
 # Status codes
 # ---------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,47 @@ section and adds the release date.
 
 ## [Unreleased]
 
+### Changed
+
+- **Lychee linkcheck resolves repo-self-references locally** —
+  closes a structural failure mode observed during the v1.1.0
+  cascade. Generated docs (coverage-matrix, compat-matrix,
+  function-mapping, api-coverage) emit absolute
+  ``github.com/jjviscomi/bqemulator/{blob,tree}/main/<path>`` URLs
+  for every repo-internal file reference — necessary for the
+  mkdocs-rendered public site, but lychee on a PR branch would
+  fetch those URLs over HTTP, get a 404 (file not yet on
+  ``main``) or a transient github.com 502, and fail the build.
+  Every PR adding new files would hit this; PRs #57, #58, and
+  #60 each failed linkcheck 1-4 times during the cascade.
+
+  Fix: invoke lychee with two ``--remap`` arguments rewriting
+  ``github.com/jjviscomi/bqemulator/{blob,tree}/main/(.+)`` to
+  ``file://<workspace>/<path>``. lychee resolves the
+  rewritten URL against the PR-branch checkout instead of
+  fetching ``main``. The remap is CLI-side (not in
+  ``.lychee.toml``) because lychee's config-file ``remap``
+  expects valid URLs and can't expand the absolute workspace
+  path. Wired in two places:
+
+  - [``.github/workflows/linkcheck.yml``](.github/workflows/linkcheck.yml)
+    — uses ``${{ github.workspace }}`` template var.
+  - [``Makefile``](Makefile) ``linkcheck`` target — uses
+    ``$$(CURDIR)`` for local-dev parity.
+
+  Behavioural envelope vs. pre-fix:
+  - PR-branch new files: now pass instead of 404 (correct).
+  - github.com 502 transients on self-links: now no-op (correct).
+  - Renamed/deleted files: still caught (lychee reports
+    "file not found" against the local checkout — equivalent
+    signal to the previous 404).
+  - The mkdocs public site keeps fetching the absolute github
+    URLs at render time — ``--remap`` is a lychee-only directive.
+
+  Verified locally: ``make linkcheck`` → 2345 total, 0 errors,
+  10s. The ``.lychee.toml`` retains the full design rationale
+  as a top-level comment block.
+
 ### Added
 
 - **TPC-DS expansion plan documented** — new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,11 @@ section and adds the release date.
   - [``.github/workflows/linkcheck.yml``](.github/workflows/linkcheck.yml)
     — uses ``${{ github.workspace }}`` template var.
   - [``Makefile``](Makefile) ``linkcheck`` target — uses
-    ``$$(CURDIR)`` for local-dev parity.
+    ``$(CURDIR)`` for local-dev parity (``$$`` in the recipe
+    expands to a literal ``$``, so the shell receives
+    ``$(CURDIR)`` which make substitutes; the trailing ``$$1``
+    is similarly the make-escape that produces the literal
+    ``$1`` lychee needs as its regex backreference).
 
   Behavioural envelope vs. pre-fix:
   - PR-branch new files: now pass instead of 404 (correct).

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,19 @@ lint: ## Lint + typecheck + security scan
 	interrogate src
 	typos .
 
+linkcheck: ## Run lychee with the workspace-aware self-link remap (CI parity)
+	@command -v lychee >/dev/null 2>&1 || { \
+	  echo "lychee not installed. Install via:"; \
+	  echo "  brew install lychee   # macOS"; \
+	  echo "  cargo install lychee  # other"; \
+	  exit 1; \
+	}
+	lychee --no-progress \
+	  --config .lychee.toml \
+	  --remap 'https://github.com/jjviscomi/bqemulator/blob/main/(.+) file://$(CURDIR)/$$1' \
+	  --remap 'https://github.com/jjviscomi/bqemulator/tree/main/(.+) file://$(CURDIR)/$$1' \
+	  '**/*.md'
+
 # ---------------------------------------------------------------------------
 # Quality gates (complexity required; duplication + dead-code non-blocking)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes a structural failure mode observed during the v1.1.0 cascade. Lychee linkcheck failed 1-4 times on each of PRs #57, #58, and #60 — not from real link rot, but because generated docs use absolute `github.com/jjviscomi/bqemulator/{blob,tree}/main/...` URLs that lychee fetches over HTTP:

- **404s on PR branches**: when a PR adds a new file referenced via one of these URLs, GitHub returns 404 because the file isn't on `main` yet.
- **502 transients**: github.com periodically returns 502 Bad Gateway on these URLs (observed during PR #57's run).

The fix is to invoke lychee with `--remap` rewriting `github.com/jjviscomi/bqemulator/{blob,tree}/main/(.+)` → `file://<workspace>/<path>`. Lychee then resolves against the PR-branch checkout's filesystem instead of fetching `main`.

## Why CLI-side and not config-side

Tried `.lychee.toml` `remap` first — lychee rejects relative paths (`Invalid remap pattern: the result \`X\` is not a valid URL`). Tried `file:./$1`, `file:$1`, `./$1`, `file:///./$1` — all rejected. Lychee's `remap` requires both sides to be valid URLs. The workspace-absolute path can't live in the static config because:

- CI runner: `/home/runner/work/bqemulator/bqemulator/`
- Local dev: `$HOME/Documents/.../bqemulator/`

So CLI-side, with `${{ github.workspace }}` in the workflow and `$(CURDIR)` in the Makefile, is the only portable form.

## Files touched

- [`.github/workflows/linkcheck.yml`](.github/workflows/linkcheck.yml) — add two `--remap` args to the lychee-action invocation
- [`Makefile`](Makefile) — new `make linkcheck` target (local-dev parity)
- [`.lychee.toml`](.lychee.toml) — top-level comment block documenting the design rationale (no functional change; the remap can't live here)
- `CHANGELOG.md` — `### Changed` entry

## Behavioural envelope

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| PR adds new file referenced via github URL | ❌ 404 against main | ✅ resolved locally on PR branch |
| File renamed, doc still references old path | ✅ caught as 404 | ✅ caught as "file not found" locally |
| github.com 502 transient | ❌ false-fail | ✅ no network hit |
| Typo in URL (`blob/maine/...`) | Caught as 404 | Caught as missing file |
| mkdocs-rendered public site | Absolute github URLs | Unchanged — remap is lychee-only |

No coverage loss. Only the *transport* changes (file:// instead of HTTP), not the *validation*.

## Test plan

- [x] `make linkcheck` locally → 2345 links, 0 errors, 10s
- [x] Focused test fixture (`/tmp/lychee_test/`) with one existing and one missing self-link → both correctly resolved
- [ ] CI linkcheck passes on this PR
- [ ] After merge: linkcheck on PR #60 (TPC-DS, currently failing the same way) passes on rebase

## Follow-up

After this lands, rebase PR #59 (Token-Permissions) and PR #60 (TPC-DS) against new main — both should clear linkcheck cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local link-check command to validate documentation links in a branch/PR.

* **Chores**
  * Improved link verification to rewrite repository self-reference URLs to local workspace paths so PR-new files and transient remote errors are handled correctly.

* **Documentation**
  * Added explanatory notes and a changelog entry describing the remap behavior and verification guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->