### PR TITLE
docs: documentation style guide (PR A.0 of doc rewrite)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,16 @@ grpc_api/ ──┘        + scripting/ + udf/ + versioning/ + types/
   etc. Squash-merge. Signed commits. DCO sign-off.
 - **ADRs** for any architectural decision — numbered, immutable, in
   [docs/adr/](docs/adr/).
+- **Documentation style.** Docstrings, code comments, and reference
+  docs describe the **current state** of the software; the
+  [`CHANGELOG.md`](CHANGELOG.md) and [ADRs](docs/adr/) describe
+  history. No dates, PR numbers, phase labels, "previously X", or
+  TODO/future-work notes in code or reference docs. The CHANGELOG
+  follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+  + [Common Changelog](https://common-changelog.org/): one-line
+  imperative entries, no per-entry sub-headings, authored at release
+  time only. Full rules + examples in
+  [`docs/architecture/contributing/documentation-style-guide.md`](docs/architecture/contributing/documentation-style-guide.md).
 - **RFCs** for any change to public API, SQL semantics, persistence
   format, or governance — in [docs/rfcs/](docs/rfcs/).
 - **PR template** required. Checklist: tests, docs, changelog,

--- a/docs/architecture/contributing/documentation-style-guide.md
+++ b/docs/architecture/contributing/documentation-style-guide.md
@@ -1,0 +1,302 @@
+# Documentation style guide
+
+Authoritative conventions for docstrings, code comments, reference
+docs, and the changelog. PRs deviate from these rules only with an
+explicit one-paragraph rationale in the PR description.
+
+## Core principle
+
+**Code and reference docs describe the _current state_ of the
+software. ADRs and the changelog describe its _history_.**
+
+A docstring on a function in `src/` answers "what does this do
+now?". A comment in `.lychee.toml` answers "why is this value set
+this way?". Neither answers "how did we get here?" — that's the
+job of `docs/adr/` and `CHANGELOG.md`.
+
+A docstring that says "added in PR #50", "previously did X",
+"calibrated against the v1.0.2 release cycle", or "see ADR 0038 for
+the three options considered" is leaking history into the
+present-tense surface. The reader needs to know the contract, not
+its provenance.
+
+## Docstrings
+
+### Form
+
+- First line: imperative-mood single sentence ending in a period.
+  ("Return the resolved caller email.", not "Returns the resolved
+  caller email." and not "This function returns…")
+- Blank line.
+- Optional body: present-tense factual prose describing the
+  contract — inputs, outputs, edge cases, invariants. Use
+  paragraphs for distinct concerns; reST field lists (`:param x:`,
+  `:returns:`) only when generated tooling needs them.
+- No headings, no bulleted "sections" inside docstrings.
+- No trailing changelog-style notes.
+
+### Allowed content
+
+- What the function/class/module does, now.
+- The contract's edge cases ("returns `None` when the row count is
+  zero", "raises `ValidationError` on malformed input").
+- Cross-references to **current** specifications: ADR numbers,
+  BigQuery / DuckDB doc URLs, RFC numbers. The reference must be
+  to a contract this code _conforms to_, not to a historical
+  decision _about_ this code.
+
+### Forbidden content
+
+- Dates, version numbers, release names ("as of v1.0.2", "shipped
+  May 2026").
+- PR numbers, issue numbers, commit SHAs.
+- Phase / wave / bucket labels (`P2.d`, `G4`, `Bucket A`, `slice-2`).
+- "Previously X" / "we used to" / "this was added when" / "this
+  closes".
+- "TODO", "FIXME", "future work", "will eventually". If something
+  is incomplete, either open a tracking issue and link it, or fix
+  it now. A docstring is not a backlog.
+- Author names ("originally written by X", "thanks to Y").
+- Calibration narratives ("after observing 502s on PR #43, retries
+  raised to 4 × 10s").
+
+### Examples
+
+❌ **Bad** (history + planning + PR references):
+
+```python
+def rewrite_session_user(bq_sql: str, caller: CallerIdentity) -> str:
+    """Pre-translate BigQuery SQL for the ``SESSION_USER()`` function.
+
+    Added in PR #50 (ADR 0038) to close the canonical
+    RAP-via-SESSION_USER tenant-isolation pattern. Extended in
+    PR #62 to also handle ``CURRENT_USER()`` and ``@@session.user``
+    (ADR 0040). The Storage Read row_restriction path was previously
+    failing to thread the caller through; that limitation was
+    closed in the same PR.
+
+    Returns the input unchanged when no rewrite is needed.
+    Idempotent. TODO: handle ``SESSION_USER()`` inside SQL UDF
+    bodies in a future release.
+    """
+```
+
+✅ **Good** (present-tense contract):
+
+```python
+def rewrite_session_user(bq_sql: str, caller: CallerIdentity) -> str:
+    """Substitute every BigQuery caller-identity call with a string literal.
+
+    Handles ``SESSION_USER()``, ``CURRENT_USER()``, and
+    ``@@session.user``. Each call site folds to the email returned
+    by :func:`resolve_session_user` for ``caller``. The input is
+    returned unchanged when no recognised spelling is present and
+    when the SQL fails to parse. Idempotent: a second pass with
+    the same caller is a no-op because the first pass replaced
+    every matching node with a literal.
+
+    See [ADR 0038](../../docs/adr/0038-session-user.md) for the
+    resolution contract.
+    """
+```
+
+### Module-level docstrings
+
+Same rules. The module docstring describes what the module is for
+right now — not its evolution. If a module collects routines from
+multiple phases of work, say what they do as a coherent surface,
+not when each was added.
+
+### Test docstrings
+
+Identical rules apply. Test docstrings describe what the test
+verifies, not which PR introduced it or which CodeRabbit thread
+prompted it.
+
+## Code comments
+
+### When to write one
+
+Only when the **why** is non-obvious from the code. Never the
+**what** — well-named identifiers cover that.
+
+### Allowed content
+
+- A subtle invariant ("DuckDB returns this as a list even for
+  single-row results; unwrap deliberately").
+- A specific workaround for an upstream bug ("workaround for
+  DuckDB issue #12345 — remove when the fix lands").
+- A non-obvious performance choice with measurement.
+
+### Forbidden content
+
+Same list as docstrings: dates, PRs, phases, "previously", "added
+in".
+
+### Example
+
+❌ **Bad**:
+
+```python
+# Bumped from 5 to 10 after the v1.1.0 cascade — Google Cloud
+# docs CDN added a locale-prefix hop in May 2026 that ran us out
+# of redirect budget. PR #63 raised the cap.
+max_redirects = 10
+```
+
+✅ **Good**:
+
+```python
+# Google Cloud docs URLs chain through CDN + locale-prefix
+# redirects (typically 6–8 hops). Bumping beyond this risks
+# masking infinite-loop CDNs.
+max_redirects = 10
+```
+
+The good version answers "why this number" without timestamping
+the answer.
+
+## Reference docs
+
+`docs/reference/**` and `docs/architecture/**` (except
+`docs/adr/**` and `docs/rfcs/**`) describe how the software
+behaves today. Apply the docstring rules: no history, no PR
+references, no phase labels.
+
+Auto-generated reference docs (`conformance-coverage-matrix`,
+`compatibility-matrix`, `sql-function-mapping`, `api-coverage`)
+are governed by their generator scripts; the same rules apply to
+those generators.
+
+## ADRs
+
+ADRs in `docs/adr/**` are exempt from these rules — historical
+decision records are exactly what the rules above push out of the
+code. An ADR's job is to record what was decided, why, and what
+was considered. They are immutable once accepted; a later decision
+that supersedes an earlier one ships as a new ADR that explicitly
+supersedes it.
+
+## CHANGELOG
+
+The changelog follows
+[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) +
+[Common Changelog](https://common-changelog.org/). Both are
+explicit specifications; deviations require justification.
+
+### Structure
+
+```markdown
+# Changelog
+
+## [X.Y.Z] - YYYY-MM-DD
+
+### Changed
+- Single-line imperative-mood entry, capitalised, period-terminated.
+
+### Added
+- One change per bullet.
+
+### Removed
+- Same.
+
+### Fixed
+- Same.
+```
+
+- Sections in the order **Changed / Added / Removed / Fixed**
+  (Common Changelog ordering; breaking changes most important).
+- Optional `### Deprecated` and `### Security` per Keep a Changelog
+  if the version actually has such entries.
+- One bullet per change. No sub-headings inside a version section.
+- No paragraphs inside entries. If a change needs explanation
+  beyond what fits in one line, that explanation belongs in an
+  ADR or in the docstring of the code it describes — link to it,
+  don't restate it.
+
+### Entry form
+
+- Imperative mood. ("Add CURRENT_USER alias for SESSION_USER",
+  not "Added CURRENT_USER alias" and not "This release adds…")
+- Capitalised first letter, period-terminated.
+- Reference link at the end is optional and discouraged. The
+  CHANGELOG is read for what changed, not who did it.
+
+### Forbidden in CHANGELOG entries
+
+- Fixture counts, PR numbers, file paths, ADR numbers, phase
+  labels, recorder narratives, contributor names.
+- Multi-paragraph essays.
+- Per-entry sub-headings (`**Implementation:**`,
+  `**Coverage:**`, `**Out of scope:**`).
+- "This PR" / "this change" — entries are about _what changed_,
+  not _what work happened_.
+- TODOs / planned follow-up.
+
+### Examples
+
+❌ **Bad** (current repo style):
+
+```markdown
+- **`CURRENT_USER()` + `@@session.user` + Storage Read
+  `row_restriction` caller threading** (ADR 0040). Closes three
+  items deferred by ADR 0038's out-of-scope section in a single
+  follow-up:
+
+  1. **`CURRENT_USER()` function alias** — BigQuery documents…
+  2. **`@@session.user` system-variable spelling**…
+  3. **Storage Read `row_restriction` caller threading**…
+
+  Coverage:
+  - **8 new unit tests** in `tests/unit/sql/rewriter/…`
+  - **1 new integration test** in `tests/integration/…`
+  - **6 new e2e tests** (2 per client × Python / Node.js / Go / Java)…
+```
+
+✅ **Good**:
+
+```markdown
+### Added
+- Recognise `CURRENT_USER()` and `@@session.user` as aliases for `SESSION_USER()`.
+- Thread the caller identity into Storage Read row-restriction filters.
+```
+
+The reader who wants more depth reads the corresponding ADR. The
+ADR is the durable place for "three options considered, here's
+why we picked C". The changelog is for "here's what changed".
+
+### Authoring cadence
+
+CHANGELOG entries are authored **at release time**, not on every
+PR. A PR's body documents what the PR did; the changelog
+captures what the release shipped. At release time the operator
+reads `git log <prev-tag>..HEAD` and synthesises one bullet per
+user-visible change.
+
+There is no `## [Unreleased]` section between releases. The first
+heading after `# Changelog` is always the most recent shipped
+version.
+
+### Mutability
+
+A released version's section is **immutable** except to fix an
+error (typo, wrong reference, factual mistake about what
+shipped). Mutability is not for adding context, expanding
+explanations, or back-filling work that was forgotten — that
+goes in a new release.
+
+## Migration path for existing content
+
+This guide ships as the authoritative standard. Existing
+docstrings, comments, and the CHANGELOG were authored before it
+and will be brought into compliance through a series of focused
+PRs:
+
+- A separate PR rewrites `CHANGELOG.md` end-to-end (every version
+  section + the removal of the `Unreleased` section).
+- A separate PR sweeps every docstring under `src/bqemulator/**`.
+- A separate PR sweeps `docs/reference/**` and
+  `docs/architecture/**` (excluding ADRs and RFCs).
+
+Until those PRs land, expect old code to violate this guide. New
+PRs against `main` are expected to comply.

--- a/docs/architecture/contributing/release-process.md
+++ b/docs/architecture/contributing/release-process.md
@@ -63,15 +63,23 @@ a dedicated exit code):
 3. `make verify` exits 0 — the full release gate chain (lint + unit +
    property + integration + docker + e2e + docs).
 4. The computed target version is strictly greater than the current.
-5. `CHANGELOG.md`'s `Unreleased` section has at least one entry
-   (override with `--allow-empty-changelog` for zero-impact patches).
+5. A new `## [X.Y.Z] - YYYY-MM-DD` section has been prepended to
+   `CHANGELOG.md` with at least one entry. The section is authored
+   during this release process (step 1 below) — not in the
+   individual PRs that landed during the cycle.
 
 ## Step-by-step (with the orchestrator)
 
-1. **Prepare the changelog.** Every PR that lands during the release
-   cycle must add an entry under `## [Unreleased]`
-   (`Added` / `Changed` / `Deprecated` / `Removed` / `Fixed` /
-   `Security`).
+1. **Author the changelog section.** Read `git log <prev-tag>..HEAD`
+   to enumerate user-visible changes since the previous release.
+   Synthesise one bullet per change under `### Changed` /
+   `### Added` / `### Removed` / `### Fixed` (Common Changelog
+   ordering — breaking changes most important). Entries follow the
+   [documentation style guide](documentation-style-guide.md#changelog):
+   imperative mood, single line, no per-entry sub-headings, no PR
+   references, no fixture counts. Prepend the new section under
+   the `# Changelog` heading; there is no `## [Unreleased]` section
+   between releases.
 
 2. **Pre-release doc sweep.** The release orchestrator only mutates
    three surfaces: `src/bqemulator/__version__` and the README

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -177,6 +177,7 @@ nav:
       - Conformance tier: architecture/conformance-tier.md
       - Contributing:
           - Dev environment: architecture/contributing/dev-environment.md
+          - Documentation style guide: architecture/contributing/documentation-style-guide.md
           - Release process: architecture/contributing/release-process.md
           - Adding SQL functions: architecture/contributing/adding-sql-functions.md
           - Adding UDF runtimes: architecture/contributing/adding-udf-runtimes.md


### PR DESCRIPTION
## Summary

First PR in the documentation rewrite series. Codifies the conventions for docstrings, code comments, reference docs, and the changelog before the sweep PRs touch hundreds of files. This is the explicit standard those PRs will reference.

**Core principle:** code and reference docs describe the **current state** of the software; ADRs and the changelog describe its **history**. The two surfaces don't mix.

## What lands here

| File | Change |
|---|---|
| `docs/architecture/contributing/documentation-style-guide.md` | **NEW** — authoritative rules + good/bad examples for docstrings, code comments, reference docs, and the changelog. Pins Keep a Changelog 1.1.0 + Common Changelog spellings. |
| `AGENTS.md` | New bullet under Conventions linking to the guide + restating the core principle. |
| `docs/architecture/contributing/release-process.md` | "Prepare the changelog" step rewritten — entries now authored at release time from `git log`, not per-PR. Pre-flight checks for `## [X.Y.Z]` section rather than `## [Unreleased]`. |
| `mkdocs.yml` | Guide added to the Contributing nav. |

## What's in the guide

- **Docstrings**: imperative-mood single-sentence first line, present-tense body. No dates / PR refs / phase labels / TODOs / "previously X" / "added in Y". Cross-references to current specs (ADRs, BQ docs) are fine; history is not.
- **Code comments**: only when *why* is non-obvious. Never *what*. Same forbidden list as docstrings.
- **Reference docs** (`docs/reference/**`, `docs/architecture/**` except ADRs/RFCs): same rules as docstrings.
- **ADRs**: explicitly exempt. They're history by design.
- **CHANGELOG**: Keep a Changelog 1.1.0 + Common Changelog. One-line imperative entries, no per-entry sub-headings, no PR refs, no fixture counts. Sections ordered Changed / Added / Removed / Fixed. No `## [Unreleased]` between releases — entries authored at release time only. Released sections immutable except for error fixes.

Each section has ✅ good / ❌ bad examples drawn from the current codebase so the contrast is concrete.

## What this PR does NOT touch

- **Existing docstrings, comments, the CHANGELOG itself, and the reference docs are NOT modified.** Those are the next three PRs in the series (A, B, C). This PR is the standard; those PRs apply it.
- **`scripts/changelog.py`** and the `make verify` changelog-presence gate are unchanged. They'll be revisited in PR A (the CHANGELOG rewrite) when the shape of the changelog itself changes.

## Migration path (documented in the guide)

- **PR A** — rewrite `CHANGELOG.md` end-to-end (every version section + `Unreleased` removal).
- **PR B** — sweep every docstring under `src/bqemulator/**`.
- **PR C** — sweep `docs/reference/**` and `docs/architecture/**` (excluding ADRs and RFCs).
- v1.1.0 cut comes after A + B + C all land.

## Test plan

- [x] `make verify` passes locally (lint + types + security + 3197 tests + e2e + matrices + docs-strict)
- [x] mkdocs builds the new doc cleanly in strict mode
- [x] No source code changes — purely additive docs
- [ ] CI green on PR
- [ ] CodeRabbit review on the guide content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a comprehensive documentation style guide establishing conventions for code documentation, comments, and changelog entries
  * Defined standards for documentation to reflect current software state, with historical context reserved for appropriate sections
  * Updated release process documentation with new changelog entry preparation and formatting requirements
  * Integrated new style guide into documentation site navigation for easy access

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->