### PR TITLE
docs(src): sweep docstrings + comments per style guide (PR B)

### DIFF
--- a/src/bqemulator/api/app.py
+++ b/src/bqemulator/api/app.py
@@ -70,7 +70,7 @@ def create_app(context: AppContext) -> FastAPI:
     app.include_router(routines_router)
     app.include_router(row_access_policies_router)
     app.include_router(jobs_router)
-    # G2 — upload host (multipart + resumable). Mounted at
+    # Upload host (multipart + resumable). Mounted at
     # /upload/bigquery/v2 to match BigQuery's documented upload URL prefix.
     app.include_router(upload_router)
     # Admin diagnostic endpoints — opt-in via Settings.admin_enabled.

--- a/src/bqemulator/api/dependencies.py
+++ b/src/bqemulator/api/dependencies.py
@@ -48,7 +48,7 @@ class AppContext:
     # /admin/streams endpoint. Defaults to a fresh instance so tests that
     # build an AppContext directly don't have to know about it.
     write_streams: WriteStreamManager = field(default_factory=WriteStreamManager)
-    # G2 — resumable upload session manager. Constructed lazily by the
+    # Resumable upload session manager. Constructed lazily by the
     # composition root when the upload router is wired in. ``None`` in
     # contexts that don't need uploads (gRPC-only tests, unit fakes).
     upload_sessions: UploadSessionManager | None = None

--- a/src/bqemulator/api/routes/datasets.py
+++ b/src/bqemulator/api/routes/datasets.py
@@ -147,12 +147,12 @@ def _dataset_to_rest(ds: DatasetMeta) -> dict[str, Any]:
         # datasets and ``LINKED`` / ``EXTERNAL`` for the federated
         # variants the emulator doesn't model. Emit the constant so
         # clients that switch on the field find the documented value.
-        # P7.c follow-up — required for ``datasets.list`` shape parity.
+        # Required for ``datasets.list`` shape parity.
         "type": "DEFAULT",
         # BigQuery's documented default time-travel window for ordinary
         # datasets is 7 days = 168 hours. Clients use this to decide
         # whether AS-OF queries within the window can be served from
-        # the time-travel index. P7.c follow-up.
+        # the time-travel index.
         "maxTimeTravelHours": "168",
     }
     if ds.friendly_name:

--- a/src/bqemulator/api/routes/jobs.py
+++ b/src/bqemulator/api/routes/jobs.py
@@ -62,7 +62,7 @@ _Caller = Annotated[CallerIdentity, Depends(get_caller)]
 
 #: DomainError subclasses that real BigQuery surfaces as
 #: ``Job.status.errorResult`` rather than a direct HTTP 4xx response
-#: (P3.a, ADR 0022 §3 ``Error parity``). The Python client maps
+#: (see ADR 0022 §3 ``Error parity``). The Python client maps
 #: ``reason`` → exception class when polling a DONE+ERROR job, so the
 #: shape needs to match real BQ. Request-level errors
 #: (UnsupportedFeatureError, ValidationError) continue to surface as
@@ -214,19 +214,19 @@ async def query(
     dry_run: bool = body.get("dryRun", False)
     max_results: int = body.get("maxResults", 10000)
     query_params = body.get("queryParameters")
-    # P7.c — surface a fresh session token when ``createSession=true``
-    # is set on the request body. The synchronous ``jobs.query`` shape
-    # accepts the field at the top level (the asynchronous
-    # ``jobs.insert`` shape places it under ``configuration.query``).
+    # Surface a fresh session token when ``createSession=true`` is set
+    # on the request body. The synchronous ``jobs.query`` shape accepts
+    # the field at the top level (the asynchronous ``jobs.insert``
+    # shape places it under ``configuration.query``).
     _validate_session_id(body)
     session_id = _maybe_mint_session(body)
 
-    # P7.c follow-up — when ``useLegacySql=true`` is set, run the
-    # narrow legacy-to-standard rewriter that handles the type-cast
-    # function subset (INTEGER/FLOAT/STRING/BOOLEAN/BYTES) and the
+    # When ``useLegacySql=true`` is set, run the narrow legacy-to-
+    # standard rewriter that handles the type-cast function subset
+    # (INTEGER/FLOAT/STRING/BOOLEAN/BYTES) and the
     # ``[project:dataset.table]`` reference shape. Queries using
     # other legacy-SQL features still surface a translation error
-    # downstream, but the simple compat-mode SELECTs now PASS.
+    # downstream, but the simple compat-mode SELECTs work.
     if use_legacy_sql:
         from bqemulator.sql.rewriter.legacy_sql import rewrite_legacy_to_standard
 
@@ -258,7 +258,7 @@ async def query(
             caller=caller,
         )
     except _SQL_EXECUTION_DOMAIN_ERRORS as exc:
-        # P3.a / ADR 0022 §3: surface SQL execution failures as
+        # ADR 0022 §3: surface SQL execution failures as
         # ``status.errorResult`` on the job rather than a direct HTTP
         # error. This matches real BigQuery's behaviour and is what
         # the BQ Python client expects for jobs.query — without this
@@ -302,15 +302,15 @@ async def query(
         "rows": rows,
         "totalRows": str(total_rows),
     }
-    # P7.b — surface the new response-metadata fields on jobs.query so
-    # the BQ Python client populates ``QueryJob.cache_hit``,
+    # Surface the response-metadata fields on jobs.query so the BQ
+    # Python client populates ``QueryJob.cache_hit``,
     # ``QueryJob.statement_type``, and ``QueryJob.num_dml_affected_rows``.
     # The values come from the executor's ``statistics.query`` block;
     # we mirror them onto the top-level body since the Python client
     # reads both shapes on the synchronous query path.
     _attach_query_metadata(response, job_meta)
-    # P7.c — attach the minted session token to the response shape and
-    # to the persisted JobMeta so async polls find the same id.
+    # Attach the minted session token to the response shape and to the
+    # persisted JobMeta so async polls find the same id.
     if session_id is not None:
         job_meta.statistics.setdefault("sessionInfo", {"sessionId": session_id})
         response["sessionInfo"] = {"sessionId": session_id}
@@ -379,7 +379,7 @@ async def _dry_run_response(
         # Dry-run resolver errors surface through the dry-run-specific
         # wire shape: ``error.location="q"`` (single character, not
         # ``"query"``) and the original identifier case from the BQ SQL
-        # (DuckDB lowercases identifiers through its parser). P7.c.
+        # (DuckDB lowercases identifiers through its parser).
         try:
             job_meta = await execute_query_job(
                 project_id,
@@ -400,13 +400,12 @@ async def _dry_run_response(
         captured = job_meta.statistics.get("query", {}).get("statementType")
         statement_type = captured or statement_type
     elif is_destructive:
-        # P7.b phase 2 follow-up #1 — destructive statements skip
-        # execution to avoid committing side effects, but BigQuery
-        # still reconstructs the schema preview from the DDL column
-        # list (CREATE TABLE) or the destination table's catalog
-        # entry (INSERT/UPDATE/DELETE/MERGE). Walk the AST in
-        # :func:`_destructive_dry_run_schema` to mirror the wire
-        # shape without running the statement.
+        # Destructive statements skip execution to avoid committing
+        # side effects, but BigQuery still reconstructs the schema
+        # preview from the DDL column list (CREATE TABLE) or the
+        # destination table's catalog entry (INSERT/UPDATE/DELETE/
+        # MERGE). Walk the AST in :func:`_destructive_dry_run_schema`
+        # to mirror the wire shape without running the statement.
         schema_fields = _destructive_dry_run_schema(
             bq_sql=bq_sql,
             statement_type=statement_type,
@@ -425,10 +424,9 @@ async def _dry_run_response(
     }
     if statement_type:
         body["statementType"] = statement_type
-        # P7.b phase 2 follow-up #1 — surface ddlOperationPerformed on
-        # the dry-run preview for DDL statements; the comparator's
-        # ``_compare_job_metadata`` reads this key when present on the
-        # recorded baseline.
+        # Surface ddlOperationPerformed on the dry-run preview for DDL
+        # statements; the comparator's ``_compare_job_metadata`` reads
+        # this key when present on the recorded baseline.
         from bqemulator.jobs.executor import _ddl_operation_for  # local import to avoid cycle
 
         ddl_op = _ddl_operation_for(statement_type)
@@ -446,7 +444,7 @@ async def _dry_run_response(
 #: Match ``Function not found: <name> at [L:C]`` where ``<name>`` is
 #: an unquoted identifier. The mapper renders this shape with DuckDB's
 #: lower-cased identifier; the rewrite below recovers the original
-#: casing from the BQ source SQL. P7.c.
+#: casing from the BQ source SQL.
 _FUNCTION_NOT_FOUND_RE = re.compile(
     r"Function not found: (?P<name>[A-Za-z_][A-Za-z0-9_]*)",
 )
@@ -466,8 +464,7 @@ def _rewrite_for_dry_run(exc: DomainError, *, bq_sql: str) -> None:
        caller's casing. The recorded BigQuery baseline carries the
        original case (e.g. ``BQEMU_NONEXISTENT_FUNCTION``), so we scan
        the BQ SQL for any identifier whose lower-cased form matches the
-       error's name and substitute back. Closes the P7.c
-       ``api_configuration/dry_run_invalid_function`` follow-up.
+       error's name and substitute back.
     """
     if exc.location == "query":
         exc.location = "q"
@@ -519,7 +516,6 @@ def _destructive_dry_run_schema(
 
     Returns an empty list when the AST shape doesn't match a known
     pattern — the caller falls back to the existing 0-col preview.
-    P7.b phase 2 follow-up #1.
     """
     import sqlglot
 
@@ -731,7 +727,7 @@ _DESTRUCTIVE_STATEMENT_TYPES = frozenset(
 #: base64-encoded protobuf, but clients treat the value as opaque so we
 #: mint a URL-safe random token and round-trip it verbatim. The catalog
 #: is process-local — sessions don't survive an emulator restart, same
-#: as TEMP TABLES and declared variables. P7.b phase 2 follow-up #1.
+#: as TEMP TABLES and declared variables.
 _SESSION_CATALOG: set[str] = set()
 
 
@@ -771,7 +767,7 @@ def _maybe_mint_session(query_config: dict[str, Any]) -> str | None:
     The token gets added to :data:`_SESSION_CATALOG` so subsequent jobs
     that reference it via ``connectionProperties.session_id`` survive
     the :func:`_validate_session_id` check. Returns ``None`` when the
-    caller did not request a new session. P7.c.
+    caller did not request a new session.
     """
     if not query_config.get("createSession"):
         return None
@@ -786,7 +782,7 @@ def _attach_session_info(statistics: dict[str, Any], session_id: str | None) -> 
     — the BQ Python client reads that field via
     ``QueryJob.session_info.session_id`` and feeds it into the next
     job's ``connectionProperties``. The emulator mirrors the shape so
-    a round-trip client survives unchanged. P7.c.
+    a round-trip client survives unchanged.
     """
     if session_id is None:
         return
@@ -804,7 +800,7 @@ def _check_schema_update_options(query_config: dict[str, Any]) -> None:
     disposition, or with WRITE_TRUNCATE disposition on a table
     partition."``. The emulator mirrors the rule so clients that rely
     on the rejection (idempotent re-writes, accidental-truncate
-    guard-rails) see the same wire shape. P7.c follow-up.
+    guard-rails) see the same wire shape.
     """
     options = query_config.get("schemaUpdateOptions")
     if not options:
@@ -837,7 +833,7 @@ def _validate_destination_layout_columns(
     schema.``; ``timePartitioning.field`` surfaces as
     ``The field specified for partitioning cannot be found in the
     schema.``. The emulator parses the SELECT's output schema via
-    sqlglot to recover the projected column names. P7.c follow-up.
+    sqlglot to recover the projected column names.
     """
     clustering = query_config.get("clustering") or {}
     clustering_fields = (clustering.get("fields") if isinstance(clustering, dict) else None) or []
@@ -905,7 +901,7 @@ def _apply_default_dataset(
     and fail with ``Referenced column / table not found``. The
     closure here rewrites the SQL through the
     :func:`qualify_unqualified_tables` pre-translator before the
-    executor sees it. P7.b phase 2 follow-up #1.
+    executor sees it.
     """
     default_dataset = query_config.get("defaultDataset")
     if not isinstance(default_dataset, dict):
@@ -1038,8 +1034,6 @@ async def _apply_write_append(
     WRITE_TRUNCATE doesn't need a post-processing step — the
     truncate-then-write semantic makes post-write = SELECT, which is
     already what the executor returns.
-
-    P7.b phase 2 follow-up #1.
     """
     if query_config.get("writeDisposition") != "WRITE_APPEND":
         return job_meta
@@ -1049,7 +1043,7 @@ async def _apply_write_append(
     meta, dest_field_names = resolved
 
     # Schema-superset rejection — ``ALLOW_FIELD_ADDITION`` bypass
-    # routed through ``_validate_write_append_schema`` (P7.c).
+    # routed through ``_validate_write_append_schema``.
     options = {opt.upper() for opt in (query_config.get("schemaUpdateOptions") or [])}
     allow_field_addition = "ALLOW_FIELD_ADDITION" in options
     arrow_table = JOB_RESULTS.get(job_id)
@@ -1106,7 +1100,7 @@ def _pad_table_with_null_columns(table: Any, new_fields: list[Any]) -> Any:
     BigQuery's ``ALLOW_FIELD_ADDITION`` semantics fill pre-existing
     rows with NULL for the newly-added columns. The arrow concat
     needs both tables to share a schema, so we pad the existing
-    table here before the concat. P7.c follow-up.
+    table here before the concat.
     """
     import pyarrow as pa
 
@@ -1129,7 +1123,7 @@ def _evolve_destination_schema(
     schema in place — future reads see the new columns. The emulator
     mirrors the mutation by composing a new ``TableSchema`` with the
     new fields appended (NULLABLE because the column didn't exist for
-    pre-existing rows). P7.c follow-up.
+    pre-existing rows).
     """
     from bqemulator.catalog.models import TableFieldSchema, TableSchema
     from bqemulator.storage.type_map import _DUCKDB_TO_BQ as _ARROW_TO_BQ
@@ -1161,7 +1155,6 @@ def _check_create_disposition(
     executing the query and rejects with ``404 notFound`` when the
     table does not exist and the disposition forbids creating it.
     Composes with both ``WRITE_TRUNCATE`` and ``WRITE_APPEND``.
-    P7.b phase 2 follow-up #1.
     """
     if query_config.get("createDisposition") != "CREATE_NEVER":
         return
@@ -1214,22 +1207,22 @@ async def insert_job(  # noqa: PLR0915 — linear job-type dispatch + async erro
         bq_sql = query_config.get("query", "")
         use_legacy_sql = query_config.get("useLegacySql", False)
         query_params = query_config.get("queryParameters")
-        # P7.b phase 2 follow-up #1 — pre-execution validations that
-        # match real BigQuery's submission-time rejections. These run
-        # before the dry-run / execution path so an invalid request
-        # gets the documented error envelope without touching the
-        # executor or persisting a job.
+        # Pre-execution validations that match real BigQuery's
+        # submission-time rejections. These run before the dry-run /
+        # execution path so an invalid request gets the documented
+        # error envelope without touching the executor or persisting
+        # a job.
         _validate_session_id(query_config)
-        # P7.c follow-up — schemaUpdateOptions are only legal with
-        # WRITE_APPEND (or WRITE_TRUNCATE on a partition decorator).
+        # schemaUpdateOptions are only legal with WRITE_APPEND (or
+        # WRITE_TRUNCATE on a partition decorator).
         _check_schema_update_options(query_config)
-        # P7.c follow-up — clustering / partitioning column references
-        # must exist on the SELECT projection.
+        # Clustering / partitioning column references must exist on
+        # the SELECT projection.
         _validate_destination_layout_columns(bq_sql, query_config)
-        # P7.c — mint a session token if ``createSession=true``; the
-        # token will be attached to ``statistics.sessionInfo.sessionId``
-        # on the response so the client can route follow-up jobs to
-        # the same session via ``connectionProperties.session_id``.
+        # Mint a session token if ``createSession=true``; the token
+        # will be attached to ``statistics.sessionInfo.sessionId`` on
+        # the response so the client can route follow-up jobs to the
+        # same session via ``connectionProperties.session_id``.
         session_id = _maybe_mint_session(query_config)
         if not dry_run:
             _check_create_disposition(
@@ -1237,15 +1230,14 @@ async def insert_job(  # noqa: PLR0915 — linear job-type dispatch + async erro
                 ctx=ctx,
                 request_project_id=project_id,
             )
-        # P7.b phase 2 follow-up #1 — apply ``defaultDataset`` to
-        # unqualified table refs in the SQL body. BigQuery's parser
-        # does this at submission time; the emulator's translator
-        # doesn't have access to the job-level config, so we rewrite
-        # before handing the SQL to the executor.
+        # Apply ``defaultDataset`` to unqualified table refs in the SQL
+        # body. BigQuery's parser does this at submission time; the
+        # emulator's translator doesn't have access to the job-level
+        # config, so we rewrite before handing the SQL to the executor.
         bq_sql = _apply_default_dataset(bq_sql, query_config, request_project_id=project_id)
 
-        # P7.c follow-up — narrow legacy-to-standard SQL rewriter for
-        # the ``useLegacySql=true`` compat-mode case (see the matching
+        # Narrow legacy-to-standard SQL rewriter for the
+        # ``useLegacySql=true`` compat-mode case (see the matching
         # branch in ``query`` above for the rationale).
         if use_legacy_sql:
             from bqemulator.sql.rewriter.legacy_sql import rewrite_legacy_to_standard
@@ -1253,7 +1245,7 @@ async def insert_job(  # noqa: PLR0915 — linear job-type dispatch + async erro
             bq_sql = rewrite_legacy_to_standard(bq_sql)
 
         if dry_run:
-            # P7.b — populate the schema preview + statementType + cacheHit
+            # Populate the schema preview + statementType + cacheHit
             # so the wire shape matches real BigQuery. Reuse the
             # ``_dry_run_response`` helper used by ``jobs.query``; the
             # ``insert`` shape adds a persisted JobMeta on top so async
@@ -1276,9 +1268,9 @@ async def insert_job(  # noqa: PLR0915 — linear job-type dispatch + async erro
             }
             if preview.get("statementType"):
                 statistics["query"]["statementType"] = preview["statementType"]
-            # P7.b phase 2 follow-up #1 — propagate ddlOperationPerformed
-            # so the recorded job_metadata diff for DDL dry-runs has
-            # the same key as a real BigQuery dry-run preview.
+            # Propagate ddlOperationPerformed so the recorded
+            # job_metadata diff for DDL dry-runs has the same key as a
+            # real BigQuery dry-run preview.
             if preview.get("ddlOperationPerformed"):
                 statistics["query"]["ddlOperationPerformed"] = preview["ddlOperationPerformed"]
             job_meta = JobMeta(
@@ -1293,8 +1285,8 @@ async def insert_job(  # noqa: PLR0915 — linear job-type dispatch + async erro
                 end_time=now,
                 etag=generate_etag(project_id, job_id, str(now)),
             )
-            # P7.c — even on a dry-run, BigQuery surfaces the minted
-            # session token on the response so the client can chain a
+            # Even on a dry-run, BigQuery surfaces the minted session
+            # token on the response so the client can chain a
             # subsequent (non-dry-run) job that references it.
             _attach_session_info(job_meta.statistics, session_id)
             ctx.catalog.upsert_job(job_meta)
@@ -1315,14 +1307,14 @@ async def insert_job(  # noqa: PLR0915 — linear job-type dispatch + async erro
                 caller=caller,
             )
         except _SQL_EXECUTION_DOMAIN_ERRORS as exc:
-            # P3.a / ADR 0022 §3: persist SQL execution failures on
-            # the job's ``status.errorResult`` so the BQ Python
-            # client's retry logic on POST /jobs (which retries on
-            # 409 / 503) sees a settled DONE+ERROR state instead of
-            # polling for a never-completing job. See the matching
-            # branch in the POST /queries handler above. Request-level
-            # errors (UnsupportedFeatureError, ValidationError)
-            # continue to surface as direct HTTP responses.
+            # ADR 0022 §3: persist SQL execution failures on the
+            # job's ``status.errorResult`` so the BQ Python client's
+            # retry logic on POST /jobs (which retries on 409 / 503)
+            # sees a settled DONE+ERROR state instead of polling for a
+            # never-completing job. See the matching branch in the
+            # POST /queries handler above. Request-level errors
+            # (UnsupportedFeatureError, ValidationError) continue to
+            # surface as direct HTTP responses.
             job_meta = _failed_job_meta(
                 project_id=project_id,
                 job_id=job_id,
@@ -1332,13 +1324,12 @@ async def insert_job(  # noqa: PLR0915 — linear job-type dispatch + async erro
                 now=ctx.clock.now(),
             )
         else:
-            # P7.b phase 2 follow-up #1 — SELECT-with-destination +
-            # WRITE_APPEND. BigQuery returns the destination's
-            # post-write content (pre-existing rows + SELECT rows)
-            # and enforces schema-superset rejection. Run AFTER the
-            # SELECT so we can compare its projection schema to the
-            # destination's. WRITE_TRUNCATE's wire shape happens to
-            # equal the SELECT projection (BQ truncates then writes,
+            # SELECT-with-destination + WRITE_APPEND. BigQuery returns
+            # the destination's post-write content (pre-existing rows +
+            # SELECT rows) and enforces schema-superset rejection. Run
+            # AFTER the SELECT so we can compare its projection schema
+            # to the destination's. WRITE_TRUNCATE's wire shape happens
+            # to equal the SELECT projection (BQ truncates then writes,
             # so post-write = SELECT) so the existing path covers it.
             job_meta = await _apply_write_append(
                 job_meta=job_meta,
@@ -1348,24 +1339,24 @@ async def insert_job(  # noqa: PLR0915 — linear job-type dispatch + async erro
                 caller=caller,
                 request_project_id=project_id,
             )
-        # P7.c — surface the session token on the JobMeta's statistics
-        # for both the success path and the error-result path so a
+        # Surface the session token on the JobMeta's statistics for
+        # both the success path and the error-result path so a
         # subsequent ``jobs.get`` poll finds the same field shape the
         # ``jobs.insert`` synchronous response carried.
         _attach_session_info(job_meta.statistics, session_id)
 
     elif "load" in config:
-        # G1 follow-up (2026-05-20): match BQ's async load wire shape —
-        # source-file processing errors return HTTP 200 with the
-        # job's ``status.errorResult`` populated rather than a 5xx.
-        # Validation errors (UnsupportedFeatureError /
-        # InvalidQueryError("Unknown source format ...") / missing
-        # destination) still bubble out as direct HTTP responses so
-        # existing tests (test_load_unsupported_format_returns_error)
-        # and the AVRO/ORC missing-extension fallback keep their 400
-        # / 501 contracts. Engine-level exceptions (DuckDB conversion
-        # / IO / binder errors, fastavro decode errors) get the
-        # async envelope treatment.
+        # Match BQ's async load wire shape — source-file processing
+        # errors return HTTP 200 with the job's ``status.errorResult``
+        # populated rather than a 5xx. Validation errors
+        # (UnsupportedFeatureError / InvalidQueryError("Unknown source
+        # format ...") / missing destination) still bubble out as
+        # direct HTTP responses so existing tests
+        # (test_load_unsupported_format_returns_error) and the
+        # AVRO/ORC missing-extension fallback keep their 400 / 501
+        # contracts. Engine-level exceptions (DuckDB conversion / IO
+        # / binder errors, fastavro decode errors) get the async
+        # envelope treatment.
         try:
             job_meta = await execute_load_job(project_id, job_id, config, ctx)
         except (UnsupportedFeatureError, InvalidQueryError, ValidationError):
@@ -1567,12 +1558,9 @@ def delete_job_canonical(
     """Delete a job (canonical BigQuery REST API path with ``/delete`` suffix).
 
     See https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/delete.
-    Real BigQuery returns ``200 OK`` with an empty JSON body (``{}``); the
-    trailing ``/delete`` segment and the success body's wire shape were
-    both surfaced by P2.f recording when the previous ``204``-with-no-
-    suffix shape returned ``404 Not Found`` against the live service.
-    The :func:`delete_job` alias below stays for back-compat with
-    earlier emulator releases that documented the short form.
+    Real BigQuery returns ``200 OK`` with an empty JSON body (``{}``)
+    on the ``/delete``-suffixed path. The :func:`delete_job` alias
+    below carries the short form for back-compat.
     """
     ctx.catalog.delete_job(project_id, job_id)
     JOB_RESULTS.pop(job_id, None)

--- a/src/bqemulator/api/routes/tabledata.py
+++ b/src/bqemulator/api/routes/tabledata.py
@@ -28,7 +28,7 @@ _Ctx = Annotated[AppContext, Depends(get_context)]
 def _build_arrow_schema(fields_raw: list[dict[str, Any]]) -> pa.Schema:
     """Build a pyarrow schema from BigQuery REST schema fields.
 
-    Phase 9 specialized types are stamped with metadata so the
+    Specialized BigQuery types are stamped with metadata so the
     arrow_bridge coercer can dispatch on the BigQuery type when
     converting JSON input. GEOGRAPHY backs onto ``pa.string()`` and
     carries ``bq_type=GEOGRAPHY`` so the coercer turns inbound WKT
@@ -169,11 +169,10 @@ async def insert_all(
     ]
     arrow_schema = _build_arrow_schema(fields_raw)
 
-    # P7.c follow-up — when ``skipInvalidRows=true`` is set, attempt
-    # to convert each row individually and capture the per-row error
-    # so the request returns a partial success (matching BigQuery's
-    # ``insertErrors[]`` wire shape). Without the flag, the historical
-    # behaviour is preserved: the first bad row aborts the whole
+    # When ``skipInvalidRows=true`` is set, attempt to convert each row
+    # individually and capture the per-row error so the request returns
+    # a partial success (matching BigQuery's ``insertErrors[]`` wire
+    # shape). Without the flag, the first bad row aborts the whole
     # request with an internal error.
     insert_errors: list[dict[str, Any]] = []
     if skip_invalid_rows:
@@ -219,10 +218,9 @@ async def insert_all(
         updated = table_meta.model_copy(update={"num_rows": new_count})
         ctx.catalog.update_table(updated)
 
-        # Phase 7: capture a snapshot and emit TableDataChanged (the
-        # latter was already being emitted — snapshots.record_change
-        # publishes it again, but the event bus is cheap and
-        # subscribers must be idempotent).
+        # Capture a snapshot and emit TableDataChanged.
+        # ``snapshots.record_change`` publishes the event; subscribers
+        # are required to be idempotent.
         ctx.snapshots.record_change(project_id, dataset_id, table_id)
 
     response: dict[str, Any] = {"kind": "bigquery#tableDataInsertAllResponse"}
@@ -244,8 +242,7 @@ def _format_insert_error(
     Real BigQuery returns ``{index, errors: [{reason, location, debugInfo,
     message}, ...]}`` per failing row. The emulator's best-effort
     location is the first column name from the request's ``json``
-    payload — clients use this to highlight the offending field. P7.c
-    follow-up.
+    payload — clients use this to highlight the offending field.
     """
     location = ""
     bad_value: Any = None
@@ -265,7 +262,7 @@ def _format_insert_error(
     # (bad value): <value>``. Rebuild the message in that shape using
     # the failing field's declared type + the offending value, falling
     # back to the raw exception text when the location isn't a known
-    # column. P7.c follow-up.
+    # column.
     message = str(exc)
     if location:
         try:
@@ -293,7 +290,7 @@ def _bq_type_name_for(arrow_type: Any) -> str:
 
     The mapping covers the primitive types the emulator's insertAll
     converter rejects; the fallback name is the arrow type's
-    ``str(...)``. P7.c follow-up.
+    ``str(...)``.
     """
     name = str(arrow_type)
     return _ARROW_TO_BQ_USER_NAME.get(name, name)
@@ -332,7 +329,7 @@ def list_tabledata(
     Supports BigQuery's ``selectedFields`` (CSV column projection) and
     ``pageToken`` (opaque continuation token). The emulator's
     ``pageToken`` is a literal stringified offset — opaque to clients,
-    cheap to compute, and consistent across re-reads. P7.c follow-up.
+    cheap to compute, and consistent across re-reads.
     """
     table_meta = ctx.catalog.get_table(project_id, dataset_id, table_id)
     if table_meta is None:
@@ -383,7 +380,6 @@ def _parse_selected_fields(selected_fields: str | None, table_meta: Any) -> str:
     emulator passes the request through to DuckDB which raises
     ``Catalog Error`` — the existing error mapper translates that to
     the BQ wire shape. Returns ``"*"`` when no projection is requested.
-    P7.c follow-up.
     """
     if not selected_fields:
         return "*"

--- a/src/bqemulator/api/routes/tables.py
+++ b/src/bqemulator/api/routes/tables.py
@@ -69,11 +69,11 @@ def _table_to_rest(t: TableMeta) -> dict[str, Any]:
         "lastModifiedTime": str(int(t.last_modified_time.timestamp() * 1000)),
         "numRows": str(t.num_rows),
         "numBytes": str(t.num_bytes),
-        # P7.c follow-up — BigQuery emits four additional byte-count
-        # fields on the table resource. The emulator has no
-        # logical-vs-physical storage model, so we mirror ``numBytes``
-        # across all four. Wire-shape parity for clients that key on
-        # the field names; values are not load-bearing.
+        # BigQuery emits four additional byte-count fields on the table
+        # resource. The emulator has no logical-vs-physical storage
+        # model, so we mirror ``numBytes`` across all four. Wire-shape
+        # parity for clients that key on the field names; values are
+        # not load-bearing.
         "numActiveLogicalBytes": str(t.num_bytes),
         "numTotalLogicalBytes": str(t.num_bytes),
         "numLongTermBytes": "0",
@@ -438,7 +438,7 @@ async def delete_table(
     async with ctx.engine.write_lock():
         ctx.engine.execute(f"DROP TABLE IF EXISTS {target_ref}")
         ctx.catalog.delete_table(project_id, dataset_id, table_id)
-        # Phase 7: clean up the AUTO snapshots for this table and any
+        # Clean up the AUTO snapshots for this table and any
         # MV-dependency rows — no point in retaining snapshots of a
         # dropped table. USER snapshots survive only if they were
         # already materialised in other datasets.

--- a/src/bqemulator/api/routes/upload.py
+++ b/src/bqemulator/api/routes/upload.py
@@ -1,4 +1,4 @@
-"""Upload-host REST routes — G2 (multipart + resumable upload).
+"""Upload-host REST routes — multipart + resumable upload.
 
 The official BigQuery client libraries (Python, Node, Go, Java) all
 issue ``client.load_table_from_file(...)`` style calls through a

--- a/src/bqemulator/catalog/duckdb_repository.py
+++ b/src/bqemulator/catalog/duckdb_repository.py
@@ -19,9 +19,8 @@ so concurrent readers see the new state immediately. On
 :meth:`ensure_ready` the cache is hydrated by reading each catalog
 table and reconstructing the Pydantic models from the JSON column.
 
-Earlier work promoted this from an in-memory shim (the Phase 0 placeholder)
-to true persistence — backup/restore and seed/export round-trip the
-catalog because every entity now lands in DuckDB.
+Backup/restore and seed/export round-trip the catalog because every
+entity lands in DuckDB.
 """
 
 from __future__ import annotations
@@ -381,12 +380,12 @@ class DuckDBCatalogRepository(CatalogRepository):
                 )
                 # Cascade-delete every dataset-scoped resource. Without
                 # these, deleting+recreating the same ``(project, dataset)``
-                # leaks Phase 7 (snapshots, MVs, MV deps) and Phase 8 (RAPs)
-                # rows past the dataset drop. The next REST POST against
-                # the same table returns 409 Conflict because the legacy
-                # row is still keyed by the same triple. The in-memory
-                # cache cascade above already handles its mirror; this
-                # block keeps the persistent DuckDB-backed catalog in sync.
+                # leaks snapshots, MVs, MV deps, and RAPs past the dataset
+                # drop. The next REST POST against the same table returns
+                # 409 Conflict because the orphaned row is still keyed by
+                # the same triple. The in-memory cache cascade above
+                # already handles its mirror; this block keeps the
+                # persistent DuckDB-backed catalog in sync.
                 self._engine.execute(
                     f'DELETE FROM "{CATALOG_SCHEMA}"."row_access_policies" '
                     f"WHERE project_id = ? AND dataset_id = ?",

--- a/src/bqemulator/catalog/migrations/m002_versioning.py
+++ b/src/bqemulator/catalog/migrations/m002_versioning.py
@@ -1,4 +1,4 @@
-"""Phase 7 — versioning catalog schema.
+"""Versioning catalog schema — snapshots and materialized views.
 
 Adds three persistent tables:
 
@@ -34,11 +34,11 @@ if TYPE_CHECKING:  # pragma: no cover
 __all__ = ["DESCRIPTION", "SNAPSHOTS_SCHEMA", "VERSION", "up"]
 
 VERSION = 2
-DESCRIPTION = "Phase 7 — snapshot + materialized-view catalog tables"
+DESCRIPTION = "snapshot + materialized-view catalog tables"
 
 
 def up(engine: DuckDBEngine) -> None:
-    """Create the Phase 7 catalog tables and snapshots schema."""
+    """Create the versioning catalog tables and snapshots schema."""
     engine.execute(f'CREATE SCHEMA IF NOT EXISTS "{SNAPSHOTS_SCHEMA}"')
 
     engine.execute(

--- a/src/bqemulator/catalog/migrations/m003_row_access.py
+++ b/src/bqemulator/catalog/migrations/m003_row_access.py
@@ -1,4 +1,4 @@
-"""Phase 8 — row access policy + dataset access-entries catalog schema.
+"""Row access policy + dataset access-entries catalog schema.
 
 Adds two persistent tables under the reserved ``_bqemulator_catalog``
 schema:
@@ -34,11 +34,11 @@ if TYPE_CHECKING:  # pragma: no cover
 __all__ = ["DESCRIPTION", "VERSION", "up"]
 
 VERSION = 3
-DESCRIPTION = "Phase 8 — row access policy + dataset access-entries catalog tables"
+DESCRIPTION = "row access policy + dataset access-entries catalog tables"
 
 
 def up(engine: DuckDBEngine) -> None:
-    """Create the Phase 8 catalog tables."""
+    """Create the row access + dataset access-entries catalog tables."""
     engine.execute(
         f"""
         CREATE TABLE IF NOT EXISTS "{CATALOG_SCHEMA}"."row_access_policies" (

--- a/src/bqemulator/catalog/models.py
+++ b/src/bqemulator/catalog/models.py
@@ -52,9 +52,9 @@ class TableFieldSchema(_Frozen):
     default_value_expression: str | None = None
     collation: str | None = None
     rounding_mode: str | None = None
-    # Phase 9 — RANGE field subtype. Required when ``type == "RANGE"``;
-    # the inner type is one of DATE / DATETIME / TIMESTAMP. Matches
-    # BigQuery's REST ``rangeElementType`` shape.
+    # RANGE field subtype. Required when ``type == "RANGE"``; the inner
+    # type is one of DATE / DATETIME / TIMESTAMP. Matches BigQuery's
+    # REST ``rangeElementType`` shape.
     range_element_type: TableFieldSchema | None = None
 
 
@@ -191,7 +191,7 @@ class TableMeta(_Frozen):
 
 
 # ---------------------------------------------------------------------------
-# Snapshot (Phase 7 — time travel + explicit snapshots)
+# Snapshot — time travel + explicit snapshots
 # ---------------------------------------------------------------------------
 
 

--- a/src/bqemulator/catalog/repository.py
+++ b/src/bqemulator/catalog/repository.py
@@ -45,9 +45,9 @@ class CatalogRepository(Protocol):
     def list_all_datasets(self) -> tuple[DatasetMeta, ...]:
         """Return every dataset across every project (possibly empty).
 
-        Used by the Phase 10 admin / export / seed paths that need a
-        full catalog walk without knowing the project ids in advance.
-        Order is implementation-defined.
+        Used by the admin / export / seed paths that need a full catalog
+        walk without knowing the project ids in advance. Order is
+        implementation-defined.
         """
         ...
 
@@ -127,7 +127,7 @@ class CatalogRepository(Protocol):
     def list_views(self, project_id: str, dataset_id: str) -> tuple[TableMeta, ...]:
         """Return all VIEW-typed tables in the dataset (possibly empty).
 
-        This is the G4 ``INFORMATION_SCHEMA.VIEWS`` source. The returned
+        Backs ``INFORMATION_SCHEMA.VIEWS``. The returned
         :class:`TableMeta` instances carry ``table_type='VIEW'`` and
         ``view_query`` populated with the BigQuery SQL view definition.
         """

--- a/src/bqemulator/cli.py
+++ b/src/bqemulator/cli.py
@@ -208,10 +208,9 @@ def import_cmd(
     """Mirror schemas from a real BigQuery project into the local catalog."""
     # Deferred import: the implementation depends on the optional
     # ``import`` extra (``google-cloud-bigquery``). If the extra is
-    # missing — or if Phase 10 modules are not yet installed — surface a
-    # clean instruction instead of an opaque ImportError. We catch
-    # ImportError both around the module import AND around the call
-    # itself, because ``run_import`` defers the
+    # missing, surface a clean instruction instead of an opaque
+    # ImportError. We catch ImportError both around the module import
+    # AND around the call itself, because ``run_import`` defers the
     # ``from google.cloud import bigquery`` line until invocation to
     # keep the CLI's cold-start fast.
     try:
@@ -286,7 +285,7 @@ def export_cmd(data_dir: Path, output_dir: Path) -> None:
     "--input-dir",
     type=click.Path(file_okay=False, exists=True, path_type=Path),
     required=True,
-    help="Directory previously produced by 'bqemulator export'.",
+    help="Directory produced by an earlier 'bqemulator export'.",
 )
 def seed_cmd(data_dir: Path, input_dir: Path) -> None:
     """Load an export directory back into a local persistent catalog."""
@@ -349,7 +348,7 @@ def backup_cmd(data_dir: Path, output_dir: Path) -> None:
     "input_dir",
     type=click.Path(file_okay=False, exists=True, path_type=Path),
     required=True,
-    help="Backup directory previously produced by 'bqemulator backup'.",
+    help="Backup directory produced by an earlier 'bqemulator backup'.",
 )
 @click.option(
     "--force/--no-force",

--- a/src/bqemulator/commands/export.py
+++ b/src/bqemulator/commands/export.py
@@ -25,8 +25,8 @@ output is portable to any tool in the Parquet ecosystem.
 
 The export is read-only against a running emulator's persistent DuckDB
 file when ``--readonly`` is passed; otherwise it opens the file with
-write access. Phase 10 ADR 0020 documents why we did not pursue an
-"online export over REST" path.
+write access. ADR 0020 covers the exclusion of an "online export over
+REST" path.
 """
 
 from __future__ import annotations

--- a/src/bqemulator/commands/seed.py
+++ b/src/bqemulator/commands/seed.py
@@ -39,7 +39,7 @@ def run_seed(*, data_dir: Path, input_dir: Path) -> SeedSummary:
     Args:
         data_dir: Persistent ``data_dir`` for the local catalog. Created
             if absent.
-        input_dir: Directory previously produced by ``bqemulator export``.
+        input_dir: Directory produced by an earlier ``bqemulator export``.
 
     Returns:
         Counts of seeded entities.

--- a/src/bqemulator/config.py
+++ b/src/bqemulator/config.py
@@ -175,9 +175,9 @@ class Settings(BaseSettings):
         default=True,
         description=(
             "Install and load DuckDB's ``avro`` extension at engine boot "
-            "(G1 — load/extract Avro). Disable in constrained deployments "
-            "that cannot reach the DuckDB extension repository at "
-            "``extensions.duckdb.org``. When disabled, ``AVRO`` load + "
+            "(needed for Avro load/extract). Disable in constrained "
+            "deployments that cannot reach the DuckDB extension repository "
+            "at ``extensions.duckdb.org``. When disabled, ``AVRO`` load + "
             "extract jobs surface ``UnsupportedFeatureError``; ``ORC`` "
             "load continues to work because it uses the Python "
             "``pyorc`` package (optional ``[orc]`` extra) rather than a "
@@ -185,7 +185,7 @@ class Settings(BaseSettings):
         ),
     )
 
-    # -- Upload host (G2 — multipart / resumable upload endpoints) ---------
+    # -- Upload host (multipart / resumable upload endpoints) -------------
     upload_max_bytes: int = Field(
         default=1024 * 1024 * 1024,
         ge=1024,

--- a/src/bqemulator/grpc_api/proto/__init__.py
+++ b/src/bqemulator/grpc_api/proto/__init__.py
@@ -1,10 +1,8 @@
 """Generated gRPC proto stubs.
 
 This directory holds ``_pb2.py`` and ``_pb2_grpc.py`` modules generated
-from the vendored googleapis BigQuery Storage protos.
-
-Phase 0 ships this package empty; generation runs in Phase 4 via
-``scripts/generate_protos.sh``.
+from the vendored googleapis BigQuery Storage protos. Generation is
+driven by ``scripts/generate_protos.sh``.
 """
 
 from __future__ import annotations

--- a/src/bqemulator/grpc_api/read_servicer.py
+++ b/src/bqemulator/grpc_api/read_servicer.py
@@ -236,13 +236,11 @@ class BigQueryReadHandler(grpc.GenericRpcHandler):
         # Resolve the caller from gRPC metadata up-front so both the
         # row_restriction filter pre-pass (inside ``_build_read_sql``)
         # and the row-access policy rewrite below see the same
-        # ``CallerIdentity``. Pre-ADR-0040 the caller was resolved
-        # *after* ``_build_read_sql`` ran, so any caller-identity
-        # function (``SESSION_USER()``, ``CURRENT_USER()``,
-        # ``@@session.user``) inside a ``row_restriction`` folded to
-        # the ``ANONYMOUS_CALLER`` sentinel regardless of the actual
-        # ``X-Bqemu-Caller`` header. Hoisting the resolution closes
-        # that gap.
+        # ``CallerIdentity``. Caller-identity functions
+        # (``SESSION_USER()``, ``CURRENT_USER()``, ``@@session.user``)
+        # inside a ``row_restriction`` must fold to the value provided
+        # by the ``X-Bqemu-Caller`` header rather than the
+        # ``ANONYMOUS_CALLER`` sentinel; resolving here guarantees that.
         caller = resolve_caller_from_metadata(
             list(context.invocation_metadata())
             if hasattr(context, "invocation_metadata")
@@ -251,11 +249,11 @@ class BigQueryReadHandler(grpc.GenericRpcHandler):
 
         sql = _build_read_sql(target_ref, selected_fields, read_session, caller=caller)
 
-        # Phase 8: enforce row access policies on the Storage Read API
-        # too. The caller was already resolved above. The rewriter
-        # wraps the protected table in a derived subquery with the
-        # policy's filter (or WHERE FALSE on no-match). We then run
-        # that rewritten SQL against DuckDB. Tables with no policies
+        # Enforce row access policies on the Storage Read path. The
+        # caller was already resolved above. The rewriter wraps the
+        # protected table in a derived subquery with the policy's
+        # filter (or WHERE FALSE on no-match). We then run that
+        # rewritten SQL against DuckDB. Tables with no policies
         # short-circuit at the rewriter so the cheap-path keeps the
         # original DuckDB SQL.
         if self._ctx.catalog.list_all_row_access_policies():
@@ -349,10 +347,10 @@ class BigQueryReadHandler(grpc.GenericRpcHandler):
         # Build the response. Real BigQuery echoes ``read_options`` back on
         # the session so clients can confirm the projection / filter /
         # compression they asked for; the wire-format conformance suite
-        # asserts that shape (P3.d). The schema field carried on the
-        # session depends on the chosen wire format — Arrow sessions
-        # carry ``arrow_schema``, Avro sessions carry ``avro_schema``
-        # (proto oneof).
+        # asserts that shape. The schema field carried on the session
+        # depends on the chosen wire format — Arrow sessions carry
+        # ``arrow_schema``, Avro sessions carry ``avro_schema`` (proto
+        # oneof).
         session_kwargs: dict[str, Any] = {
             "name": state.session_name,
             "table": read_session.table,
@@ -398,8 +396,8 @@ class BigQueryReadHandler(grpc.GenericRpcHandler):
         # so a stateless client can deserialise the payload without
         # re-fetching the session; subsequent messages omit it. Real
         # BigQuery also surfaces a ``stats.progress`` heartbeat on
-        # every message — the wire-format conformance suite (P3.d)
-        # asserts both keys are present.
+        # every message — the wire-format conformance suite asserts
+        # both keys are present.
         from bqemulator.streaming.avro_serializer import (
             serialize_arrow_table_to_avro_rows,
         )
@@ -419,8 +417,8 @@ class BigQueryReadHandler(grpc.GenericRpcHandler):
             # documented as ``[deprecated = true]`` and real BigQuery
             # omits them (proto3 default-skip). The outer
             # ``ReadRowsResponse.row_count`` carries the canonical row
-            # count; the wire-format conformance suite (P3.d) asserts
-            # the inner field stays at its default.
+            # count; the wire-format conformance suite asserts the inner
+            # field stays at its default.
             kwargs: dict[str, Any] = {
                 "row_count": batch.num_rows,
                 "stats": types.StreamStats(
@@ -475,8 +473,8 @@ class BigQueryReadHandler(grpc.GenericRpcHandler):
         fraction. The emulator implements a stub: it mints two fresh
         stream names that route ReadRows back to the same underlying
         data (effectively a no-op split). This is sufficient for
-        wire-format conformance (P3.d) — clients that rely on the
-        split semantics for parallelism are out of scope per the
+        wire-format conformance — clients that rely on the split
+        semantics for parallelism are out of scope per the
         compatibility matrix.
         """
         from google.cloud.bigquery_storage_v1 import types

--- a/src/bqemulator/grpc_api/server.py
+++ b/src/bqemulator/grpc_api/server.py
@@ -1,7 +1,7 @@
 """gRPC server factory.
 
 Hosts the standard health service plus the BigQuery Storage Read API
-(Phase 4+) and Storage Write API (Phase 5+).
+and Storage Write API.
 """
 
 from __future__ import annotations

--- a/src/bqemulator/grpc_api/write_servicer.py
+++ b/src/bqemulator/grpc_api/write_servicer.py
@@ -74,14 +74,13 @@ _FLUSH_ROWS = f"{_SERVICE}/FlushRows"
 
 # Real BigQuery exposes the per-stream location in its WriteStream
 # wire shape. The emulator is location-agnostic, so we report ``us``
-# (lowercase, matching BQ's REST shape) — the gRPC-corpus
-# conformance suite (P3.d) asserts the field's presence.
+# (lowercase, matching BQ's REST shape) — the gRPC-corpus conformance
+# suite asserts the field's presence.
 _STREAM_LOCATION = "us"
 
 # Canonical stream-id regex: 16 hex chars OR the literal ``_default``
 # sentinel. Used by ``GetWriteStream`` to reject malformed ids with
-# INVALID_ARGUMENT — matching real BQ's wire shape rather than the
-# emulator's earlier NOT_FOUND.
+# INVALID_ARGUMENT — matching real BQ's wire shape.
 _STREAM_ID_RE = re.compile(r"^(?:[a-f0-9]{16}|_default)$")
 
 
@@ -227,8 +226,8 @@ class BigQueryWriteHandler(grpc.GenericRpcHandler):
 
         # Real BigQuery's CreateWriteStream response omits the
         # ``location`` field (empty default), whereas GetWriteStream
-        # includes it. The wire-format conformance suite (P3.d) asserts
-        # the asymmetry.
+        # includes it. The wire-format conformance suite asserts the
+        # asymmetry.
         response = types.WriteStream(
             name=stream.name,
             type_=requested_type,
@@ -632,8 +631,8 @@ class BigQueryWriteHandler(grpc.GenericRpcHandler):
                 self._ctx.catalog.update_table(
                     table_meta.model_copy(update={"num_rows": new_count}),
                 )
-            # Phase 7: capture a snapshot under the same write lock so
-            # concurrent streams can't interleave a half-applied rebase.
+            # Capture a snapshot under the same write lock so concurrent
+            # streams can't interleave a half-applied rebase.
             # ``record_change`` publishes ``TableDataChanged``, which
             # both invalidates the query cache and marks dependent MVs
             # stale.
@@ -850,8 +849,8 @@ def _strategy_type_to_proto(stream_type: WriteStreamType) -> int:
 
     # Real BigQuery reports the implicit DEFAULT stream as a COMMITTED
     # stream over the wire — clients dispatch on the type and treat
-    # both the same way. The wire-format conformance suite (P3.d)
-    # asserts this contract.
+    # both the same way. The wire-format conformance suite asserts
+    # this contract.
     mapping = {
         WriteStreamType.DEFAULT: int(types.WriteStream.Type.COMMITTED),
         WriteStreamType.COMMITTED: int(types.WriteStream.Type.COMMITTED),

--- a/src/bqemulator/jobs/avro_reader.py
+++ b/src/bqemulator/jobs/avro_reader.py
@@ -1,4 +1,4 @@
-"""Avro file → Arrow table bridge for the load executor (G1 follow-up).
+"""Avro file → Arrow table bridge for the load executor.
 
 Used as a fallback when DuckDB's native ``read_avro`` can't handle a
 particular Avro feature — in particular the ``decimal`` logical type,

--- a/src/bqemulator/jobs/error_mapper.py
+++ b/src/bqemulator/jobs/error_mapper.py
@@ -1,4 +1,4 @@
-"""DuckDB/SQLGlot → BigQuery-shape error translator (P3.a, ADR 0022 §3).
+"""DuckDB/SQLGlot → BigQuery-shape error translator (see ADR 0022 §3).
 
 This mapper closes the wire-format gap between the emulator's underlying
 engines (DuckDB for execution, SQLGlot for parsing/transpilation) and
@@ -166,11 +166,8 @@ _JS_UDF_ERROR_RE = re.compile(
 #: DuckDB's ICU extension rejects an unrecognised timezone (named zone or
 #: numeric offset) with ``Not implemented Error: Unknown TimeZone '<zone>'!``
 #: plus a trailing ``Candidate time zones: …`` list. BigQuery's documented
-#: form is the short prefix ``Invalid time zone: <zone>``. Workstream P8.e
-#: (2026-05-20) added the mapping after fixtures ``tz_error_unknown_zone``
-#: (named ``Mars/Olympus_Mons``) and ``tz_parse_timestamp_with_named_zone``
-#: (named ``IST``) both recorded the BQ error envelope. The captured value
-#: feeds the rewritten BQ-shape message.
+#: form is the short prefix ``Invalid time zone: <zone>``. The captured
+#: value feeds the rewritten BQ-shape message.
 _UNKNOWN_TIMEZONE_RE = re.compile(
     r"Unknown TimeZone '(?P<zone>[^']+)'",
 )
@@ -372,12 +369,12 @@ def translate_runtime_error(
         )
 
     if (tz_match := _UNKNOWN_TIMEZONE_RE.search(raw)) is not None:
-        # Workstream P8.e (2026-05-20). DuckDB's ICU rejection of an
-        # unrecognised zone leaks the candidate-zones list, which would
-        # break the conformance ``message_pattern`` regex match against
-        # BigQuery's clean ``Invalid time zone: <zone>`` form. The
-        # captured zone name is preserved so the user-facing message
-        # still points at the offending input.
+        # DuckDB's ICU rejection of an unrecognised zone leaks the
+        # candidate-zones list, which would break the conformance
+        # ``message_pattern`` regex match against BigQuery's clean
+        # ``Invalid time zone: <zone>`` form. The captured zone name
+        # is preserved so the user-facing message still points at the
+        # offending input.
         return InvalidQueryError(
             f"Invalid time zone: {tz_match['zone']}",
             location="query",

--- a/src/bqemulator/jobs/executor.py
+++ b/src/bqemulator/jobs/executor.py
@@ -267,7 +267,7 @@ async def execute_query_job(
     """
     now = ctx.clock.now()
 
-    # P3.a / ADR 0022 §3: scripting-lexer errors (``Unterminated string
+    # ADR 0022 §3: scripting-lexer errors (``Unterminated string
     # literal`` etc.) are raised directly as InvalidQueryError; route
     # them through the mapper so the BigQuery-shape wording (``Syntax
     # error: Unclosed string literal at [L:C]``) is surfaced before the
@@ -285,11 +285,11 @@ async def execute_query_job(
     )
     script_statement_count = len(script.statements)
 
-    # P7.b — classify the statement type up front so the response
-    # populates ``statistics.query.statementType`` consistently across
-    # the versioning-DDL fast path, the scripting path, and the
-    # legacy single-SQL path. Best-effort: unparseable input returns
-    # ``""`` and the field is omitted.
+    # Classify the statement type up front so the response populates
+    # ``statistics.query.statementType`` consistently across the
+    # versioning-DDL fast path, the scripting path, and the legacy
+    # single-SQL path. Best-effort: unparseable input returns ``""``
+    # and the field is omitted.
     statement_type = "SCRIPT" if is_scripted else classify_statement_type(bq_sql)
 
     # Intercept versioning DDL (CREATE SNAPSHOT / CLONE / MATERIALIZED
@@ -381,8 +381,8 @@ async def execute_query_job(
     # propagate TableDataChanged so dependent MVs flip stale.
     await _capture_dml_snapshots(project_id, bq_sql, ctx)
 
-    # P7.b — DML statements return a 1-column ``Count`` table from
-    # DuckDB; real BigQuery returns a 0-column schema + 0 rows + a
+    # DML statements return a 1-column ``Count`` table from DuckDB;
+    # real BigQuery returns a 0-column schema + 0 rows + a
     # ``numDmlAffectedRows`` statistic. Strip the Count column for the
     # wire-format response and capture the affected-rows count for
     # the statistics payload.
@@ -565,7 +565,7 @@ async def _run_single_sql(
         duckdb_sql, param_values = bind_parameters(duckdb_sql, query_params)
         return ctx.engine.fetch_arrow(duckdb_sql, param_values or None)
     except DomainError as exc:
-        # P3.a / ADR 0022 §3: pre-execution domain errors (RAP denials,
+        # ADR 0022 §3: pre-execution domain errors (RAP denials,
         # malformed-id ValidationErrors from the SQL pipeline) are
         # re-shaped to BigQuery wire-format ``reason`` / ``location`` /
         # ``message_pattern`` conventions before reaching the route
@@ -1427,8 +1427,7 @@ def classify_statement_type(bq_sql: str) -> str:
     """Return BigQuery's ``statementType`` for ``bq_sql``.
 
     Used by the executor to populate ``statistics.query.statementType``
-    on every job's response (P7.b — closes the
-    ``api_configuration/*`` conformance divergences surfaced by P7.a).
+    on every job's response.
 
     Returns one of: ``SELECT``, ``INSERT``, ``UPDATE``, ``DELETE``,
     ``MERGE``, ``CREATE_TABLE``, ``CREATE_TABLE_AS_SELECT``,

--- a/src/bqemulator/row_access/__init__.py
+++ b/src/bqemulator/row_access/__init__.py
@@ -1,4 +1,4 @@
-"""Phase 8 — row access policy enforcement and caller-identity resolution.
+"""Row access policy enforcement and caller-identity resolution.
 
 The package contains three concerns:
 

--- a/src/bqemulator/row_access/identity.py
+++ b/src/bqemulator/row_access/identity.py
@@ -35,10 +35,10 @@ GROUPS_HEADER = "x-bqemu-groups"
 Each entry may be either a bare email (``admins@example.com``) or
 the full IAM-member form (``group:admins@example.com``); the parser
 strips the ``group:`` prefix so the matcher always sees bare emails.
-This dual-form tolerance lets P2.d conformance fixtures that
-substitute ``${GROUP}`` (which carries ``group:<addr>``) into
-``headers.json`` produce the same caller identity as integration
-tests that pass bare emails.
+This dual-form tolerance lets conformance fixtures that substitute
+``${GROUP}`` (which carries ``group:<addr>``) into ``headers.json``
+produce the same caller identity as integration tests that pass bare
+emails.
 """
 
 DEFAULT_CALLER = "user:anonymous@bqemulator.local"

--- a/src/bqemulator/row_access/policy.py
+++ b/src/bqemulator/row_access/policy.py
@@ -4,8 +4,8 @@ The :class:`RowAccessPolicyManager` is the only place that mutates
 :class:`RowAccessPolicyMeta` rows in the catalog. It enforces:
 
 * The target table exists (raises :class:`NotFoundError` otherwise).
-* The target table is not a SNAPSHOT or MATERIALIZED_VIEW (Phase 7
-  rejects DML on those types; row access policies on read-only
+* The target table is not a SNAPSHOT or MATERIALIZED_VIEW (DML is
+  rejected on those types; row access policies on read-only
   artefacts would have no point of attachment).
 * ``policy_id`` matches BigQuery's grammar (``[A-Za-z0-9_]+``, max
   256 chars).

--- a/src/bqemulator/scripting/interpreter.py
+++ b/src/bqemulator/scripting/interpreter.py
@@ -767,9 +767,9 @@ class ScriptInterpreter:
             # Route DuckDB-side runtime errors through the central
             # error mapper so JS UDF / div-by-zero / overflow / catalog
             # failures land on the wire in BigQuery's documented shape
-            # (P3.a). Falling back to the verbose "Script SQL execution
-            # failed: ..." wrapper would mask the BQ-shaped translation
-            # the conformance corpus pins.
+            # (see ADR 0022 §3). Falling back to the verbose "Script SQL
+            # execution failed: ..." wrapper would mask the BQ-shaped
+            # translation the conformance corpus pins.
             from bqemulator.jobs.error_mapper import translate_runtime_error
 
             mapped = translate_runtime_error(exc, duckdb_sql=duckdb_sql)
@@ -946,16 +946,16 @@ def _rewrite_vars_to_params(
         var_value = visible[name].value
         var_type = visible[name].type_name
         placeholder: exp.Expression = _next_placeholder(var_value)
-        # P8.b — preserve the declared variable type when DEFAULT NULL
-        # leaves ``value`` as Python ``None``. Without a CAST, the DuckDB
-        # driver binds NULL as the default INT64 type and the schema
-        # renderer surfaces the column as ``INTEGER`` even though the
-        # script said ``DECLARE x STRING DEFAULT NULL``. Wrapping the
-        # placeholder in a ``CAST(... AS <declared_type>)`` makes the
-        # type travel through to the wire schema — matching BigQuery's
-        # "declared type is authoritative" contract. STRUCT-valued
-        # variables short-circuit out via the ``table`` branch above so
-        # the CAST here only fires for scalar variables.
+        # Preserve the declared variable type when DEFAULT NULL leaves
+        # ``value`` as Python ``None``. Without a CAST, the DuckDB driver
+        # binds NULL as the default INT64 type and the schema renderer
+        # surfaces the column as ``INTEGER`` even though the script said
+        # ``DECLARE x STRING DEFAULT NULL``. Wrapping the placeholder in
+        # a ``CAST(... AS <declared_type>)`` makes the type travel
+        # through to the wire schema — matching BigQuery's "declared
+        # type is authoritative" contract. STRUCT-valued variables
+        # short-circuit out via the ``table`` branch above so the CAST
+        # here only fires for scalar variables.
         if var_value is None and var_type and var_type.upper() != "ANY":
             # Defensive: fall back to bare placeholder if the declared
             # type string is not parseable by ``exp.DataType.build``.

--- a/src/bqemulator/server.py
+++ b/src/bqemulator/server.py
@@ -144,12 +144,11 @@ class EmulatorServer:
         )
         # Storage Write API stream registry shared between the gRPC servicer
         # (which owns lifecycle) and the admin /admin/streams endpoint
-        # (which reads it for diagnostics). Phase 10 lifts construction out
-        # of the servicer so both consumers see the same instance; the
-        # servicer wires the metric-cleanup callback after AppContext is
-        # built (see ``BigQueryWriteHandler.__init__``).
+        # (which reads it for diagnostics). The servicer wires the
+        # metric-cleanup callback after AppContext is built (see
+        # ``BigQueryWriteHandler.__init__``).
         write_stream_manager = WriteStreamManager()
-        # G2 — upload host (resumable / multipart). The manager owns the
+        # Upload host (resumable / multipart). The manager owns the
         # in-memory session map and the temp staging directory under
         # ``Settings.upload_staging_dir`` (or the system tempdir when
         # unset). See ADR 0029.

--- a/src/bqemulator/sql/__init__.py
+++ b/src/bqemulator/sql/__init__.py
@@ -2,7 +2,7 @@
 
 The core pipeline:
 
-1. Pre-process (rewriters — Phase 3+ additions).
+1. Pre-process (rewriters).
 2. ``sqlglot.transpile(read="bigquery", write="duckdb")``.
 3. Post-process (rule engine applies registered ``TranslationRule``s).
 

--- a/src/bqemulator/sql/builtin_udfs.py
+++ b/src/bqemulator/sql/builtin_udfs.py
@@ -723,7 +723,7 @@ def bqemu_sha512(value: str | None) -> bytes | None:
 
 
 # ---------------------------------------------------------------------------
-# Timestamp ISO format / parse helpers (workstream P8.e, 2026-05-20)
+# Timestamp ISO format / parse helpers.
 # ---------------------------------------------------------------------------
 #: BigQuery's ``%Ez`` extension specifier produces an ISO-format offset with
 #: a colon separator (``+05:30`` / ``-04:30``). DuckDB's STRFTIME / STRPTIME
@@ -760,9 +760,6 @@ def bqemu_format_timestamp_iso(
     specifiers — :class:`bqemulator.sql.rules.datetime_semantics.FormatTimestampZoneRule`
     routes every call that carries either a zone arg or a ``%E``-bearing
     format through this helper.
-
-    Workstream P8.e (2026-05-20) added the helper to close the
-    ``tz_format_timestamp_named_zone`` fixture.
 
     Parameters
     ----------
@@ -831,10 +828,6 @@ def bqemu_parse_timestamp_iso(
     Returns a *naive* UTC datetime so the caller's
     ``timezone('UTC', …)`` wrap (per :class:`ParseTimestampStrictRule`)
     surfaces the column as ``TIMESTAMP`` on the wire.
-
-    Workstream P8.e (2026-05-20) added the helper to close
-    ``tz_parse_timestamp_with_offset`` (``%Ez`` accepted) and
-    ``tz_parse_timestamp_with_named_zone`` (``IST`` rejected).
     """
     if fmt is None or value is None:
         return None

--- a/src/bqemulator/sql/errors.py
+++ b/src/bqemulator/sql/errors.py
@@ -3,7 +3,7 @@
 These wrap the domain-error hierarchy with convenience constructors
 for common SQL failure modes.
 
-P3.a / ADR 0022 §3 ``Error parity``: :func:`sql_parse_error` rewrites
+ADR 0022 §3 ``Error parity``: :func:`sql_parse_error` rewrites
 common SQLGlot parse-error wordings to BigQuery's documented
 ``Syntax error: <kind> at [L:C]`` wire format and always sets
 ``location="query"`` so the recorded conformance fixtures match. The
@@ -47,8 +47,8 @@ _SQLGLOT_UNTERMINATED_STRING_RE = re.compile(
 )
 #: SQLGlot's ``Required keyword: 'expressions' missing for ... Concat``,
 #: emitted when ``CONCAT()`` is called with zero arguments. BigQuery
-#: replies with the multi-line signature-not-found message, which the
-#: P3.a recorder captured as a fixed-text ``message_pattern``.
+#: replies with the multi-line signature-not-found message that
+#: conformance fixtures pin as a fixed-text ``message_pattern``.
 _SQLGLOT_CONCAT_NO_ARGS_RE = re.compile(
     r"Required keyword: 'expressions' missing for .*Concat",
     re.IGNORECASE,

--- a/src/bqemulator/sql/parameters.py
+++ b/src/bqemulator/sql/parameters.py
@@ -13,7 +13,7 @@ This module:
 3. Wraps NULL-valued parameters in ``CAST(? AS <duckdb-type>)`` so the
    BigQuery schema renderer surfaces the declared type rather than
    DuckDB's default-inferred type (which falls back to BIGINT for a
-   bare NULL parameter regardless of the BQ-declared type). P2.e.
+   bare NULL parameter regardless of the BQ-declared type).
 """
 
 from __future__ import annotations
@@ -276,8 +276,8 @@ def _extract_value(param: dict[str, Any]) -> Any:
 
         return Decimal(str(raw))
 
-    # P2.e: DATE / DATETIME / TIME / TIMESTAMP parameters must be
-    # converted to typed Python objects, not left as strings. DuckDB
+    # DATE / DATETIME / TIME / TIMESTAMP parameters must be converted
+    # to typed Python objects, not left as strings. DuckDB
     # infers a prepared-statement parameter's column type from the
     # Python value's type — a plain string binds as VARCHAR, which the
     # BigQuery schema renderer surfaces as ``STRING`` rather than the

--- a/src/bqemulator/sql/rewriter/__init__.py
+++ b/src/bqemulator/sql/rewriter/__init__.py
@@ -3,9 +3,6 @@
 Rewriters transform the BigQuery AST BEFORE it reaches SQLGlot's
 transpiler. Each rewriter is a function that takes a parsed SQLGlot
 AST (in BigQuery dialect) and returns a (possibly modified) AST.
-
-Phase 1 ships this package empty — the first rewriters (partition
-pruning, wildcard expansion, pseudo-column injection) land in Phase 3.
 """
 
 from __future__ import annotations

--- a/src/bqemulator/sql/rewriter/create_table_schema_ctas.py
+++ b/src/bqemulator/sql/rewriter/create_table_schema_ctas.py
@@ -32,17 +32,10 @@ Column-count mismatch — fewer schema columns than ``SELECT``
 projections, or vice versa — is intentionally left alone. SQLGlot's
 transpile will still hand the original combined form to DuckDB and
 the user will see the same DuckDB parser error they saw before, which
-is no worse than the pre-rewriter behaviour. A future iteration could
-emit a BigQuery-shaped error here, but matching BQ's exact wording
-across "column count" / "type mismatch" / "duplicate column" surface
-area is its own piece of work.
-
-Discovery: 2026-05-17 during P2.d Phase 8 conformance recording. All
-20 authored fixtures used the combined form; all 20 failed conformance
-with the DuckDB parse error. The fixtures were temporarily rewritten
-to the bare form so P2.d could close; this rewriter closes the
-underlying gap so future fixture authors (and end-users running
-DDL through the emulator) can use the canonical BigQuery idiom.
+is no worse than the pre-rewriter behaviour. Matching BQ's exact
+wording for the "column count" / "type mismatch" / "duplicate column"
+shapes is outside the scope of this rewriter; the bare CTAS path
+surfaces those errors via the standard pipeline.
 """
 
 from __future__ import annotations

--- a/src/bqemulator/sql/rewriter/default_dataset.py
+++ b/src/bqemulator/sql/rewriter/default_dataset.py
@@ -28,8 +28,6 @@ inner ``products`` would actually resolve to the default-dataset
 table — this is a CTE-shadowing edge case BigQuery handles by lexical
 scoping, which we replicate by NOT qualifying inside a CTE definition
 that shadows the name.
-
-P7.b phase 2 follow-up #1.
 """
 
 from __future__ import annotations

--- a/src/bqemulator/sql/rewriter/division_by_zero.py
+++ b/src/bqemulator/sql/rewriter/division_by_zero.py
@@ -38,7 +38,7 @@ error branch. ``CASE`` is short-circuited per SQL semantics.
   the AST stays simple — a sizeable optimisation for the common
   divide-by-constant case in user queries.
 
-The Bucket J ``IEEE_DIVIDE`` rule and SQLGlot's native ``SAFE_DIVIDE``
+The ``IEEE_DIVIDE`` rule and SQLGlot's native ``SAFE_DIVIDE``
 transpile both produce ``Div`` AST nodes after this pre-translator has
 already run (``IeeeDivideRule`` runs in the post-translate rule pass;
 ``SAFE_DIVIDE`` is lowered to ``CASE WHEN denominator <> 0 THEN

--- a/src/bqemulator/sql/rewriter/information_schema.py
+++ b/src/bqemulator/sql/rewriter/information_schema.py
@@ -3,13 +3,9 @@
 BigQuery exposes a family of virtual tables under
 ``{project}.{dataset}.INFORMATION_SCHEMA.*`` that describe the catalog.
 
-Coverage shipped per phase:
-
-* Phase 6 — ``ROUTINES``.
-* Phase 7 — ``MATERIALIZED_VIEWS``.
-* Phase 8 — ``ROW_ACCESS_POLICIES``.
-* G4 (this module's 2026-05-21 expansion) — ``SCHEMATA``, ``TABLES``,
-  ``COLUMNS``, ``TABLE_OPTIONS``, ``VIEWS``, ``PARTITIONS``.
+Supported views: ``ROUTINES``, ``MATERIALIZED_VIEWS``,
+``ROW_ACCESS_POLICIES``, ``SCHEMATA``, ``TABLES``, ``COLUMNS``,
+``TABLE_OPTIONS``, ``VIEWS``, ``PARTITIONS``.
 
 This rewriter runs as a PRE-translation pass on the original BigQuery
 SQL (same stage as the wildcard expander). When it detects a reference
@@ -55,8 +51,7 @@ def _build_patterns(view_name: str) -> tuple[re.Pattern[str], re.Pattern[str], r
     so a fully-quoted reference like
     ``` `dataset.INFORMATION_SCHEMA.TABLES` ``` is consumed cleanly
     (without the trailing backtick, the substitution leaves a stray
-    closing backtick that breaks the downstream SQLGlot tokeniser —
-    pinned by the G4 fixture replay step).
+    closing backtick that breaks the downstream SQLGlot tokeniser).
     """
     escaped = re.escape(view_name.upper())
     project_ds = re.compile(
@@ -97,9 +92,11 @@ def expand_information_schema(
 ) -> str:
     """Replace every supported ``INFORMATION_SCHEMA.*`` virtual table inline.
 
-    The orchestrator chains all nine supported view expanders in
-    a fixed order: the three Phase 6/7/8 surfaces first (preserving
-    existing semantics) followed by the six G4 additions.
+    Chains the nine view expanders in a fixed order (``ROUTINES`` →
+    ``MATERIALIZED_VIEWS`` → ``ROW_ACCESS_POLICIES`` → ``SCHEMATA`` →
+    ``TABLES`` → ``COLUMNS`` → ``TABLE_OPTIONS`` → ``VIEWS`` →
+    ``PARTITIONS``) so each pass operates on the output of the
+    previous one.
     """
     out = expand_information_schema_routines(bq_sql, project_id, catalog)
     out = expand_information_schema_materialized_views(out, project_id, catalog)

--- a/src/bqemulator/sql/rewriter/legacy_sql.py
+++ b/src/bqemulator/sql/rewriter/legacy_sql.py
@@ -16,8 +16,6 @@ implicit-correlated-subquery rules, the ``date_add(NOW(), -7, 'DAY')``
 form, etc.) still fall through to the standard pipeline and surface
 the appropriate translation error. The handful of clients that only
 needed legacy SQL for type-casts now see a clean PASS.
-
-P7.c follow-up — closes ``api_configuration/legacy_sql_select_compat_mode``.
 """
 
 from __future__ import annotations
@@ -58,7 +56,7 @@ def rewrite_legacy_to_standard(bq_sql: str) -> str:
 
     Queries using legacy-SQL features outside this subset survive
     unchanged; the standard pipeline raises the appropriate
-    translation error. P7.c follow-up.
+    translation error.
     """
     out = bq_sql
     for legacy_name, standard_type in _LEGACY_CAST_FUNCTIONS.items():

--- a/src/bqemulator/sql/rewriter/partition_pseudo_columns.py
+++ b/src/bqemulator/sql/rewriter/partition_pseudo_columns.py
@@ -20,8 +20,7 @@ The rewrite is conservative: it only touches the bare identifier
 spellings (``_PARTITIONDATE`` / ``_PARTITIONTIME``), case-insensitive,
 word-bounded. References inside backtick-quoted strings or string
 literals are left alone — they're already not pseudo-column
-references. P7.c follow-up — closes the three
-``partitioning_clustering/partition_prune_*`` XFAILs.
+references.
 """
 
 from __future__ import annotations

--- a/src/bqemulator/sql/rewriter/range_sessionize.py
+++ b/src/bqemulator/sql/rewriter/range_sessionize.py
@@ -118,8 +118,7 @@ def _expand_call(match: re.Match[str]) -> str:
     projected out via ``SELECT * EXCEPT`` so the call site sees only
     the original columns plus ``session_range``.
 
-    NULL-bridge semantic (P2.a closure-bug follow-up, 2026-05-18):
-    BigQuery's ``RANGE_SESSIONIZE`` collapses every non-NULL row in
+    NULL-bridge semantic: BigQuery's ``RANGE_SESSIONIZE`` collapses every non-NULL row in
     a partition into a single session spanning
     ``[min(start), max(end)]`` whenever any NULL range is present in
     that partition; the NULL rows themselves return

--- a/src/bqemulator/sql/rewriter/row_access_filter.py
+++ b/src/bqemulator/sql/rewriter/row_access_filter.py
@@ -215,8 +215,8 @@ class _Rewriter:
         if proj is None or dataset is None or table is None:
             return False
 
-        # Skip reserved schemas (catalog, snapshots) — Phase 7 already
-        # treats these as live catalog reads, not user tables.
+        # Reserved schemas (catalog, snapshots) are live catalog reads,
+        # not user tables; row-access enforcement does not apply.
         if dataset in _RESERVED_SCHEMAS:
             return False
 

--- a/src/bqemulator/sql/rewriter/specialized_types.py
+++ b/src/bqemulator/sql/rewriter/specialized_types.py
@@ -35,10 +35,10 @@ The function short-circuits when the SQL contains nothing that needs
 rewriting (the common case for queries that don't touch INTERVAL or
 RANGE syntax).
 
-Other Phase 9 transforms (``ST_*`` renames, ``RANGE_*`` expansions,
-``JUSTIFY_*``) all happen in the *post-translator* rule pass because
-their syntax parses cleanly under DuckDB's grammar — only the names
-and call shapes need rewriting.
+Other specialized-type transforms (``ST_*`` renames, ``RANGE_*``
+expansions, ``JUSTIFY_*``) happen in the *post-translator* rule pass
+because their syntax parses cleanly under DuckDB's grammar — only the
+names and call shapes need rewriting.
 """
 
 from __future__ import annotations

--- a/src/bqemulator/sql/rewriter/timestamp_iso_helpers.py
+++ b/src/bqemulator/sql/rewriter/timestamp_iso_helpers.py
@@ -8,13 +8,13 @@ DuckDB's own ``STRFTIME`` / ``STRPTIME`` reject the BigQuery-only
 silently accept ``%Z`` named-zone abbreviations such as ``IST`` that
 real BigQuery rejects with ``Invalid time zone: <zone>``.
 
-Workstream **P8.e (2026-05-20)** added this pre-translator to route
-the affected calls through Python-backed helpers
-(:func:`bqemulator.sql.builtin_udfs.bqemu_format_timestamp_iso` and
-:func:`bqemulator.sql.builtin_udfs.bqemu_parse_timestamp_iso`) while
-the BigQuery AST still carries the zone argument. The helpers handle
-``%Ez`` natively, preserve the zone conversion, and validate ``%Z``
-named zones against ``zoneinfo.ZoneInfo`` (strict IANA semantics).
+This pre-translator routes the affected calls through Python-backed
+helpers (:func:`bqemulator.sql.builtin_udfs.bqemu_format_timestamp_iso`
+and :func:`bqemulator.sql.builtin_udfs.bqemu_parse_timestamp_iso`)
+while the BigQuery AST still carries the zone argument. The helpers
+handle ``%Ez`` natively, preserve the zone conversion, and validate
+``%Z`` named zones against ``zoneinfo.ZoneInfo`` (strict IANA
+semantics).
 
 The rewriter short-circuits when no ``FORMAT_TIMESTAMP`` /
 ``PARSE_TIMESTAMP`` reference appears in the input.

--- a/src/bqemulator/sql/rewriter/wildcard_expander.py
+++ b/src/bqemulator/sql/rewriter/wildcard_expander.py
@@ -4,25 +4,17 @@ Rewrites BigQuery wildcard-table references like ``FROM dataset.events_*``
 into a ``UNION ALL`` of all matching tables, with ``_TABLE_SUFFIX``
 injected as a literal column per source table.
 
-Phase 3 shipped the basic expansion: every matching table is included,
-row-level ``_TABLE_SUFFIX`` filters apply after expansion.
-
-Phase 6 adds the advanced form — **``_TABLE_SUFFIX`` predicate pushdown**.
 When the query's WHERE clause references ``_TABLE_SUFFIX`` with an
-equality, range, or ``IN (...)`` predicate, we evaluate the predicate
+equality, range, or ``IN (...)`` predicate, the predicate is evaluated
 on the suffix list *before* building the UNION ALL, so only matching
 tables appear in the expansion. This matches BigQuery's cost model
 (only scanned tables bill bytes) and is essential for workloads that
 query date-sharded tables across large windows.
 
-Phase 11 (Bucket C closure 2026-05-15) generalises the predicate so
-the rewriter now also engages on fully-qualified 3-part references
-(``project.dataset.events_*``, optionally wrapped in a single pair of
-backticks) and on every wildcard reference in the query — not just
-the first. The pre-closure predicate looked only at the trailing
-2-part shape and a single ``re.search`` match, which left self-joins
-and project-qualified fixtures stranded with
-``Catalog Error: Table with name events_* does not exist``.
+The rewriter engages on every wildcard reference in the query and on
+all qualifier shapes (1-/2-/3-part, with or without backticks; whole-
+reference or per-segment backticked), so self-joins and project-
+qualified references resolve consistently with bare ones.
 
 This rewriter operates on the ORIGINAL BigQuery SQL (before SQLGlot
 transpilation) because SQLGlot strips the ``*`` during AST parsing.
@@ -103,8 +95,8 @@ def expand_wildcard_tables(
         if not matching_ids:
             return match.group(0)
 
-        # Phase 6 advanced form: restrict the matching set using any
-        # _TABLE_SUFFIX predicate present in the outer WHERE clause.
+        # Restrict the matching set using any _TABLE_SUFFIX predicate
+        # in the outer WHERE clause (pre-expansion pushdown).
         matching_ids = _apply_table_suffix_pushdown(matching_ids, prefix, bq_sql)
 
         if not matching_ids:

--- a/src/bqemulator/sql/rules/__init__.py
+++ b/src/bqemulator/sql/rules/__init__.py
@@ -33,10 +33,8 @@ def get_all_rules() -> list[TranslationRule]:
     return [cls() for cls in _REGISTRY]
 
 
-# Phase 1 rule modules — imported AFTER register() is defined so the
+# Rule modules — imported AFTER register() is defined so the
 # @register decorator is available at class-definition time.
-# Phase 9 rule modules.
-# Phase 11 (Bucket J closure) rule modules.
 from bqemulator.sql.rules import aggregate_types as _aggregate_types  # noqa: E402, F401
 from bqemulator.sql.rules import array_helpers as _array_helpers  # noqa: E402, F401
 from bqemulator.sql.rules import datetime_semantics as _datetime_semantics  # noqa: E402, F401

--- a/src/bqemulator/sql/rules/datetime_semantics.py
+++ b/src/bqemulator/sql/rules/datetime_semantics.py
@@ -642,10 +642,9 @@ class AtTimeZoneNumericOffsetRule(TranslationRule):
     DuckDB's ICU build does not accept numeric-offset literals such as
     ``'-04:30'`` or ``'+05:45'`` as a zone — it errors with
     ``Not implemented Error: Unknown TimeZone``. BigQuery accepts the
-    numeric-offset form natively, so workstream P8.e (2026-05-20)
-    rewrites ``ts AT TIME ZONE '<sign>HH:MM'`` to the algebraic
-    equivalent ``(ts AT TIME ZONE 'UTC') + INTERVAL '<sign>HH:MM' HOUR
-    TO MINUTE``.
+    numeric-offset form natively, so this rule rewrites
+    ``ts AT TIME ZONE '<sign>HH:MM'`` to the algebraic equivalent
+    ``(ts AT TIME ZONE 'UTC') + INTERVAL '<sign>HH:MM' HOUR TO MINUTE``.
 
     The input ``ts`` is a TIMESTAMPTZ (the BigQuery-emitted form after
     the SQLGlot transpile lifts the literal into a ``CAST AS TIMESTAMPTZ``).
@@ -725,9 +724,10 @@ class TimestampTruncWeekZoneSundayRule(TranslationRule):
     fixture, a separate AST pattern (no inner ``AtTimeZone``) will be
     needed.
 
-    Workstream P8.e (2026-05-20) added this rule once
-    ``tz_timestamp_trunc_named_zone_week`` recorded a Sunday baseline
-    that DuckDB's ISO-week truncation got wrong by one day.
+    BigQuery's WEEK starts on Sunday; DuckDB's ISO-week truncation
+    rounds to Monday, off by one day. This rule re-pivots the
+    ``TIMESTAMP_TRUNC`` to a Sunday-anchored boundary before
+    reapplying the zone.
     """
 
     name = "TIMESTAMP_TRUNC_WEEK_ZONE_SUNDAY"

--- a/src/bqemulator/sql/rules/misc_helpers.py
+++ b/src/bqemulator/sql/rules/misc_helpers.py
@@ -1,33 +1,32 @@
-"""Translation rules for the miscellaneous Bucket J builtins.
+"""Translation rules for miscellaneous GoogleSQL builtins.
 
 Functions covered:
 
-* ``IEEE_DIVIDE(a, b)`` — BigQuery semantic: IEEE-754 division that
-  returns ``±Inf`` / ``NaN`` instead of raising. We emit
+* ``IEEE_DIVIDE(a, b)`` — IEEE-754 division returning ``±Inf`` / ``NaN``
+  instead of raising on zero. Emits
   ``CAST(a AS DOUBLE) / CAST(b AS DOUBLE)`` so DuckDB's natural float
   arithmetic produces ``±Inf`` for zero divisors and ``NaN`` for
   ``0/0``. DuckDB does not raise on float division by zero.
 
 * ``FARM_FINGERPRINT(s)`` — BigQuery's FarmHash ``Fingerprint64``.
-  DuckDB ships no native FarmHash, so we route through the Python
-  helper ``bqemu_farm_fingerprint`` registered in
+  DuckDB ships no native FarmHash; routes through the Python helper
+  ``bqemu_farm_fingerprint`` registered in
   :mod:`bqemulator.sql.builtin_udfs`. The helper emits a deterministic
-  64-bit signed hash derived from SHA-256; the bit-pattern will *not*
-  match real BigQuery, so the fixture cascades to ADR 0023 §1.I (bit-
-  exact mismatch) once this rule is in place.
+  64-bit signed hash derived from SHA-256; bit-patterns are not
+  expected to match real BigQuery, so dependent fixtures cascade to
+  ADR 0023 §1.I (bit-exact mismatch).
 
-* ``RANGE_BUCKET(point, boundaries)`` — BigQuery contract: returns the
-  count of boundaries ≤ ``point``. We emit
+* ``RANGE_BUCKET(point, boundaries)`` — returns the count of
+  boundaries ≤ ``point``. Emits
   ``len(list_filter(boundaries, x -> x <= point))`` which mirrors the
-  semantic for the half-open [10, 20) → bucket 1 example.
+  semantic for the half-open ``[10, 20) → bucket 1`` example.
 
 * ``APPROX_TOP_SUM(value, weight, k)`` — BigQuery returns an array of
   ``{value, sum}`` STRUCT records ordered by weighted sum descending.
-  DuckDB ships only ``approx_top_k(value, k)`` (no weight). We rewrite
-  ``APPROX_TOP_SUM(value, weight, k)`` to ``approx_top_k(value, k)``
-  and let the fixture cascade to ADR 0023 §1.I (different ranking) —
-  the conformance fixture only asserts the result's *length* so the
-  array_length assertion still flips to XPASS.
+  DuckDB ships only ``approx_top_k(value, k)`` (no weight). Rewrites
+  ``APPROX_TOP_SUM(value, weight, k)`` to ``approx_top_k(value, k)``;
+  dependent fixtures cascade to ADR 0023 §1.I for the ranking
+  difference.
 """
 
 from __future__ import annotations
@@ -77,8 +76,8 @@ class FarmFingerprintRule(TranslationRule):
     """``FARM_FINGERPRINT(s)`` → ``bqemu_farm_fingerprint(s)``.
 
     Bit-pattern compatibility with real BigQuery is *not* guaranteed —
-    the helper uses a SHA-256-derived hash. The fixture cascades to
-    Bucket I (bit-exact value mismatch) once this rule lands.
+    the helper uses a SHA-256-derived hash. Dependent fixtures
+    cascade to ADR 0023 §1.I (bit-exact value mismatch).
     """
 
     name = "FARM_FINGERPRINT"
@@ -106,15 +105,13 @@ class RangeBucketRule(TranslationRule):
     Mirrors BigQuery's contract: returns the number of boundary
     entries that are less than or equal to *point*. The DuckDB
     expression evaluates the same predicate over the boundaries array
-    and returns the count. **P8.b NULL-propagation closure**: BigQuery's
-    contract is "if *point* is NULL or *boundaries* is NULL, returns
-    NULL". The bare ``list_filter`` over a NULL point would emit ``0``
-    (every ``x <= NULL`` predicate evaluates to NULL → falsy → filtered
-    out, leaving a 0-length array), which masks the NULL-propagation
-    semantic. The rewrite wraps the result in a ``CASE`` that returns
-    ``NULL`` when either input is NULL so the conformance fixture
-    ``math_range_bucket_null`` lands PASS without changing the happy
-    path.
+    and returns the count. BigQuery returns ``NULL`` when either
+    *point* or *boundaries* is ``NULL``; DuckDB's bare ``list_filter``
+    over a ``NULL`` point would emit ``0`` (every ``x <= NULL``
+    predicate evaluates to ``NULL`` → falsy → filtered out, leaving a
+    0-length array), masking the NULL-propagation semantic. The
+    rewrite wraps the result in a ``CASE`` that returns ``NULL`` when
+    either input is ``NULL``.
     """
 
     name = "RANGE_BUCKET"
@@ -133,7 +130,7 @@ class RangeBucketRule(TranslationRule):
             expressions=[exp.Column(this=exp.Identifier(this="x", quoted=False))],
         )
         happy_branch = _anon("len", _anon("list_filter", boundaries, lambda_expr))
-        # P8.b — NULL propagation guard. BigQuery returns NULL for
+        # NULL propagation guard: BigQuery returns NULL for
         # RANGE_BUCKET(NULL, …) and RANGE_BUCKET(…, NULL); DuckDB's bare
         # list_filter emits 0 in both cases.
         null_guard = exp.Or(
@@ -150,23 +147,19 @@ class RangeBucketRule(TranslationRule):
 class SignFloatTypeRule(TranslationRule):
     """``SIGN(<float_arg>)`` → NaN-aware FLOAT64 wrapper.
 
-    **P8.b type-preservation + NaN-propagation closure**: BigQuery's
-    ``SIGN(x)`` returns the same type as ``x`` (``INT64 → INT64``,
-    ``FLOAT64 → FLOAT64``, ``NUMERIC → NUMERIC``) and propagates
-    ``NaN`` (``SIGN(NaN) = NaN``). DuckDB's ``sign(x)`` always returns
-    ``TINYINT`` and emits ``0`` for ``NaN`` inputs. For FLOAT64-typed
-    arguments — explicit ``CAST(... AS FLOAT64)``, FLOAT64 literals
-    (``±Infinity`` / ``NaN`` string-cast), and FLOAT64 columns — the
-    rewrite emits ``CASE WHEN isnan(arg) THEN arg ELSE
-    CAST(SIGN(arg) AS DOUBLE) END`` so the result column surfaces as
-    FLOAT and ``NaN`` propagates. The ``math_sign_null`` /
-    ``math_sign_inf`` fixtures land PASS without disturbing the INT64
-    happy path. Detection is conservative: the rule only fires when
-    the immediate argument is a ``CAST`` whose target type contains
-    ``FLOAT`` or ``DOUBLE`` — the literal-cast pattern used by every
-    recorded fixture. A future closure can widen detection (column
-    type look-up, NUMERIC preservation); the rule's narrow scope keeps
-    it from disturbing the existing INT64 happy path.
+    BigQuery's ``SIGN(x)`` returns the same type as ``x`` (``INT64 →
+    INT64``, ``FLOAT64 → FLOAT64``, ``NUMERIC → NUMERIC``) and
+    propagates ``NaN`` (``SIGN(NaN) = NaN``). DuckDB's ``sign(x)``
+    always returns ``TINYINT`` and emits ``0`` for ``NaN`` inputs. For
+    FLOAT64-typed arguments — explicit ``CAST(... AS FLOAT64)``,
+    FLOAT64 literals (``±Infinity`` / ``NaN`` string-cast), and
+    FLOAT64 columns — the rewrite emits ``CASE WHEN isnan(arg) THEN
+    arg ELSE CAST(SIGN(arg) AS DOUBLE) END`` so the result column
+    surfaces as FLOAT and ``NaN`` propagates. Detection is
+    conservative: the rule fires only when the immediate argument is
+    a ``CAST`` whose target type contains ``FLOAT`` or ``DOUBLE``;
+    other FLOAT64-bearing shapes (column references, NUMERIC inputs)
+    fall back to DuckDB's TINYINT result.
     """
 
     name = "SIGN_FLOAT_TYPE"
@@ -214,17 +207,15 @@ class SignFloatTypeRule(TranslationRule):
 class CountIfEmptyZeroRule(TranslationRule):
     """``COUNTIF(p)`` → ``COALESCE(COUNTIF(p), 0)`` (wrapped only when needed).
 
-    **P8.b empty-input closure**: BigQuery's ``COUNTIF`` returns ``0``
-    for an empty input (the aggregate never sees a row, but the
-    grouping-key-less ``SELECT COUNTIF(...) FROM empty_t`` still emits
-    one row with ``0``). DuckDB's transpiled equivalent — typically
+    BigQuery's ``COUNTIF`` returns ``0`` for an empty input (the
+    aggregate never sees a row, but the grouping-key-less
+    ``SELECT COUNTIF(...) FROM empty_t`` still emits one row with
+    ``0``). DuckDB's transpiled equivalent — typically
     ``COUNT(*) FILTER (WHERE p)`` or ``SUM(CASE WHEN p THEN 1 END)``
     via SQLGlot — emits ``NULL`` for the same shape. Wrapping the
     typed ``CountIf`` node in ``COALESCE(..., 0)`` recovers
-    BigQuery's "always-INT64, never NULL" contract so the
-    ``agg_countif_empty`` fixture lands PASS without disturbing the
-    happy-path COUNTIF over non-empty sources (where ``COALESCE`` is a
-    no-op).
+    BigQuery's "always-INT64, never NULL" contract; on non-empty
+    sources the ``COALESCE`` is a no-op.
     """
 
     name = "COUNTIF_EMPTY_ZERO"
@@ -250,11 +241,11 @@ class CountIfEmptyZeroRule(TranslationRule):
 class ApproxTopSumRule(TranslationRule):
     """``APPROX_TOP_SUM(value, weight, k)`` → ``approx_top_k(value, k)``.
 
-    DuckDB has no weighted equivalent. The non-weighted top-k stand-in
-    preserves the BigQuery output shape (``ARRAY<value>``) so callers
-    that only inspect the array length (the slice-2 fixture pattern)
-    pass; queries that depend on the ranking value cascade to Bucket
-    I.
+    DuckDB has no weighted equivalent. The non-weighted top-k
+    stand-in preserves the BigQuery output shape (``ARRAY<value>``).
+    Callers that only inspect the array length recover the expected
+    cardinality; callers that depend on the ranking weight see
+    BigQuery's weighted ordering replaced by DuckDB's unweighted one.
     """
 
     name = "APPROX_TOP_SUM"

--- a/src/bqemulator/sql/rules/numeric_types.py
+++ b/src/bqemulator/sql/rules/numeric_types.py
@@ -11,8 +11,9 @@
   UDF (see :mod:`bqemulator.sql.builtin_udfs`) which is registered with
   return type ``DECIMAL(38, 10)`` so the REST schema renderer surfaces
   the column as BIGNUMERIC (any DECIMAL whose ``scale > 9`` is BIGNUMERIC
-  per ADR 0023 §1.B closure). Values exceeding DECIMAL(38, …)'s
-  38-digit cap still cannot be represented — those cascade to Bucket I.
+  per ADR 0023 §1.B). Values exceeding DECIMAL(38, …)'s 38-digit cap
+  cannot be represented and cascade to ADR 0023 §1.I (bit-exact value
+  mismatch).
 
 The rules match the typed SQLGlot nodes ``exp.ParseJSON``-style — for
 ``PARSE_NUMERIC`` / ``PARSE_BIGNUMERIC`` SQLGlot does not synthesise a

--- a/src/bqemulator/sql/rules/spatial.py
+++ b/src/bqemulator/sql/rules/spatial.py
@@ -99,9 +99,9 @@ class StAsGeoJsonStringTypeRule(TranslationRule):
     DuckDB-spatial's ``ST_AsGeoJSON`` returns a value whose Arrow
     output is a VARCHAR string but whose DuckDB *logical* type is
     ``JSON`` (verifiable via ``SELECT typeof(ST_AsGeoJSON(...))``).
-    The engine's ``bqemu.duckdb_type`` field-metadata override (added
-    in the Bucket J closure) reads that logical type and tags the
-    column as ``JSON`` on the wire — but BigQuery's ``ST_AsGeoJSON``
+    The engine's ``bqemu.duckdb_type`` field-metadata override reads
+    that logical type and tags the column as ``JSON`` on the wire —
+    but BigQuery's ``ST_AsGeoJSON``
     returns ``STRING``, so the schema check in the conformance
     comparison helper fails.
 
@@ -188,10 +188,9 @@ class StAsGeoJsonStringTypeRule(TranslationRule):
            recorded ``ST_AsGeoJSON`` output for non-equatorial,
            non-meridian edges.
 
-        The existing JSON-shaped STRING tolerance (ADR 0022 §3,
-        extended in P3.d-followup with float-ULP tolerance) absorbs
-        the inter-token whitespace / key-order / int-vs-float /
-        libm-vs-S2 ULP drift on the populated body.
+        The JSON-shaped STRING tolerance (ADR 0022 §3, with float-ULP
+        tolerance) absorbs the inter-token whitespace / key-order /
+        int-vs-float / libm-vs-S2 ULP drift on the populated body.
         """
         normalised = exp.Anonymous(
             this="bqemu_geojson_geodesic_interp",
@@ -607,10 +606,9 @@ class StMaxDistanceRule(TranslationRule):
 
     Multi-point and shape-shape combinations (MaxDistance between two
     POLYGONs is the diameter of the bounding-arc of all vertex pairs)
-    aren't exercised yet; the helper returns ``NULL`` for those and
+    are unsupported; the helper returns ``NULL`` for those shapes and
     the surrounding query surfaces the unsupported combination to the
-    user rather than silently returning a planar value. P7.c follow-up
-    — closes ``specialized_types/st_maxdistance_basic``.
+    user rather than silently returning a planar value.
     """
 
     name = "ST_MAXDISTANCE"

--- a/src/bqemulator/sql/table_rewriter.py
+++ b/src/bqemulator/sql/table_rewriter.py
@@ -41,8 +41,8 @@ def rewrite_table_refs(duckdb_sql: str, project_id: str) -> str:
 
     This is a regex-based heuristic that works well for common SQL but
     does NOT handle all edge cases (e.g. table names inside string
-    literals). A full AST-based rewriter ships in Phase 3's
-    ``sql/rewriter/`` package.
+    literals). The AST-based rewriter in ``sql/rewriter/`` handles the
+    full surface.
     """
     import sqlglot
     from sqlglot import exp
@@ -89,11 +89,11 @@ def _rewrite_table_node(table_node: object, project_id: str) -> bool:
     if db and "." in db and not catalog and not is_tvf:
         catalog, _, db = db.partition(".")
 
-    # Phase 7: leave references to bqemulator's *reserved* schemas
-    # alone. The time-travel rewriter emits
-    # ``_bqemulator_snapshots.<id>`` references that must reach
-    # DuckDB unmangled. Exact match: a user dataset whose id starts
-    # with the prefix still gets the regular rewrite.
+    # Leave references to bqemulator's *reserved* schemas alone. The
+    # time-travel rewriter emits ``_bqemulator_snapshots.<id>``
+    # references that must reach DuckDB unmangled. Exact match: a user
+    # dataset whose id starts with the prefix still gets the regular
+    # rewrite.
     if db in _RESERVED_SCHEMAS:
         return False
 
@@ -298,7 +298,7 @@ def _rewrite_schema_qualified_calls(tree: object, project_id: str) -> bool:
             # usually because it's a compound ``project.dataset``
             # back-ticked qualifier that contained a dot. BigQuery's
             # user-facing form for this is ``Function not found:
-            # `<qualifier>`.<routine> at [L:C]`` (P3.a, ADR 0022 §3).
+            # `<qualifier>`.<routine> at [L:C]`` (see ADR 0022 §3).
             raise InvalidQueryError(
                 f"Function not found: `{dataset}`.{routine_name} at [1:8]",
                 location="query",

--- a/src/bqemulator/sql/translator.py
+++ b/src/bqemulator/sql/translator.py
@@ -3,7 +3,7 @@
 Pipeline::
 
     BigQuery SQL
-        → pre-process rewriters (Phase 3+: partition pruning, wildcard expansion, …)
+        → pre-process rewriters (partition pruning, wildcard expansion, …)
         → sqlglot.transpile(read="bigquery", write="duckdb")
         → post-process: walk AST, apply every matching TranslationRule
         → serialize back to SQL string
@@ -183,9 +183,7 @@ class SQLTranslator:
         #    Strip the schema clause and wrap each SELECT projection in
         #    ``CAST(<value> AS <declared-type>) AS <declared-name>`` so
         #    the resulting bare CTAS preserves the user's declared
-        #    column types. Discovered 2026-05-17 during P2.d Phase 8
-        #    conformance recording — every fixture using the canonical
-        #    BigQuery CTAS-with-schema form failed at DuckDB parse time.
+        #    column types.
         bq_sql_for_transpile = rewrite_create_table_schema_ctas(bq_sql)
         # 2-pre. Scope-expansion #15 pre-translator: rewrite the
         #    BigQuery ``RANGE_SESSIONIZE(TABLE …, …)`` TVF call into
@@ -197,80 +195,79 @@ class SQLTranslator:
         #    parser doesn't accept the ``TABLE <ref>`` TVF-argument
         #    keyword.
         bq_sql_for_transpile = rewrite_range_sessionize(bq_sql_for_transpile)
-        # 2. Phase 9 pre-translator: expand BigQuery compound interval
-        #    literals (``INTERVAL '1-2 3 4:5:6.789' YEAR TO SECOND``)
-        #    into single-unit additive expressions so DuckDB's parser
-        #    accepts the SQL after SQLGlot's transpile pass.
+        # 2. Specialized-types pre-translator: expand BigQuery compound
+        #    interval literals (``INTERVAL '1-2 3 4:5:6.789' YEAR TO
+        #    SECOND``) into single-unit additive expressions so DuckDB's
+        #    parser accepts the SQL after SQLGlot's transpile pass.
         bq_sql_for_transpile = rewrite_specialized_types(bq_sql_for_transpile)
-        # 2b. Bucket J pre-translator: route NORMALIZE /
+        # 2b. String-helpers pre-translator: route NORMALIZE /
         #     NORMALIZE_AND_CASEFOLD through Python helpers — SQLGlot
         #     collapses the casefold flag during the DuckDB transpile,
         #     so we must rewrite while the BigQuery AST still carries
         #     the distinction.
         bq_sql_for_transpile = rewrite_string_helpers(bq_sql_for_transpile)
-        # 2c. Bucket J pre-translator: ARRAY_AGG / STRING_AGG ORDER BY
-        #     LIMIT n + ARRAY_AGG IGNORE NULLS. DuckDB rejects LIMIT
-        #     inside aggregates and SQLGlot silently drops IGNORE NULLS
-        #     during the DuckDB transpile, so we must rewrite while the
-        #     BigQuery AST still carries the original shape.
+        # 2c. Aggregate-variants pre-translator: ARRAY_AGG / STRING_AGG
+        #     ORDER BY LIMIT n + ARRAY_AGG IGNORE NULLS. DuckDB rejects
+        #     LIMIT inside aggregates and SQLGlot silently drops IGNORE
+        #     NULLS during the DuckDB transpile, so we must rewrite
+        #     while the BigQuery AST still carries the original shape.
         bq_sql_for_transpile = rewrite_aggregate_variants(bq_sql_for_transpile)
-        # 2d. Bucket J pre-translator: pin NUMERIC / BIGNUMERIC typed
-        #     literals to explicit DECIMAL precision so DuckDB's default
-        #     DECIMAL(18, 3) doesn't reject wide BigQuery numerics. The
-        #     Bucket B (2026-05-16) closure switched BIGNUMERIC handling
-        #     to a Python UDF so the scale-marker (> 9) lands on the
-        #     wire as BIGNUMERIC even when the literal's natural scale
-        #     is ≤ 9.
+        # 2d. Numeric-literals pre-translator: pin NUMERIC / BIGNUMERIC
+        #     typed literals to explicit DECIMAL precision so DuckDB's
+        #     default DECIMAL(18, 3) doesn't reject wide BigQuery
+        #     numerics. BIGNUMERIC routes through a Python UDF so the
+        #     scale-marker (> 9) lands on the wire as BIGNUMERIC even
+        #     when the literal's natural scale is ≤ 9.
         bq_sql_for_transpile = rewrite_numeric_literals(bq_sql_for_transpile)
-        # 2e. Bucket B pre-translator: rewrite bare BigQuery decimal
-        #     literals (``3.25``, ``-1.5``) to scientific notation so
-        #     DuckDB types them as ``DOUBLE`` (matching BigQuery's
-        #     ``FLOAT64`` typing) instead of inferring a narrow
-        #     ``DECIMAL(p, s)`` that surfaces as NUMERIC on the wire.
+        # 2e. Decimal-literals pre-translator: rewrite bare BigQuery
+        #     decimal literals (``3.25``, ``-1.5``) to scientific
+        #     notation so DuckDB types them as ``DOUBLE`` (matching
+        #     BigQuery's ``FLOAT64`` typing) instead of inferring a
+        #     narrow ``DECIMAL(p, s)`` that surfaces as NUMERIC on the
+        #     wire.
         bq_sql_for_transpile = rewrite_decimal_literals(bq_sql_for_transpile)
-        # 2f. Bucket I pre-translator: rewrite ``LAST_DAY(x, WEEK)`` to
-        #     ``DATE_ADD(x, INTERVAL (7 - EXTRACT(DAYOFWEEK FROM x))
-        #     DAY)``. SQLGlot's default transpile inlines the call to a
-        #     Sunday-end (not BigQuery's Saturday-end) expression; the
-        #     pre-translate runs while the AST still carries the
-        #     LastDay shape so we can replace it cleanly.
+        # 2f. Datetime-helpers pre-translator: rewrite ``LAST_DAY(x,
+        #     WEEK)`` to ``DATE_ADD(x, INTERVAL (7 - EXTRACT(DAYOFWEEK
+        #     FROM x)) DAY)``. SQLGlot's default transpile inlines the
+        #     call to a Sunday-end (not BigQuery's Saturday-end)
+        #     expression; the pre-translate runs while the AST still
+        #     carries the LastDay shape so we can replace it cleanly.
         bq_sql_for_transpile = rewrite_datetime_helpers(bq_sql_for_transpile)
-        # 2g. Bucket I pre-translator: wrap ``TO_JSON(x)`` in
+        # 2g. JSON-helpers pre-translator: wrap ``TO_JSON(x)`` in
         #     ``CAST(... AS JSON)`` so the result column lands on the
         #     wire as ``JSON`` rather than ``STRING`` (which is what
         #     SQLGlot's default ``CAST(TO_JSON(...) AS TEXT)`` produces
         #     for both ``TO_JSON`` and ``TO_JSON_STRING``).
         bq_sql_for_transpile = rewrite_json_helpers(bq_sql_for_transpile)
-        # 2h-pre. Pre-translator (runs BEFORE ``rewrite_struct_helpers``):
-        #     propagate the first STRUCT's named-field aliases to every
-        #     subsequent positional STRUCT in an ``UNNEST([...])`` array
-        #     literal. This preserves BigQuery's "first struct seeds the
-        #     field names for the array" semantic so the downstream
-        #     ``rewrite_struct_helpers`` pass sees a homogeneously-named
-        #     array (and therefore leaves it alone). Closes the
-        #     ``script_for_iterate_into_table`` conformance fixture —
-        #     before this rewriter ran, ``rewrite_struct_helpers`` would
-        #     convert ``STRUCT('b', 2)`` → ``ROW('b', 2)`` while leaving
-        #     the first ``STRUCT('a' AS label, 1 AS value)`` named, and
-        #     the resulting mixed array failed DuckDB's field-name
-        #     binder on the outer ``SELECT label, value``.
+        # 2h-pre. UNNEST-struct pre-translator (runs BEFORE
+        #     ``rewrite_struct_helpers``): propagate the first STRUCT's
+        #     named-field aliases to every subsequent positional STRUCT
+        #     in an ``UNNEST([...])`` array literal. This preserves
+        #     BigQuery's "first struct seeds the field names for the
+        #     array" semantic so the downstream ``rewrite_struct_helpers``
+        #     pass sees a homogeneously-named array (and therefore
+        #     leaves it alone). Without this step, the downstream pass
+        #     would convert ``STRUCT('b', 2)`` → ``ROW('b', 2)`` while
+        #     leaving the first ``STRUCT('a' AS label, 1 AS value)``
+        #     named, and the resulting mixed array would fail DuckDB's
+        #     field-name binder on the outer ``SELECT label, value``.
         bq_sql_for_transpile = rewrite_unnest_struct(bq_sql_for_transpile)
-        # 2h. Bucket I pre-translator: rewrite positional
+        # 2h. Struct-helpers pre-translator: rewrite positional
         #     ``STRUCT(value, value, …)`` to DuckDB's ``ROW(…)`` so the
         #     struct aligns *positionally* with its target — matching
         #     BigQuery's name-from-context inference for INSERT VALUES
         #     and UNION ALL chains where the first SELECT carries
         #     explicit field aliases.
         bq_sql_for_transpile = rewrite_struct_helpers(bq_sql_for_transpile)
-        # 2i. Bucket I pre-translator: rewrite BigQuery's ``SAFE.X``
+        # 2i. Safe-helpers pre-translator: rewrite BigQuery's ``SAFE.X``
         #     prefix form (``SAFE.LN(-1)``, ``SAFE.SQRT(-1)``, etc.) to
         #     DuckDB's ``TRY(...)`` — the SQLGlot transpile leaves the
         #     ``SAFE.`` schema-qualified call intact and the table
         #     rewriter then mangles it into a synthetic project-qualified
         #     function name.
         bq_sql_for_transpile = rewrite_safe_helpers(bq_sql_for_transpile)
-        # 2j. Scope-expansion #17 pre-translator: wrap every bare ``/``
-        #     in a CASE that raises ``Division by zero`` via DuckDB's
+        # 2j. Division-by-zero pre-translator: wrap every bare ``/`` in
+        #     a CASE that raises ``Division by zero`` via DuckDB's
         #     ``error(VARCHAR)`` builtin when the divisor evaluates to
         #     0. Runs AFTER ``safe_helpers`` so a user-written ``a / b``
         #     inside the ``SAFE.X(...)`` prefix form is already nested
@@ -280,8 +277,8 @@ class SQLTranslator:
         #     ``IEEE_DIVIDE``) are opaque ``Anonymous`` / typed nodes
         #     at this stage so the walk does not see them — their Div
         #     children are emitted post-translate by SQLGlot's transpile
-        #     and the Bucket J ``IeeeDivideRule``, respectively, after
-        #     our pre-translator has already run.
+        #     and the ``IeeeDivideRule``, respectively, after our
+        #     pre-translator has already run.
         bq_sql_for_transpile = rewrite_division_by_zero(bq_sql_for_transpile)
         # 2k-pre. SHA512 pre-translator: rewrite every ``SHA512(x)`` to
         #     ``bqemu_sha512(x)`` while the AST still carries the
@@ -290,16 +287,17 @@ class SQLTranslator:
         #     ``sha512`` builtin); rewriting here preserves the
         #     algorithm width.
         bq_sql_for_transpile = rewrite_sha512(bq_sql_for_transpile)
-        # 2k-tz. Timestamp ISO helpers pre-translator (P8.e, 2026-05-20):
-        #     Route ``FORMAT_TIMESTAMP`` / ``PARSE_TIMESTAMP`` through the
+        # 2k-tz. Timestamp ISO helpers pre-translator: route
+        #     ``FORMAT_TIMESTAMP`` / ``PARSE_TIMESTAMP`` through the
         #     Python helpers ``bqemu_format_timestamp_iso`` /
         #     ``bqemu_parse_timestamp_iso`` whenever the format carries a
-        #     ``%Ez`` extension specifier or a ``%Z`` named-zone token, or
-        #     when ``FORMAT_TIMESTAMP`` carries an explicit zone argument
-        #     SQLGlot would otherwise drop on transpile. The helpers
-        #     bridge DuckDB's STRFTIME / STRPTIME, which reject ``%E#``
-        #     specifiers and silently accept ambiguous zone abbreviations
-        #     that real BigQuery rejects with ``Invalid time zone``.
+        #     ``%Ez`` extension specifier or a ``%Z`` named-zone token,
+        #     or when ``FORMAT_TIMESTAMP`` carries an explicit zone
+        #     argument SQLGlot would otherwise drop on transpile. The
+        #     helpers bridge DuckDB's STRFTIME / STRPTIME, which reject
+        #     ``%E#`` specifiers and silently accept ambiguous zone
+        #     abbreviations that real BigQuery rejects with ``Invalid
+        #     time zone``.
         bq_sql_for_transpile = rewrite_timestamp_iso_helpers(bq_sql_for_transpile)
         # 2k. COLLATE specifier pre-translator: rewrite the two
         #     BigQuery specifiers the corpus exercises — ``'und:ci'``
@@ -312,13 +310,13 @@ class SQLTranslator:
         #     ``<value> COLLATE und:ci`` form which DuckDB's lexer
         #     rejects (the ``:`` is a divider).
         bq_sql_for_transpile = rewrite_collate_specifier(bq_sql_for_transpile)
-        # 2l. P7.c follow-up — rewrite BigQuery's ``_PARTITIONDATE`` /
-        #     ``_PARTITIONTIME`` pseudo-columns to ``CURRENT_DATE()`` /
-        #     ``CURRENT_TIMESTAMP()``. The emulator's storage layer
-        #     doesn't tag rows with a partition timestamp; collapsing
-        #     to today's date matches the recorded-fixtures' filters
-        #     (``> '1900-01-01'``, ``BETWEEN ...``) and the fixture
-        #     for ``< '1900-01-01'`` that expects 0 rows.
+        # 2l. Partition-pseudo-columns pre-translator: rewrite BigQuery's
+        #     ``_PARTITIONDATE`` / ``_PARTITIONTIME`` pseudo-columns to
+        #     ``CURRENT_DATE()`` / ``CURRENT_TIMESTAMP()``. The
+        #     emulator's storage layer doesn't tag rows with a partition
+        #     timestamp; collapsing to today's date matches the fixture
+        #     filters (``> '1900-01-01'``, ``BETWEEN ...``) and the
+        #     fixture for ``< '1900-01-01'`` that expects 0 rows.
         bq_sql_for_transpile = rewrite_partition_pseudo_columns(bq_sql_for_transpile)
 
         # 3. SQLGlot transpile.

--- a/src/bqemulator/storage/arrow_bridge.py
+++ b/src/bqemulator/storage/arrow_bridge.py
@@ -390,10 +390,9 @@ def _coerce_arrow_binary(value: Any, _arrow_type: pa.DataType, _field: pa.Field 
       already validated the wire encoding upstream and a strict
       base64 check would mis-fire on the binary payload.
 
-    Any other type raises ``TypeError`` — previously such values went
-    through ``bytes(value)`` which tolerated iterables of ints and
-    masked real bugs. Strictness here matches the BigQuery contract
-    and surfaces caller errors loudly.
+    Any other type raises ``TypeError``. Tolerating arbitrary iterables
+    of ints would mask real caller bugs; strictness here matches the
+    BigQuery contract and surfaces those errors loudly.
     """
     import base64
 
@@ -521,7 +520,7 @@ def _coerce_to_arrow_value(
 
 
 # ---------------------------------------------------------------------------
-# Phase 9 specialized-type coercion helpers.
+# Specialized-type coercion helpers (GEOGRAPHY, RANGE, INTERVAL).
 # ---------------------------------------------------------------------------
 
 

--- a/src/bqemulator/storage/engine.py
+++ b/src/bqemulator/storage/engine.py
@@ -9,10 +9,10 @@ The engine also handles startup tasks:
 
 * Ensure the reserved ``_bqemulator_catalog`` schema exists.
 * Set the connection's time zone to ``UTC`` (BigQuery TIMESTAMP semantics).
-* Install and load the ``spatial`` extension. From Phase 9 onward this is
-  a required dependency — startup fails fast with a clear error if the
-  extension cannot be installed/loaded (e.g. offline build with no
-  cached extension), because GEOGRAPHY queries depend on it.
+* Install and load the ``spatial`` extension. Required — startup fails
+  fast with a clear error if the extension cannot be installed/loaded
+  (e.g. offline build with no cached extension), because GEOGRAPHY
+  queries depend on it.
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ _log = get_logger(__name__)
 # create datasets that collide with this (validated elsewhere).
 CATALOG_SCHEMA = "_bqemulator_catalog"
 
-# Reserved schema where Phase 7 time-travel snapshot tables live. Like
+# Reserved schema where time-travel snapshot tables live. Like
 # ``CATALOG_SCHEMA`` it's created unconditionally at engine startup so
 # the snapshot layer works under both memory- and DuckDB-backed
 # catalogs (the memory path never runs migrations).
@@ -196,14 +196,14 @@ class DuckDBEngine:
         _log.debug("duckdb.builtin_udfs_registered")
 
     def _load_spatial(self) -> None:
-        """Load DuckDB's spatial extension. Required (fail-fast) since Phase 9.
+        """Load DuckDB's spatial extension; fail fast if unavailable.
 
-        Phase 9 ships GEOGRAPHY support backed by DuckDB's spatial
-        extension. The extension powers every ``ST_*`` function the
-        emulator translates BigQuery GEOGRAPHY queries into. Without it
-        the emulator cannot honour its GEOGRAPHY contract, so we surface
-        the failure at startup rather than letting query-time
-        ``ST_*`` calls fail with confusing catalog errors.
+        GEOGRAPHY support is backed by DuckDB's spatial extension. The
+        extension powers every ``ST_*`` function the emulator translates
+        BigQuery GEOGRAPHY queries into. Without it the emulator cannot
+        honour its GEOGRAPHY contract, so we surface the failure at
+        startup rather than letting query-time ``ST_*`` calls fail with
+        confusing catalog errors.
         """
         if self._connection is None:  # internal invariant
             raise InternalError("DuckDBEngine not started")

--- a/src/bqemulator/storage/type_map.py
+++ b/src/bqemulator/storage/type_map.py
@@ -7,12 +7,11 @@ catalog DDL generator) consults this mapping.
 The mapping is not 1:1 in every case — see the ``Notes`` column in
 :data:`TYPE_MAP` for cases where precision or semantics differ.
 
-Phase 1 types
--------------
+Supported BigQuery types
+------------------------
 INT64, FLOAT64, NUMERIC, BIGNUMERIC, BOOL, STRING, BYTES, DATE, TIME,
-DATETIME, TIMESTAMP, JSON, ARRAY<T>, STRUCT<…>.
-
-Phase 9 additions: GEOGRAPHY, RANGE<T>, INTERVAL.
+DATETIME, TIMESTAMP, JSON, ARRAY<T>, STRUCT<…>, GEOGRAPHY, RANGE<T>,
+INTERVAL.
 """
 
 from __future__ import annotations
@@ -47,7 +46,7 @@ TYPE_MAP: tuple[TypeMapping, ...] = (
     TypeMapping("DATETIME", "TIMESTAMP", notes="BigQuery DATETIME is timezone-naive"),
     TypeMapping("TIMESTAMP", "TIMESTAMPTZ", notes="BigQuery TIMESTAMP is always UTC"),
     TypeMapping("JSON", "JSON"),
-    # Phase 9 specialized types.
+    # Specialized BigQuery types.
     TypeMapping("GEOGRAPHY", "GEOMETRY", notes="DuckDB spatial extension; planar (not spheroidal)"),
     TypeMapping("INTERVAL", "INTERVAL", notes="Native DuckDB INTERVAL"),
     # ARRAY, STRUCT, and RANGE<T> are parameterized — handled specially below.
@@ -91,7 +90,7 @@ _DUCKDB_ALIASES: dict[str, str] = {
     "TIMESTAMPTZ": "TIMESTAMP",
     "TIMESTAMP WITH TIME ZONE": "TIMESTAMP",
     "JSON": "JSON",
-    # Phase 9 specialized types.
+    # Specialized BigQuery types.
     "GEOMETRY": "GEOGRAPHY",
     "INTERVAL": "INTERVAL",
 }

--- a/src/bqemulator/streaming/avro_serializer.py
+++ b/src/bqemulator/streaming/avro_serializer.py
@@ -1,9 +1,9 @@
-r"""Avro row-format serializer for the Storage Read API (G3 / ADR 0030).
+r"""Avro row-format serializer for the Storage Read API (ADR 0030).
 
 Real BigQuery's Storage Read API supports two wire formats:
 
-* **Arrow IPC** — Python / Go / Node default. Phase 4 ships this.
-* **Apache Avro** — Java client default. G3 closes this gap.
+* **Arrow IPC** — Python / Go / Node default.
+* **Apache Avro** — Java client default.
 
 The Storage Read Avro wire contract is "schema-once on the session,
 naked binary rows per response chunk":

--- a/src/bqemulator/streaming/read_session.py
+++ b/src/bqemulator/streaming/read_session.py
@@ -70,7 +70,7 @@ _SESSIONS: dict[str, ReadSessionState] = {}
 # Real BigQuery returns 1 stream regardless of ``max_stream_count``
 # when the underlying table is under this size — empirically ~1 MB.
 # Matched by :func:`create_read_session` so the wire-format
-# conformance suite (P3.d) holds for small fixtures.
+# conformance suite holds for small fixtures.
 _SMALL_TABLE_BYTE_THRESHOLD = 1_000_000
 
 
@@ -121,7 +121,7 @@ def create_read_session(
     # ``max_stream_count`` as an upper bound and returns fewer streams
     # when the table is too small to benefit from parallel reads —
     # empirically, tables under ~1 MB get 1 stream regardless. Match
-    # that contract so the gRPC-corpus wire-format diff (P3.d) holds.
+    # that contract so the gRPC-corpus wire-format diff holds.
     num_rows = arrow_table.num_rows
     table_bytes = arrow_table.nbytes
     requested = max(max_streams, 1)
@@ -215,9 +215,9 @@ def split_stream(stream_name: str, fraction: float) -> tuple[str, str] | None:
     Both are registered with the owning session so subsequent
     ``ReadRows`` calls route through :func:`get_stream_data`. Returns
     ``None`` if the stream is not found. The wire-format conformance
-    suite (P3.d) asserts that ``SplitReadStream`` returns a non-empty
-    response shape; the emulator does not optimise parallelism (the
-    BQ compatibility matrix flags this as a hint-only surface).
+    suite asserts that ``SplitReadStream`` returns a non-empty response
+    shape; the emulator does not optimise parallelism (the BQ
+    compatibility matrix flags this as a hint-only surface).
     """
     session_name = "/".join(stream_name.split("/")[:-2])
     state = _SESSIONS.get(session_name)
@@ -280,14 +280,13 @@ def serialize_arrow_record_batch(batch: pa.RecordBatch) -> bytes:
     separately via ``ReadSession.arrow_schema.serialized_schema`` and
     the first ``ReadRowsResponse.arrow_schema`` field.
 
-    Earlier (≤ v1.0.0) the read servicer packed a full IPC stream
-    (schema framing + batches + EOS marker) into ``serialized_record_batch``.
-    Real Storage Read clients tripped on the format mismatch — e.g.
-    ``google-cloud-bigquery-storage``'s ``reader.to_arrow(session)``
-    calls ``pyarrow.ipc.read_record_batch(...)`` which raises
-    ``OSError: Expected IPC message of type record batch but got schema``.
-    This function emits the documented format so those clients work
-    unchanged. See issue #15.
+    Packing a full IPC stream (schema framing + batches + EOS marker)
+    into ``serialized_record_batch`` would trip real Storage Read
+    clients — e.g. ``google-cloud-bigquery-storage``'s
+    ``reader.to_arrow(session)`` calls ``pyarrow.ipc.read_record_batch(...)``
+    which raises ``OSError: Expected IPC message of type record batch
+    but got schema``. This function emits the documented format so
+    those clients work unchanged.
 
     The implementation writes the batch through ``pa.ipc.new_stream``
     to a transient buffer, then re-reads the stream with a

--- a/src/bqemulator/streaming/strategies/buffered.py
+++ b/src/bqemulator/streaming/strategies/buffered.py
@@ -91,7 +91,7 @@ class BufferedWriteStrategy:
 
         ``offset`` is the exclusive upper bound in BigQuery's semantics:
         every row at index ``< offset`` becomes visible. ``offset`` must be
-        strictly greater than the previously flushed offset and at most
+        strictly greater than the prior flushed offset and at most
         ``next_offset`` (the count of rows buffered so far).
         """
         if stream.state is not WriteStreamState.OPEN:
@@ -102,8 +102,8 @@ class BufferedWriteStrategy:
         # Real BigQuery wording for an out-of-range FlushRows offset is
         # "Offset N is beyond the end of the stream Entity: <stream>"
         # — including the entity name in the message itself so the
-        # error surfaces from one log line. The gRPC-corpus
-        # conformance suite (P3.d) asserts this contract.
+        # error surfaces from one log line. The gRPC-corpus conformance
+        # suite asserts this contract.
         if offset > stream.next_offset:
             return FlushOutcome(
                 ok=False,

--- a/src/bqemulator/testing/testcontainers.py
+++ b/src/bqemulator/testing/testcontainers.py
@@ -55,12 +55,12 @@ class BigQueryEmulatorContainer(DockerContainer):
         self.with_env("BQEMU_GRPC_HOST", "0.0.0.0")  # noqa: S104
         self.with_env("BQEMU_REST_PORT", str(rest_port))
         self.with_env("BQEMU_GRPC_PORT", str(grpc_port))
-        # Phase 10 admin endpoints are off by default in the published
-        # image. The testcontainer wrapper always opts them in so the
-        # Python / Node / Go / Java E2E suites can exercise the
-        # ``/admin/*`` surface without a custom image build.
+        # Admin endpoints are off by default in the published image.
+        # The testcontainer wrapper always opts them in so the Python /
+        # Node / Go / Java E2E suites can exercise the ``/admin/*``
+        # surface without a custom image build.
         self.with_env("BQEMU_ADMIN_ENABLED", "1")
-        # G1: load/extract jobs that reference ``gs://`` URIs need a
+        # Load/extract jobs that reference ``gs://`` URIs need a
         # host→container bind mount so the file the test writes on the
         # host is visible to the executor inside the container. The
         # caller passes a host directory; the wrapper mounts it at

--- a/src/bqemulator/types/__init__.py
+++ b/src/bqemulator/types/__init__.py
@@ -1,4 +1,4 @@
-"""Phase 9 specialized types: GEOGRAPHY, RANGE<T>, INTERVAL.
+"""Specialized BigQuery types: GEOGRAPHY, RANGE<T>, INTERVAL.
 
 Each module in this package isolates the codec / parsing / formatting
 concerns for a single specialized BigQuery type. Storage type-mapping

--- a/src/bqemulator/versioning/__init__.py
+++ b/src/bqemulator/versioning/__init__.py
@@ -1,4 +1,4 @@
-"""Phase 7 — versioning: snapshots, time travel, clones, materialized views.
+"""Versioning: snapshots, time travel, clones, materialized views.
 
 Module layout:
 
@@ -12,10 +12,10 @@ Module layout:
 * :mod:`bqemulator.versioning.materialized_views` — MV registry with
   event-driven staleness and lazy recompute.
 * :mod:`bqemulator.versioning.ddl` — regex-based detector that routes
-  Phase 7 DDL statements to the right manager without going through
+  versioning DDL statements to the right manager without going through
   the SQL translator.
 
-See ADRs `0009`, `0016`, and `0017` for the locked decisions.
+See ADRs `0009`, `0016`, and `0017` for the contracts.
 """
 
 from __future__ import annotations

--- a/src/bqemulator/versioning/ddl.py
+++ b/src/bqemulator/versioning/ddl.py
@@ -1,12 +1,12 @@
-"""DDL router for Phase 7 statements.
+"""DDL router for versioning statements.
 
 ``CREATE SNAPSHOT TABLE``, ``CREATE TABLE ... CLONE``,
 ``CREATE MATERIALIZED VIEW``, ``REFRESH MATERIALIZED VIEW``, ``DROP
-SNAPSHOT TABLE``, and ``DROP MATERIALIZED VIEW`` are all Phase-7
+SNAPSHOT TABLE``, and ``DROP MATERIALIZED VIEW`` are versioning DDL
 statements that SQLGlot either round-trips opaquely or rejects. They
 never go through the regular SQL translator — instead, the job
 executor asks this module whether the incoming statement is a
-Phase-7 DDL, and if so delegates the whole job to the matching
+versioning DDL, and if so delegates the whole job to the matching
 manager.
 
 The detection is regex-based (similar in spirit to
@@ -193,10 +193,10 @@ class VersioningDDLRouter:
             return self._project_id, parts[0], parts[1]
         if len(parts) == _PARTS_BARE:
             raise InvalidQueryError(
-                "Phase 7 DDL requires a fully-qualified or dataset-qualified table reference",
+                "Versioning DDL requires a fully-qualified or dataset-qualified table reference",
             )
         raise InvalidQueryError(
-            f"Could not parse Phase 7 DDL target: {raw!r}",
+            f"Could not parse versioning DDL target: {raw!r}",
         )
 
 

--- a/src/bqemulator/versioning/materialized_views.py
+++ b/src/bqemulator/versioning/materialized_views.py
@@ -1,7 +1,7 @@
 """Materialized-view registry, refresh, and staleness tracking.
 
-Implements the Phase 7 MV model locked in by ADR 0017 — event-driven
-staleness flagging plus lazy recompute on read.
+Implements the MV model from ADR 0017 — event-driven staleness
+flagging plus lazy recompute on read.
 
 Lifecycle:
 


### PR DESCRIPTION
## Summary

- Strips phase labels (`P3.a`, `P7.b phase 2 follow-up #1`, `G4`, `Bucket J`, `slice-2`), PR references, dates, "previously X", TODOs, author names, and calibration narratives from docstrings and inline comments under `src/bqemulator/**`.
- Preserves technical depth: invariants, edge cases, contract details, and ADR cross-references that point at current specifications.
- Applies the rules codified in [PR #64](https://github.com/jjviscomi/bqemulator/pull/64)'s [documentation style guide](docs/architecture/contributing/documentation-style-guide.md).

## Scope

62 files changed, +466 / -545 lines (the net deletion reflects the bias toward stripping history). After the sweep, the survey regex reports zero matches:

```bash
grep -rnE "P[0-9]+\.[a-z]|PR #[0-9]+|\bG[0-9] |Phase [0-9]|TODO\b|FIXME\b|future work|Bucket [A-Z]" src/bqemulator --include="*.py"
# (no output)
```

The two surviving "previously" usages are legitimate English ("previously declared total ...", "Remove a previously registered handler") — not historical narrative about the code.

## Context

Third PR in the doc-rewrite series:

- [#64](https://github.com/jjviscomi/bqemulator/pull/64) MERGED — PR A.0 style guide.
- [#65](https://github.com/jjviscomi/bqemulator/pull/65) MERGED — PR A CHANGELOG + tooling rewrite.
- **This PR (PR B)** — `src/bqemulator/**` docstring sweep.
- **PR C (next)** — `docs/reference/**` + `docs/architecture/**` sweep (excluding ADRs and RFCs).

## Test plan

- [x] `ruff check src/bqemulator/` — clean
- [x] `ruff format --check src/bqemulator/` — 168 files already formatted
- [x] `python -m mypy --config-file pyproject.toml src/` — 168 files, no issues
- [x] `python -m interrogate --config pyproject.toml src/` — 99.4% (≥90% gate)
- [x] `python -m pytest tests/unit/` — 2896 passed
- [ ] CI: full gate chain (will run on push)

## Out of scope

- Reference docs sweep in `docs/reference/**` + `docs/architecture/**` (PR C).
- Test docstring sweep (deferred until after a green doc-rewrite series).
- ADRs and RFCs are explicitly out of scope per the style guide (historical decision records).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation and comments throughout the codebase to remove outdated phase and workstream references.
  * Clarified technical descriptions across API routes, storage engines, SQL processing, and streaming components.
  * No functional changes or API modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->