### PR TITLE
chore(release): emit attestation under a Scorecard-discoverable filename

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -22,7 +22,7 @@ on:
     paths:
       - "**/*.md"
       - ".lychee.toml"
-      - ".github/workflows/linkcheck.yml"
+      - ".github/workflows/*.yml"
   # Nightly run on main so URL rot in unmodified docs is caught
   # within 24h even without a PR.
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,9 +95,21 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: 'dist/*'
+      - name: Stage attestation under a Scorecard-discoverable filename
+        # OpenSSF Scorecard's ``Signed-Releases`` check matches release
+        # assets by extension: ``*.intoto.jsonl`` / ``*.sigstore`` /
+        # ``*.sig``. The action's default ``attestation.json`` output
+        # is a valid sigstore bundle (``mediaType:
+        # application/vnd.dev.sigstore.bundle.v0.3+json``) but the
+        # filename pattern doesn't match. Copy it into ``dist/`` under
+        # the canonical name so the upload step picks it up alongside
+        # the wheel + sdist and Scorecard credits the release.
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          cp "${{ steps.attest.outputs.bundle-path }}" \
+             "dist/bqemulator-${VERSION}.intoto.jsonl"
       - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
           files: |
             dist/*
-            ${{ steps.attest.outputs.bundle-path }}


### PR DESCRIPTION
## Summary

OpenSSF Scorecard's `Signed-Releases` check matches release assets by filename extension (`*.intoto.jsonl` / `*.sigstore` / `*.sig`). `actions/attest-build-provenance@v4.1.0` writes its sigstore bundle to `attestation.json` by default — valid bundle (`mediaType: application/vnd.dev.sigstore.bundle.v0.3+json`), but the extension is invisible to Scorecard's matcher.

Result: v1.1.0 shipped with a verifiable attestation (`gh attestation verify` works), but Scorecard reports `Signed-Releases: 0/10 — Project has not signed or included provenance with any releases`.

## Fix

After `attest-build-provenance` runs, stage the bundle under `dist/bqemulator-<version>.intoto.jsonl` before the upload step. The wheel + sdist + canonical-named attestation all land in the release together. Drop the explicit `${{ steps.attest.outputs.bundle-path }}` from the upload `files:` list since the copy is already in `dist/*`.

## v1.1.0 retroactive

The v1.1.0 release asset has already been re-uploaded under the new name (`bqemulator-1.1.0.intoto.jsonl`) — byte-identical copy of the existing `attestation.json`. Scorecard will pick it up on next weekly scan.

## Test plan

- [x] `gh release view v1.1.0 --json assets --jq '.assets[].name'` shows `bqemulator-1.1.0.intoto.jsonl` alongside the wheel + sdist.
- [x] Bundle content is the same sigstore v0.3 bundle (`gh attestation verify bqemulator-1.1.0.intoto.jsonl --owner jjviscomi` works on the new filename too).
- [ ] Next release (v1.1.1 onward) will produce the canonical name natively — verified on next release dry-run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release artifacts now include build attestation files packaged with the distribution assets.
* **Chores**
  * Link-check CI is now triggered when workflow YAML files are modified, expanding checks to workflow edits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->