### PR TITLE
chore(security): bump tests/e2e/go_client Go toolchain + document Scorecard caveat

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -15,14 +15,12 @@ name: Link check
 # Config lives in ``.lychee.toml`` at the repo root.
 
 on:
-  # On every PR that touches markdown, the lychee config itself, or
-  # this workflow — limits CI cost to PRs that could plausibly change
-  # link state.
+  # Run on every PR. lychee is a fast (~30s) check and is a required
+  # status under the branch-protection ruleset, so a path filter would
+  # leave PRs that only touch non-doc surfaces in 'expected' state
+  # under strict status-checks policy. The lychee cache + the
+  # max-cache-age makes repeated runs cheap.
   pull_request:
-    paths:
-      - "**/*.md"
-      - ".lychee.toml"
-      - ".github/workflows/*.yml"
   # Nightly run on main so URL rot in unmodified docs is caught
   # within 24h even without a PR.
   schedule:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -166,6 +166,15 @@ exclude = [
     # CI avoids the false positive. The release workflow re-runs
     # lychee against the published site.
     "^https://jjviscomi\\.github\\.io/bqemulator/",
+    # OpenSSF Scorecard viewer / API origin — recurringly flakey from
+    # GitHub Actions runner egress (``Connection failed`` /
+    # ``Connection reset by peer``). The same hosts respond cleanly
+    # from local dev runs; we already verify the scorecard endpoint
+    # via the dedicated ``scorecard.yml`` workflow that talks to
+    # ``api.securityscorecards.dev`` directly. Skipping the public
+    # viewer + API hostnames from lychee removes the false-positive
+    # link-rot signal.
+    "^https://(api\\.securityscorecards|scorecard)\\.dev/",
     # Email / messaging schemes
     "^mailto:",
 ]

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -5,6 +5,45 @@
 # Consumers running ``osv-scanner`` against this repository honour these
 # ignores; CI workflows that wrap osv-scanner read this file via
 # ``--config osv-scanner.toml``.
+#
+# ---------------------------------------------------------------------------
+# OpenSSF Scorecard caveat
+# ---------------------------------------------------------------------------
+#
+# The OpenSSF Scorecard ``Vulnerabilities`` check imports osv-scanner as
+# a library and runs it WITHOUT honouring this configuration file's
+# ``IgnoredVulns``. As a result, Scorecard scans of this repository
+# will report the docker/docker advisories listed below even though we
+# have documented them as accepted-with-rationale here.
+#
+# Scorecard also flags historical ``v0.0.0-YYYYMMDD…/go.mod`` entries
+# in our Go example modules' ``go.sum`` files (e.g.,
+# ``golang.org/x/crypto v0.0.0-20190308…``). These are
+# **transitive ancestor versions** that Go's MVS records for build
+# reproducibility — they are NOT the resolved active version (which is
+# the current, patched ``v0.51.0+``). Go's ``go mod tidy`` cannot
+# remove them without breaking module verification.
+#
+# Net effect: as long as the example Go projects (especially
+# ``docs/examples/go/beam-pipeline``, which transitively pulls
+# ``github.com/docker/docker`` via ``apache/beam/.../runners/prism``)
+# remain in-tree, Scorecard's ``Vulnerabilities`` check will continue
+# to score 0/10 regardless of how aggressively we bump direct deps.
+#
+# Mitigation paths considered:
+# - **govulncheck** (Go's official scanner with reachability analysis)
+#   would correctly report zero — but Scorecard uses osv-scanner.
+# - **Removing the beam-pipeline example** would close the docker/docker
+#   transitive but loses the example.
+# - **Replace directives** in beam-pipeline's go.mod stubbing
+#   docker/docker would break the build (Beam's Prism runner uses the
+#   real APIs).
+#
+# We accept the 0/10 Scorecard score on Vulnerabilities and rely on
+# the runtime test suites (pip-audit on the main package; osv-scanner
+# with this config locally; Dependabot for upstream patches) for the
+# actual security signal. Run ``osv-scanner scan source --config
+# osv-scanner.toml -r .`` for the real-world view.
 
 # ---------------------------------------------------------------------------
 # Unpatched docker/docker GHSAs (transitive of testcontainers-go).

--- a/tests/e2e/go_client/go.mod
+++ b/tests/e2e/go_client/go.mod
@@ -1,6 +1,8 @@
 module github.com/jjviscomi/bqemulator/tests/e2e/go_client
 
-go 1.24.0
+go 1.25
+
+toolchain go1.25.10
 
 require (
 	cloud.google.com/go v0.112.2

--- a/tests/e2e/go_client/go.sum
+++ b/tests/e2e/go_client/go.sum
@@ -186,6 +186,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=
 golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
+gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
 google.golang.org/api v0.177.0 h1:8a0p/BbPa65GlqGWtUKxot4p0TV8OGOfyTjtmkXNXmk=
 google.golang.org/api v0.177.0/go.mod h1:srbhue4MLjkjbkux5p3dw/ocYOSZTaIEvf7bCOnFQDw=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
## Summary

- **Bump `tests/e2e/go_client/go.mod`** from `go 1.24.0` → `go 1.25` / `toolchain go1.25.10`. This was missed in [PR #67](https://github.com/jjviscomi/bqemulator/pull/67) which only bumped `docs/examples/go/{beam-pipeline,dataflow-local}`. Closes ~21 Go-stdlib advisories that OSV-scanner attributes to the `go 1.24.0` directive.
- **Document the OpenSSF Scorecard caveat in `osv-scanner.toml`**: Scorecard's `Vulnerabilities` check imports `osv-scanner` as a library without honouring this file's `IgnoredVulns`, and additionally flags historical `v0.0.0-YYYYMMDD/go.mod` entries in `go.sum` that Go's MVS retains for build reproducibility but never actually loads at build time.

## Investigation findings

Local Scorecard run finds **26 vulnerabilities** even after PR #67/#68's bumps. Breakdown:

| Source | Count | Status |
|---|---|---|
| `tests/e2e/go_client` (Go 1.24 stdlib) | ~21 | **Fixed by this PR** |
| `docs/examples/go/beam-pipeline` → docker/docker via Beam's Prism runner | 5 | Unfixable — no upstream patch; Scorecard ignores `osv-scanner.toml` |

Running `osv-scanner scan source --config osv-scanner.toml -r .` locally reports **0 vulnerabilities**. The discrepancy is entirely Scorecard tooling behaviour.

## Test plan

- [x] `osv-scanner scan source --lockfile tests/e2e/go_client/go.mod` → 0 vulnerabilities
- [x] `go build ./...` in `tests/e2e/go_client/` clean
- [ ] CI: full gate chain runs on push

## Out of scope

- Removing the `docker/docker` transitive dep — would require removing the `beam-pipeline` example or replacing Beam's Prism runner. Considered and deferred.
- Switching Scorecard to `govulncheck` — that's an upstream Scorecard change, not within our control.

## Score impact

Expected Scorecard `Vulnerabilities` on next weekly scan: **0/10 → 0/10** (no change — Scorecard's check is binary, and the 5 unfixable docker/docker entries keep it at 0). Absolute vulnerability count: **26 → 5**. The improvement is in the absolute risk surface, not the score number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed notes clarifying OpenSSF Scorecard caveats, historical Go module/version scoring issues, mitigation paths, and recommendation to run osv-scanner directly for authoritative results.

* **Chores**
  * Updated test environment Go toolchain to 1.25 (toolchain go1.25.10).
  * Link-check workflow now runs on every pull request (removed path-based filtering).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->