### PR TITLE
fix(ci): pin Go 1.25 in E2E + examples workflows to match go.mod

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -143,7 +143,11 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: "1.22"
+          # Match the go.mod toolchain (go 1.25 / toolchain go1.25.10).
+          # setup-go v6 defaults GOTOOLCHAIN=local, so the installed Go
+          # must already satisfy the go.mod requirement — a stale 1.22
+          # pin no longer auto-downloads the newer toolchain.
+          go-version: "1.25"
           cache: true
           cache-dependency-path: tests/e2e/go_client/go.mod
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -210,7 +210,7 @@ jobs:
         with: { name: bqemu-image, path: /tmp }
       - run: docker load -i /tmp/bqemu.tar
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
-        with: { go-version: "1.22" }
+        with: { go-version: "1.25" }
       - name: make test
         env:
           BQEMU_IMAGE: ${{ needs.build-image.outputs.image }}
@@ -227,7 +227,7 @@ jobs:
         with: { name: bqemu-image, path: /tmp }
       - run: docker load -i /tmp/bqemu.tar
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
-        with: { go-version: "1.22" }
+        with: { go-version: "1.25" }
       - name: make test
         env:
           BQEMU_IMAGE: ${{ needs.build-image.outputs.image }}


### PR DESCRIPTION
## Summary

The Go workflows pin `go-version: "1.22"` (e2e.yml ×1, examples.yml ×2) while the go.mod files require **go 1.25 / toolchain go1.25.10** (since the #67/#72 toolchain bump). This only worked because `actions/setup-go` **v5** silently auto-downloaded the newer toolchain. `setup-go` **v6** defaults `GOTOOLCHAIN=local`, which surfaces the latent drift:

```
go: go.mod requires go >= 1.25 (running go 1.22.12; GOTOOLCHAIN=local)
```

Pin all three `setup-go` steps to `go-version: "1.25"` to match go.mod. Correct under both v5 (current main) and v6.

## Why this is its own PR

The drift lives on **main**, not in the Dependabot bump — the setup-go v6 PR (#80) merely exposes it. Fixing it here lands the correctness fix independently and unblocks #80 (it rebases onto this and passes), and removes main's implicit reliance on setup-go auto-downloading the toolchain.

## Test plan

- [x] Both workflows are valid YAML; no `go-version: "1.22"` remains
- [ ] E2E — Go client, beam-pipeline, dataflow-local jobs green on this PR (go 1.25 + setup-go v5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.22 to 1.25 across CI/CD pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->