### PR TITLE
release: bump to v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ new release.
 See [`docs/architecture/contributing/documentation-style-guide.md`](docs/architecture/contributing/documentation-style-guide.md)
 for the full entry-form rules and worked examples.
 
+## [1.1.1] - 2026-05-27
+
+### Fixed
+
+- Persist and enforce `CREATE ROW ACCESS POLICY` DDL submitted via `jobs.query` / `jobs.insert`, including the `IF NOT EXISTS`, grantee-less (filter-only), and backtick-quoted forms that previously failed to register.
+- Register datasets and tables created through SQL DDL (`CREATE SCHEMA`, `CREATE TABLE`) in the catalog so `INFORMATION_SCHEMA`, `tables.list`, and row-access-policy target validation resolve them.
+
+### Security
+
+- Exclude `fastapi` 0.136.3 (MAL-2026-4750), a tampered release that injects an undocumented `fastar` dependency.
+
 ## [1.1.0] - 2026-05-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ DuckDB-backed, SQLGlot-powered, and tested against the real service. Point the o
 [![E2E](https://github.com/jjviscomi/bqemulator/actions/workflows/e2e.yml/badge.svg)](https://github.com/jjviscomi/bqemulator/actions/workflows/e2e.yml)
 [![Conformance](https://github.com/jjviscomi/bqemulator/actions/workflows/conformance.yml/badge.svg)](https://github.com/jjviscomi/bqemulator/actions/workflows/conformance.yml)
 [![Docs](https://github.com/jjviscomi/bqemulator/actions/workflows/docs.yml/badge.svg)](https://jjviscomi.github.io/bqemulator/)
-[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg?cacheSeconds=120&v=1.1.0)](https://pypi.org/project/bqemulator/)
-[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg?cacheSeconds=120&v=1.1.0)](https://pypi.org/project/bqemulator/)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jjviscomi/bqemulator/badge?v=1.1.0)](https://scorecard.dev/viewer/?uri=github.com/jjviscomi/bqemulator)
+[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg?cacheSeconds=120&v=1.1.1)](https://pypi.org/project/bqemulator/)
+[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg?cacheSeconds=120&v=1.1.1)](https://pypi.org/project/bqemulator/)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jjviscomi/bqemulator/badge?v=1.1.1)](https://scorecard.dev/viewer/?uri=github.com/jjviscomi/bqemulator)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
@@ -201,7 +201,7 @@ See the [`docker-compose/full-stack`](docs/examples/docker-compose/full-stack/) 
 
 ## What works today
 
-`bqemulator` is at **v1.1.0** — first minor on the production-stable
+`bqemulator` is at **v1.1.1** — first minor on the production-stable
 line. SemVer applies: breaking changes ship only in MAJOR,
 deprecations live ≥2 MINOR or 6 months. The [compatibility matrix](https://jjviscomi.github.io/bqemulator/latest/reference/compatibility-matrix/) is auto-generated from the conformance corpus on every CI run; the [conformance coverage matrix](https://jjviscomi.github.io/bqemulator/latest/reference/conformance-coverage-matrix/) breaks down support by surface item.
 
@@ -271,7 +271,7 @@ Every example under [`docs/examples/`](docs/examples/) is a complete, runnable p
 
 ## Project status
 
-`bqemulator` is at **v1.1.0** — first minor on the production-stable
+`bqemulator` is at **v1.1.1** — first minor on the production-stable
 line. SemVer applies: breaking changes ship only in MAJOR
 versions, preceded by ≥1 MINOR with deprecation warnings;
 deprecated APIs remain for ≥2 MINOR versions or 6 months.
@@ -286,8 +286,8 @@ Maturity signals:
 - ✅ Fuzz-tier (`Atheris`) harnesses on the SQL translator, dynamic-protobuf decoder, and Arrow bridge.
 - ✅ Differential-tier row-order perturbation of the entire conformance corpus passes.
 - ✅ Performance baselines committed for `darwin-arm64`, with regression gates (`pytest-benchmark` `--benchmark-compare-fail=median:10%`).
-- ✅ PyPI publish via Trusted Publishing (sigstore-attested wheels) — `pip install bqemulator==1.1.0` resolves from [PyPI](https://pypi.org/project/bqemulator/).
-- ✅ GHCR publish with keyless cosign signatures — `docker pull ghcr.io/jjviscomi/bqemulator:1.1.0` resolves and the image is cosign-verifiable.
+- ✅ PyPI publish via Trusted Publishing (sigstore-attested wheels) — `pip install bqemulator==1.1.1` resolves from [PyPI](https://pypi.org/project/bqemulator/).
+- ✅ GHCR publish with keyless cosign signatures — `docker pull ghcr.io/jjviscomi/bqemulator:1.1.1` resolves and the image is cosign-verifiable.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for the complete v1.0 inventory.
 

--- a/src/bqemulator/__init__.py
+++ b/src/bqemulator/__init__.py
@@ -15,4 +15,4 @@ __all__ = ["__version__"]
 
 # Single source of truth for the version; hatchling reads this via
 # `[tool.hatch.version] path = "src/bqemulator/__init__.py"`.
-__version__ = "1.1.0"
+__version__ = "1.1.1"


### PR DESCRIPTION
## Summary

Patch release **v1.1.0 → v1.1.1**. Ships the user-facing changes landed since the v1.1.0 tag:

- **Fixed** — `CREATE ROW ACCESS POLICY` via SQL DDL (`jobs.query` / `jobs.insert`) now persists + enforces, including `IF NOT EXISTS`, filter-only, and backtick-quoted forms (#83); SQL-created datasets/tables (`CREATE SCHEMA` / `CREATE TABLE`) are now catalog-visible to `INFORMATION_SCHEMA`, `tables.list`, and RAP validation.
- **Security** — exclude `fastapi` 0.136.3 (MAL-2026-4750 tampered release).

The CI/docs/test PRs merged this cycle (#76–82, #84) don't ship in the package, so they're not in the changelog.

## Release mechanics

- `src/bqemulator/__init__.py`: `__version__` 1.1.0 → 1.1.1 (via `bump_version.py`)
- `README.md`: version prose + `pip install` / `docker pull` commands + shields.io badge cache-bust (`v=1.1.1`)
- `CHANGELOG.md`: authored + date-stamped `[1.1.1] - 2026-05-27` (`changelog.py`)

After this PR is green and squash-merged, the `v1.1.1` tag is created on the merge commit and pushed, which fires `release.yml` (PyPI Trusted Publishing + sigstore attestation, GitHub Release) and `docker.yml` (GHCR multi-arch + cosign).

## Checklist

- [x] `bump_version.py --next patch` (validated strictly-greater)
- [x] `changelog.py 1.1.1 --check` well-formed + dated
- [x] `import bqemulator` → 1.1.1; ruff clean
- [ ] Full CI gate green on this PR
- [ ] Tag pushed → artefacts published + smoke-tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed persistence and enforcement of CREATE ROW ACCESS POLICY DDL, including various syntax forms and conditional variations.
  * Fixed automatic registration of datasets and tables created via SQL DDL statements in the catalog.

* **Security**
  * Excluded a compromised dependency version to prevent injection of unwanted packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->