### PR TITLE
docs(index): refresh Status callout to v1.1.1 + goccy reference

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ A local emulator for Google BigQuery. Run it on your laptop or in CI and
 point the official Google Cloud client libraries at it.
 
 !!! note "Status"
-    **v1.0.1** — production-stable. SemVer applies: breaking changes
+    **v1.1.1** — production-stable. SemVer applies: breaking changes
     ship only in MAJOR, preceded by ≥1 MINOR with deprecation
     warnings; deprecated APIs remain for ≥2 MINOR or 6 months. See
     the [compatibility matrix](reference/compatibility-matrix.md) for
@@ -16,7 +16,8 @@ point the official Google Cloud client libraries at it.
 BigQuery tests against real cloud are slow, expensive, and require
 network. Mocking the client library misses SQL-dialect mistakes. The
 existing [goccy/bigquery-emulator](https://github.com/goccy/bigquery-emulator)
-is Go + SQLite + ZetaSQL, slow to compile, and has significant SQL gaps.
+provided a lot of inspiration for this project and how we could approach
+the problem differently.
 
 bqemulator is:
 


### PR DESCRIPTION
## Summary

Two fixes to the docs landing page (`docs/index.md`):

1. **Stale Status callout** — it read `v1.0.1`, never bumped through the v1.1.0 *or* v1.1.1 releases (the release version-bump sweep covers `__init__.py` + README badges, not this callout). Now `v1.1.1`.
2. **Reframe the goccy reference** — "provided a lot of inspiration for this project and how we could approach the problem differently."

## Note on deploy

This corrects the **source** and, on merge, the `main`/`latest` mike-versioned docs (push-to-main deploy). The live **default is `stable` = the pinned `1.1.1`** docs, which were deployed from the immutable v1.1.1 tag — so that pinned version stays stale until it's refreshed. I'll follow up on refreshing `stable`/`1.1.1` separately (see PR discussion / my message).

## Follow-up suggestion (not in this PR)

Add the `docs/index.md` Status callout to the release-process.md manual version-bump sweep so it's not missed again.

## Test plan
- [x] `mkdocs build --strict` clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated version badge to v1.1.1
  * Revised comparison section with other tools to reflect a more balanced and constructive perspective

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->