### PR TITLE
fix(sql): emit un-padded year for FORMAT_DATE %Y on years < 1000

### DIFF
--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -139,7 +139,7 @@ surfaces).
 
 > **Auto-generated.** Edit fixtures under [`tests/conformance/`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance) or update the XFAIL registry in [`tests/conformance/divergences.py`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/divergences.py), then run `make compat-matrix` to regenerate this block. The CI gate (`--check`) refuses to merge a PR whose committed snapshot has drifted from the corpus.
 
-- **Corpus totals**: 1244 fixtures (1170 SQL + 48 HTTP + 26 gRPC); **1231 PASS / 13 XFAIL**
+- **Corpus totals**: 1244 fixtures (1170 SQL + 48 HTTP + 26 gRPC); **1232 PASS / 12 XFAIL**
 - **XFAIL contract**: every pin in `KNOWN_DIVERGENCES` references an ADR or `out-of-scope.md` section — invented divergences are forbidden (see [ADR 0023](https://github.com/jjviscomi/bqemulator/blob/main/docs/adr/0023-conformance-divergence-baseline.md)).
 
 ### Per-phase fixture coverage
@@ -155,16 +155,16 @@ Each row aggregates fixtures by corpus (SQL / HTTP / gRPC) and the on-disk phase
 | SQL | `routines_scripting` | 58 | 58 | 0 | ✅ |
 | SQL | `row_access` | 23 | 22 | 1 | ⚠ |
 | SQL | `specialized_types` | 150 | 143 | 7 | ⚠ |
-| SQL | `standard_functions` | 662 | 657 | 5 | ⚠ |
+| SQL | `standard_functions` | 662 | 658 | 4 | ⚠ |
 | SQL | `versioning` | 24 | 24 | 0 | ✅ |
 | HTTP | `jobs` | 48 | 48 | 0 | ✅ |
 | gRPC | `storage_read` | 16 | 16 | 0 | ✅ |
 | gRPC | `storage_write` | 10 | 10 | 0 | ✅ |
-| **Total** | | **1244** | **1231** | **13** | ⚠ |
+| **Total** | | **1244** | **1232** | **12** | ⚠ |
 
 ### XFAIL pin registry
 
-All 13 entries in [`tests/conformance/divergences.py`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/divergences.py) — each rationale references an ADR or [`out-of-scope.md`](https://github.com/jjviscomi/bqemulator/blob/main/docs/reference/out-of-scope.md) section so closure paths stay traceable.
+All 12 entries in [`tests/conformance/divergences.py`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/divergences.py) — each rationale references an ADR or [`out-of-scope.md`](https://github.com/jjviscomi/bqemulator/blob/main/docs/reference/out-of-scope.md) section so closure paths stay traceable.
 
 | Fixture id | Rationale (short) |
 |---|---|
@@ -179,7 +179,6 @@ All 13 entries in [`tests/conformance/divergences.py`](https://github.com/jjvisc
 | [`standard_functions/agg_hll_count_init_basic`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/agg_hll_count_init_basic) | HLL sketch BYTES format differs — see docs/reference/out-of-scope.md#hll-sketch-binary-format-hll_countinit-m… |
 | [`standard_functions/agg_hll_count_merge_partial_basic`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/agg_hll_count_merge_partial_basic) | HLL sketch BYTES format differs — see docs/reference/out-of-scope.md#hll-sketch-binary-format-hll_countinit-m… |
 | [`standard_functions/bound_bignumeric_max`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/bound_bignumeric_max) | BIGNUMERIC literal with 39 integer digits exceeds DuckDB's DECIMAL(38, 0) cap; literals with ≤ 38 integer dig… |
-| [`standard_functions/dt_format_date_min`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/dt_format_date_min) | FORMAT_DATE %Y year-padding differs from BigQuery for years < 1000: BQ emits '1-01-01' for DATE '0001-01-01',… |
 | [`standard_functions/tpcds_q47`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/tpcds_q47) | TPC-DS Q47-style multi-CTE pattern: a CTE that carries a window aggregate (AVG OVER PARTITION BY ... |
 
 <!-- END AUTO-GENERATED CONFORMANCE SNAPSHOT -->

--- a/docs/reference/gap-analysis.md
+++ b/docs/reference/gap-analysis.md
@@ -76,9 +76,6 @@ documented in [out-of-scope.md](out-of-scope.md), including:
   BigQuery gates the view on `bigquery.rowAccessPolicies.list`; the
   emulator does not enforce IAM. See
   [out-of-scope.md#iam-enforcement](out-of-scope.md#iam-enforcement).
-* **`FORMAT_DATE %Y` year-padding for years < 1000** — DuckDB's POSIX
-  `strftime` zero-pads `%Y` where BigQuery does not. See
-  [out-of-scope.md#format_date-y-year-padding-for-years-1000](out-of-scope.md#format_date-y-year-padding-for-years-1000).
 * **CTE self-join with window aggregate (TPC-DS Q47)** — a SQLGlot
   CTE-inlining shape DuckDB's binder rejects. See
   [out-of-scope.md#cte-self-join-with-window-aggregate-tpc-ds-q47](out-of-scope.md#cte-self-join-with-window-aggregate-tpc-ds-q47).

--- a/docs/reference/out-of-scope.md
+++ b/docs/reference/out-of-scope.md
@@ -477,45 +477,6 @@ standard pipeline. A full legacy-SQL parser remains out of scope.
 standard SQL (the canonical migration path BigQuery itself
 recommends) and submit it with `useLegacySql=false` (the default).
 
-### FORMAT_DATE `%Y` year-padding for years < 1000
-
-BigQuery's `FORMAT_DATE('%Y-%m-%d', DATE '0001-01-01')` returns
-``'1-01-01'`` — the ``%Y`` specifier does **not** zero-pad the
-year for values < 1000. DuckDB's ``STRFTIME(d, '%Y-%m-%d')``
-returns ``'0001-01-01'`` — it zero-pads ``%Y`` to four digits per
-POSIX ``strftime(3)``. The semantic difference only surfaces for
-dates between ``DATE '0001-01-01'`` and ``DATE '0999-12-31'``,
-which are vanishingly rare in real-world data: BigQuery itself
-caps DATE at ``DATE '0001-01-01'`` lower-bound but most
-real-world dates are post-1900.
-
-Closing this divergence cleanly requires either:
-
-1. A custom Python helper UDF (``bqemu_format_date``) that
-   implements BigQuery's exact ``strftime`` semantics for every
-   conversion specifier (``%Y`` without padding, ``%G`` with
-   ISO-week semantics, ``%U`` / ``%V`` / ``%W`` BigQuery-specific
-   week-number contracts, the locale-dependent ``%a`` / ``%A``
-   / ``%b`` / ``%B`` strings — currently all routed through
-   DuckDB's POSIX ``strftime``), wired through a new
-   ``FormatDateRule`` that intercepts every call. The maintenance
-   burden grows with every BigQuery format-specifier release.
-2. A narrow ``%Y``-specific pre-translator that rewrites
-   ``FORMAT_DATE('…%Y…', d)`` calls to a `REPLACE`-based emit
-   that strips leading zeros from the year. Brittle — the
-   year token can appear in arbitrary positions inside the
-   format string and the rewrite would have to track quoting.
-
-The conformance fixture
-[`standard_functions/dt_format_date_min`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/dt_format_date_min)
-is pinned XFAIL against this divergence so the surface is tracked
-without forcing an inline closure.
-
-*Workaround*: clients that need the un-padded year for pre-1000
-dates should format the year explicitly (e.g.
-``CAST(EXTRACT(YEAR FROM d) AS STRING)``) or use a SAFE_CAST to
-strip leading zeros from the rendered output.
-
 ### CTE self-join with window aggregate (TPC-DS Q47)
 
 TPC-DS Q47 uses a multi-CTE pattern where a CTE (`v1`) is

--- a/docs/reference/sql-function-mapping.md
+++ b/docs/reference/sql-function-mapping.md
@@ -50,7 +50,7 @@ table below maps each BigQuery view to its rewriter function.
 
 > **Auto-generated.** Edit translation rules under [`src/bqemulator/sql/rules/`](https://github.com/jjviscomi/bqemulator/blob/main/src/bqemulator/sql/rules/) or rewriters under [`src/bqemulator/sql/rewriter/`](https://github.com/jjviscomi/bqemulator/blob/main/src/bqemulator/sql/rewriter/), then run `make function-mapping` to regenerate this block. The CI gate (`--check`) refuses to merge a PR whose committed registry has drifted from the live source. Per-rule docstring summaries are extracted as the cell text — if a cell reads wrong, edit the rule's docstring.
 
-- **Registered rules**: 92 (13 rule modules)
+- **Registered rules**: 93 (13 rule modules)
 - **Rewriter functions**: 24 (24 rewriter modules; the INFORMATION_SCHEMA rewriter has its own hand-maintained per-view table below)
 
 ### Translation rules (post-transpile AST passes)
@@ -71,6 +71,7 @@ table below maps each BigQuery view to its rewriter function.
 | Date / time / timestamp | `EXTRACT(DATE FROM ts)` | `CAST(ts AS DATE)` | `EXTRACT_DATE_FROM_TS` |
 | Date / time / timestamp | `EXTRACT(DAYOFWEEK FROM x)` | `EXTRACT(DAYOFWEEK FROM x) + 1` | `EXTRACT_DAYOFWEEK` |
 | Date / time / timestamp | `EXTRACT(WEEK FROM x)` | Sunday-start week number | `EXTRACT_WEEK_SUNDAY_START` |
+| Date / time / timestamp | `FORMAT_DATE('…%Y…', d)` | unpadded-year rewrite (years < 1000) | `FORMAT_DATE_YEAR_PAD` |
 | Date / time / timestamp | `FORMAT(fmt, args…)` | `printf(fmt, args…)` | `FORMAT_PRINTF` |
 | Date / time / timestamp | `FORMAT_TIME(fmt, t)` | `STRFTIME(DATE '1970-01-01' + t, fmt)` | `FORMAT_TIME` |
 | Date / time / timestamp | `JSON_TYPE(x)` | `LOWER(JSON_TYPE(x))` | `JSON_TYPE_LOWER` |

--- a/src/bqemulator/sql/rules/datetime_semantics.py
+++ b/src/bqemulator/sql/rules/datetime_semantics.py
@@ -504,6 +504,148 @@ class FormatTimeRule(TranslationRule):
         )
 
 
+def _split_format_on_year(fmt: str) -> list[str]:
+    """Split a strftime format string on the ``%Y`` directive.
+
+    Returns the literal / non-``%Y`` runs between ``%Y`` occurrences: *N*
+    occurrences of ``%Y`` yield *N + 1* parts (any of which may be
+    empty). ``%%`` is a literal percent, so ``%%Y`` is a literal ``%``
+    followed by a literal ``Y`` and is **not** a split point. Every other
+    ``%`` directive (``%m``, ``%d``, …) is carried through verbatim as a
+    two-character token so DuckDB's ``STRFTIME`` still formats it.
+
+    Used by :class:`FormatDateYearPadRule` to splice an unpadded year
+    between the surrounding format runs.
+    """
+    parts: list[str] = []
+    run: list[str] = []
+    i = 0
+    n = len(fmt)
+    while i < n:
+        if fmt[i] == "%" and i + 1 < n:
+            nxt = fmt[i + 1]
+            if nxt == "Y":
+                parts.append("".join(run))
+                run = []
+                i += 2
+                continue
+            # ``%%`` (literal percent) or any other directive — keep the
+            # two-character token together so it reaches STRFTIME intact.
+            run.append(fmt[i : i + 2])
+            i += 2
+            continue
+        run.append(fmt[i])
+        i += 1
+    parts.append("".join(run))
+    return parts
+
+
+#: A format string with no real ``%Y`` split point tokenizes to a single
+#: part; a real ``%Y`` yields at least two. Below this the rule is a no-op
+#: (the ``"%Y"`` substring that triggered :meth:`applies_to` was an
+#: escaped ``%%Y``).
+_MIN_YEAR_SPLIT_PARTS = 2
+
+
+@register
+class FormatDateYearPadRule(TranslationRule):
+    """``FORMAT_DATE('…%Y…', d)`` → unpadded-year rewrite (years < 1000).
+
+    DuckDB's ``STRFTIME`` zero-pads ``%Y`` to four digits per POSIX
+    ``strftime(3)`` (``DATE '0001-01-01'`` → ``'0001-01-01'``).
+    BigQuery's ``FORMAT_DATE`` emits the minimum-width year
+    (``'1-01-01'``). The two agree for years ≥ 1000, so the divergence
+    only surfaces for years 1-999; DuckDB exposes no no-pad flag
+    (``%-Y`` errors).
+
+    Rather than reimplement every conversion specifier in Python, this
+    rule keeps DuckDB's ``STRFTIME`` as the engine for every specifier
+    *except* ``%Y`` and substitutes only the year with
+    ``CAST(EXTRACT(YEAR FROM d) AS VARCHAR)`` (no zero-pad), splicing the
+    surrounding format runs back with ``||``::
+
+        FORMAT_DATE('%Y-%m-%d', d)
+            → CAST(EXTRACT(YEAR FROM d) AS VARCHAR) || STRFTIME(d, '-%m-%d')
+
+    ``NULL`` propagates through ``||`` (a NULL date yields NULL), matching
+    BigQuery. The whole concatenation is wrapped in ``CAST(… AS VARCHAR)``
+    to pin the column to STRING: an all-NULL ``||`` chain would otherwise
+    surface as INTEGER on the wire — the same hazard
+    :class:`ConcatStringTypeRule` guards against, which cannot fire on
+    our freshly-emitted node (the rule walker snapshots the tree before
+    rewriting). Empty format runs are dropped — DuckDB's ``STRFTIME``
+    rejects an empty format string.
+
+    Scope is ``FORMAT_DATE`` only: SQLGlot wraps every FORMAT_DATE
+    argument in ``CAST(… AS DATE)`` (for literals, columns and function
+    results alike), which distinguishes the call from ``FORMAT_DATETIME``
+    / ``FORMAT_TIMESTAMP`` (``CAST(… AS TIMESTAMP)``). A zoned ``%Y`` on
+    FORMAT_TIMESTAMP is a separate concern and is not in the conformance
+    corpus.
+
+    Fires only when the format is a string literal containing ``%Y``; a
+    dynamic (non-literal) format is left on DuckDB's native path.
+    """
+
+    name = "FORMAT_DATE_YEAR_PAD"
+
+    def applies_to(self, node: exp.Expression) -> bool:
+        """Match ``STRFTIME(CAST(… AS DATE), '<string literal with %Y>')``."""
+        if not isinstance(node, exp.TimeToStr):
+            return False
+        fmt = node.args.get("format")
+        if not isinstance(fmt, exp.Literal) or not fmt.is_string:
+            return False
+        if "%Y" not in str(fmt.this):
+            return False
+        inner = node.this
+        if not isinstance(inner, exp.Cast):
+            return False
+        target = inner.to
+        return target is not None and target.is_type(exp.DataType.Type.DATE)
+
+    def rewrite(self, node: exp.Expression) -> exp.Expression:
+        """Emit ``(… STRFTIME(d, run) || CAST(EXTRACT(YEAR FROM d) AS VARCHAR) …)``."""
+        date_expr = node.this
+        fmt_node = node.args.get("format")
+        if date_expr is None or fmt_node is None:
+            return node
+        parts = _split_format_on_year(str(fmt_node.this))
+        if len(parts) < _MIN_YEAR_SPLIT_PARTS:
+            # No real ``%Y`` split point — the match was an escaped
+            # ``%%Y``. Leave DuckDB's native STRFTIME untouched.
+            return node
+        terms: list[exp.Expression] = []
+        for index, part in enumerate(parts):
+            if part:
+                terms.append(
+                    exp.Anonymous(
+                        this="STRFTIME",
+                        expressions=[date_expr.copy(), exp.Literal.string(part)],
+                    ),
+                )
+            if index < len(parts) - 1:
+                terms.append(
+                    exp.Cast(
+                        this=exp.Extract(
+                            this=exp.Var(this="YEAR"),
+                            expression=date_expr.copy(),
+                        ),
+                        to=exp.DataType.build("VARCHAR"),
+                    ),
+                )
+        if not terms:
+            return node
+        concat = terms[0]
+        for term in terms[1:]:
+            concat = exp.DPipe(this=concat, expression=term)
+        # Wrap in ``CAST(… AS VARCHAR)`` so the column type stays STRING
+        # even when every operand is NULL (an all-NULL ``||`` chain
+        # otherwise lands on INTEGER on the wire). ``CAST`` also supplies
+        # the grouping the surrounding expression needs.
+        return exp.Cast(this=concat, to=exp.DataType.build("VARCHAR"))
+
+
 @register
 class ParseDatetimeRule(TranslationRule):
     """``PARSE_DATETIME(fmt, value)`` → ``strptime(value, fmt)``.
@@ -776,6 +918,7 @@ __all__ = [
     "ExtractDateFromTimestampRule",
     "ExtractDayofweekRule",
     "ExtractWeekSundayStartRule",
+    "FormatDateYearPadRule",
     "FormatPrintfRule",
     "FormatTimeRule",
     "JsonTypeLowerRule",

--- a/tests/conformance/divergences.py
+++ b/tests/conformance/divergences.py
@@ -63,14 +63,6 @@ _BIGNUMERIC_CAP = (
     "fractional truncation (Path C of numeric_literals.py) — see "
     "docs/reference/out-of-scope.md#bignumeric-literals-with-39-integer-digits"
 )
-_FORMAT_DATE_YEAR_PAD = (
-    "FORMAT_DATE %Y year-padding differs from BigQuery for years < 1000: "
-    "BQ emits '1-01-01' for DATE '0001-01-01', DuckDB's STRFTIME emits "
-    "'0001-01-01' (POSIX strftime always pads %Y to 4 digits). Closure "
-    "needs a bqemu_format_date Python helper UDF or a narrow %Y "
-    "pre-translator — see "
-    "docs/reference/out-of-scope.md#format_date-y-year-padding-for-years-1000"
-)
 _CTE_SELF_JOIN_WINDOW_UNNEST = (
     "TPC-DS Q47-style multi-CTE pattern: a CTE that carries a window "
     "aggregate (AVG OVER PARTITION BY ... and RANK OVER ...) is self-"
@@ -113,8 +105,6 @@ KNOWN_DIVERGENCES: dict[str, str] = {
     "standard_functions/agg_hll_count_merge_partial_basic": _HLL_SKETCH_BINARY,
     # docs/reference/out-of-scope.md#bignumeric-literals-with-39-integer-digits
     "standard_functions/bound_bignumeric_max": _BIGNUMERIC_CAP,
-    # docs/reference/out-of-scope.md#format_date-y-year-padding-for-years-1000
-    "standard_functions/dt_format_date_min": _FORMAT_DATE_YEAR_PAD,
     # docs/reference/out-of-scope.md#cte-self-join-with-window-aggregate-tpc-ds-q47
     "standard_functions/tpcds_q47": _CTE_SELF_JOIN_WINDOW_UNNEST,
     # docs/reference/out-of-scope.md#iam-enforcement

--- a/tests/unit/sql/rules/test_datetime_semantics.py
+++ b/tests/unit/sql/rules/test_datetime_semantics.py
@@ -14,6 +14,7 @@ import duckdb
 import pytest
 
 from bqemulator.domain.result import Ok
+from bqemulator.sql.rules.datetime_semantics import _split_format_on_year
 from bqemulator.sql.translator import SQLTranslator
 
 pytestmark = pytest.mark.unit
@@ -345,3 +346,101 @@ class TestAtTimeZoneNumericOffset:
             "SELECT TIMESTAMP '2026-05-21 16:00:00+00' AT TIME ZONE '+00:00' AS local_ts",
         )
         assert row == (_dt.datetime(2026, 5, 21, 16, 0, 0),)  # noqa: DTZ001
+
+
+class TestSplitFormatOnYear:
+    """The ``%Y`` tokenizer behind :class:`FormatDateYearPadRule`.
+
+    ``%%`` is a literal percent, so ``%%Y`` must not be a split point;
+    every other ``%`` directive is carried through as a two-character
+    token. *N* real ``%Y`` occurrences yield *N + 1* parts.
+    """
+
+    @pytest.mark.parametrize(
+        ("fmt", "parts"),
+        [
+            ("", [""]),  # empty format
+            ("%m-%d", ["%m-%d"]),  # no %Y at all
+            ("%Y", ["", ""]),  # bare %Y
+            ("%Y-%m-%d", ["", "-%m-%d"]),  # leading %Y
+            ("yr%Y", ["yr", ""]),  # trailing %Y
+            ("a%Yb%Yc", ["a", "b", "c"]),  # multiple %Y
+            ("%%Y", ["%%Y"]),  # escaped %% + literal Y — not a split
+            ("%%Y-%Y", ["%%Y-", ""]),  # escaped then real %Y
+            ("%%%Y", ["%%", ""]),  # %% then real %Y
+            ("%H:%M %Y", ["%H:%M ", ""]),  # other directives carried through
+        ],
+    )
+    def test_split(self, fmt: str, parts: list[str]) -> None:
+        assert _split_format_on_year(fmt) == parts
+
+
+class TestFormatDateYearPad:
+    """``FORMAT_DATE('…%Y…', d)`` emits the un-padded year for years < 1000.
+
+    DuckDB's ``STRFTIME`` zero-pads ``%Y`` to four digits; BigQuery emits
+    the minimum-width year. The rule substitutes only ``%Y`` and leaves
+    every other specifier on DuckDB's native ``STRFTIME`` path.
+    """
+
+    @pytest.mark.parametrize(
+        ("sql", "expected"),
+        [
+            # The closed divergence: year 1 → '1', not '0001'.
+            ("SELECT FORMAT_DATE('%Y-%m-%d', DATE '0001-01-01') AS s", "1-01-01"),
+            ("SELECT FORMAT_DATE('%Y-%m-%d', DATE '0085-03-07') AS s", "85-03-07"),
+            ("SELECT FORMAT_DATE('%Y-%m-%d', DATE '0999-12-31') AS s", "999-12-31"),
+            ("SELECT FORMAT_DATE('%Y', DATE '0007-02-03') AS s", "7"),
+            # %Y in trailing / middle positions.
+            ("SELECT FORMAT_DATE('year %Y', DATE '0042-01-01') AS s", "year 42"),
+            ("SELECT FORMAT_DATE('a%Yb', DATE '0003-01-01') AS s", "a3b"),
+            # Years >= 1000 are byte-identical (no regression).
+            ("SELECT FORMAT_DATE('%Y/%m/%d', DATE '2024-01-15') AS s", "2024/01/15"),
+        ],
+    )
+    def test_unpadded_year(
+        self,
+        t: SQLTranslator,
+        con: duckdb.DuckDBPyConnection,
+        sql: str,
+        expected: str,
+    ) -> None:
+        assert _execute(t, con, sql) == (expected,)
+
+    def test_null_date_propagates(self, t: SQLTranslator, con: duckdb.DuckDBPyConnection) -> None:
+        # A NULL date yields NULL through ``||``, matching BigQuery.
+        row = _execute(t, con, "SELECT FORMAT_DATE('%Y-%m-%d', CAST(NULL AS DATE)) AS s")
+        assert row == (None,)
+
+    def test_non_year_format_untouched(
+        self, t: SQLTranslator, con: duckdb.DuckDBPyConnection
+    ) -> None:
+        # No %Y → the rule doesn't fire; %B still renders via STRFTIME.
+        row = _execute(t, con, "SELECT FORMAT_DATE('%B', DATE '2024-01-15') AS s")
+        assert row == ("January",)
+
+    def test_column_operand(self, t: SQLTranslator, con: duckdb.DuckDBPyConnection) -> None:
+        # SQLGlot wraps a column operand in CAST(... AS DATE) too, so the
+        # rule fires on non-literal dates as well — not just literals.
+        row = _execute(
+            t,
+            con,
+            "SELECT FORMAT_DATE('%Y-%m-%d', d) AS s FROM (SELECT DATE '0005-06-07' AS d)",
+        )
+        assert row == ("5-06-07",)
+
+    def test_escaped_percent_y_not_substituted(self, t: SQLTranslator) -> None:
+        # ``%%Y`` is a literal percent + 'Y' — the year must NOT be spliced.
+        result = t.translate("SELECT FORMAT_DATE('%%Y', DATE '0001-01-01') AS s")
+        assert isinstance(result, Ok)
+        assert "EXTRACT(YEAR" not in result.value.upper()
+        assert "STRFTIME" in result.value.upper()
+
+    def test_format_datetime_scope_excluded(self, t: SQLTranslator) -> None:
+        # FORMAT_DATETIME's operand is CAST(... AS TIMESTAMP); the rule is
+        # scoped to DATE operands and must leave this on the native path.
+        result = t.translate(
+            "SELECT FORMAT_DATETIME('%Y-%m-%d %H:%M:%S', DATETIME '2024-01-15 12:30:45') AS s",
+        )
+        assert isinstance(result, Ok)
+        assert "EXTRACT(YEAR" not in result.value.upper()


### PR DESCRIPTION
## Summary

Closes the `standard_functions/dt_format_date_min` conformance XFAIL — the most tractable of the 13 active divergences.

BigQuery's `FORMAT_DATE('%Y-%m-%d', DATE '0001-01-01')` returns `'1-01-01'`; DuckDB's `STRFTIME` zero-pads `%Y` to four digits (`'0001-01-01'`) and has no no-pad flag (`%-Y` errors), so `FORMAT_DATE` diverged for years 1–999.

- **New `FormatDateYearPadRule`** (`src/bqemulator/sql/rules/datetime_semantics.py`): keeps DuckDB `STRFTIME` as the engine for every specifier **except** `%Y`, substituting the year with `CAST(EXTRACT(YEAR FROM d) AS VARCHAR)` and splicing the surrounding format runs back with `||`. No per-row Python and no reimplementation of other specifiers → zero regression risk for `%m`/`%d`/`%A`/…
- **Type-pinned**: the concatenation is wrapped in `CAST(… AS VARCHAR)` so an all-NULL date still surfaces as STRING (not INTEGER) on the wire (`ConcatStringTypeRule` cannot fire on the freshly-emitted node, since the rule walker snapshots the tree before rewriting).
- **Scoped to FORMAT_DATE only**: SQLGlot wraps the operand in `CAST(… AS DATE)` for literals, columns *and* function results, which distinguishes it from `FORMAT_DATETIME`/`FORMAT_TIMESTAMP` (`CAST(… AS TIMESTAMP)`). `%%Y` escapes are honored (not treated as a year directive).
- **Ledger**: removed the `dt_format_date_min` entry + `_FORMAT_DATE_YEAR_PAD` constant from `divergences.py` (13 → **12** divergences); regenerated the compatibility + sql-function-mapping matrices; removed the now-stale `out-of-scope.md` section and `gap-analysis.md` bullet.

No CHANGELOG entry (authored at release time). This is not a release.

## Test plan

- [x] 22 new unit tests — tokenizer (`%%Y` escape, leading/trailing/multiple `%Y`) + rule (years 1/85/999, no-regression ≥1000, NULL, column operand, scope exclusion) in `tests/unit/sql/rules/test_datetime_semantics.py`
- [x] Full unit suite: **2938 passed**
- [x] Conformance corpus: **1158 passed, 12 xfailed** (was 13), 0 unexpected pass/fail
- [x] HTTP corpus (48) + gRPC corpus (26) green
- [x] All four matrix `--check` gates clean (compat / coverage / function-mapping / api-coverage)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mkdocs build --strict` clean
- [ ] CI: docker-build + e2e (Python / Node / Go / Java)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced DATE formatting compatibility to align with BigQuery behavior for dates with years before 1000.

* **Documentation**
  * Updated compatibility matrix showing improved test results: 1232 PASS / 12 XFAIL (previously 1231 PASS / 13 XFAIL).
  * Removed documentation for previously tracked formatting divergences now addressed.

* **Tests**
  * Added comprehensive test coverage for DATE formatting transformations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->