### PR TITLE
refactor(complexity): drop REST DTO mappers below rank C

### DIFF
--- a/src/bqemulator/api/routes/_rest_helpers.py
+++ b/src/bqemulator/api/routes/_rest_helpers.py
@@ -14,7 +14,20 @@ from typing import Any
 
 
 def existing_attr_or(existing: Any, attr: str, default: Any) -> Any:
-    """Return ``existing.attr`` when *existing* is set, else *default*."""
+    """Resolve an attribute from an existing catalog object, with a fallback.
+
+    Args:
+        existing: The catalog-meta object the upsert handler is updating
+            (e.g. :class:`bqemulator.catalog.models.DatasetMeta` or
+            :class:`bqemulator.catalog.models.RoutineMeta`), or ``None`` on
+            a fresh insert.
+        attr: Attribute name to read from ``existing``.
+        default: Value returned when ``existing`` is ``None``.
+
+    Returns:
+        ``getattr(existing, attr)`` when ``existing`` is not ``None``,
+        otherwise ``default``. The function is side-effect-free.
+    """
     return getattr(existing, attr) if existing is not None else default
 
 
@@ -25,11 +38,28 @@ def body_or_existing(
     attr: str,
     default: Any,
 ) -> Any:
-    """Three-way field resolve: request *body*, then *existing*, then *default*.
+    """Resolve a REST field with request-body precedence (three-way coalesce).
 
     Mirrors ``body.get(key, existing.attr if existing else default)`` while
     keeping the ``key in body`` semantics exact — a body value of ``None``
     wins over the existing / default fallback, just as ``dict.get`` does.
+
+    Args:
+        body: The decoded REST request payload.
+        key: REST field name to look up in ``body``.
+        existing: The catalog-meta object the upsert handler is updating
+            (e.g. :class:`bqemulator.catalog.models.DatasetMeta` or
+            :class:`bqemulator.catalog.models.RoutineMeta`), or ``None`` on
+            a fresh insert.
+        attr: Attribute name on ``existing`` to read when ``key`` is absent
+            from ``body``.
+        default: Value returned when ``key`` is absent and ``existing`` is
+            ``None``.
+
+    Returns:
+        ``body[key]`` when ``key in body`` (even if the value is ``None``);
+        otherwise :func:`existing_attr_or` applied to ``existing``, ``attr``,
+        and ``default``. The function is side-effect-free.
     """
     if key in body:
         return body[key]

--- a/src/bqemulator/api/routes/_rest_helpers.py
+++ b/src/bqemulator/api/routes/_rest_helpers.py
@@ -1,0 +1,36 @@
+"""Shared helpers for REST request-body ↔ catalog-meta mapping.
+
+The dataset / routine upsert handlers resolve each field from three
+sources, in priority order: the request body, the existing resource
+(for PATCH / idempotent PUT), then a static default. Centralising that
+three-way coalesce keeps the per-field branching out of the mapper
+functions — both for readability and to hold them under the
+cyclomatic-complexity ceiling.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def existing_attr_or(existing: Any, attr: str, default: Any) -> Any:
+    """Return ``existing.attr`` when *existing* is set, else *default*."""
+    return getattr(existing, attr) if existing is not None else default
+
+
+def body_or_existing(
+    body: dict[str, Any],
+    key: str,
+    existing: Any,
+    attr: str,
+    default: Any,
+) -> Any:
+    """Three-way field resolve: request *body*, then *existing*, then *default*.
+
+    Mirrors ``body.get(key, existing.attr if existing else default)`` while
+    keeping the ``key in body`` semantics exact — a body value of ``None``
+    wins over the existing / default fallback, just as ``dict.get`` does.
+    """
+    if key in body:
+        return body[key]
+    return existing_attr_or(existing, attr, default)

--- a/src/bqemulator/api/routes/datasets.py
+++ b/src/bqemulator/api/routes/datasets.py
@@ -22,6 +22,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, Query, Request, Response, status
 
 from bqemulator.api.dependencies import AppContext, get_context
+from bqemulator.api.routes._rest_helpers import body_or_existing, existing_attr_or
 from bqemulator.catalog.etag import generate_etag
 from bqemulator.catalog.models import AccessEntry, DatasetMeta
 from bqemulator.domain.errors import (
@@ -189,20 +190,18 @@ def _rest_to_dataset_meta(
     return DatasetMeta(
         project_id=project_id,
         dataset_id=dataset_id,
-        friendly_name=body.get("friendlyName", existing.friendly_name if existing else None),
-        description=body.get("description", existing.description if existing else None),
-        labels=body.get("labels", existing.labels if existing else {}),
-        location=body.get("location", existing.location if existing else "US"),
-        default_table_expiration_ms=body.get(
-            "defaultTableExpirationMs",
-            existing.default_table_expiration_ms if existing else None,
+        friendly_name=body_or_existing(body, "friendlyName", existing, "friendly_name", None),
+        description=body_or_existing(body, "description", existing, "description", None),
+        labels=body_or_existing(body, "labels", existing, "labels", {}),
+        location=body_or_existing(body, "location", existing, "location", "US"),
+        default_table_expiration_ms=body_or_existing(
+            body, "defaultTableExpirationMs", existing, "default_table_expiration_ms", None
         ),
-        default_partition_expiration_ms=body.get(
-            "defaultPartitionExpirationMs",
-            existing.default_partition_expiration_ms if existing else None,
+        default_partition_expiration_ms=body_or_existing(
+            body, "defaultPartitionExpirationMs", existing, "default_partition_expiration_ms", None
         ),
         access_entries=access_entries,
-        creation_time=existing.creation_time if existing else now,
+        creation_time=existing_attr_or(existing, "creation_time", now),
         last_modified_time=now,
         etag=generate_etag(project_id, dataset_id, str(now)),
     )

--- a/src/bqemulator/api/routes/routines.py
+++ b/src/bqemulator/api/routes/routines.py
@@ -19,6 +19,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, Request, Response, status
 
 from bqemulator.api.dependencies import AppContext, get_context
+from bqemulator.api.routes._rest_helpers import body_or_existing, existing_attr_or
 from bqemulator.catalog.etag import generate_etag
 from bqemulator.catalog.models import RoutineArgument, RoutineMeta
 from bqemulator.domain.errors import (
@@ -114,27 +115,25 @@ def _rest_to_routine_meta(
     else:
         args = ()
 
-    return_type = body.get("returnType", existing.return_type if existing else None)
-    routine_type = body.get("routineType", existing.routine_type if existing else "SCALAR_FUNCTION")
-    language = body.get("language", existing.language if existing else "SQL")
-    definition = body.get("definitionBody", existing.definition_body if existing else "")
-    imported = body.get("importedLibraries", list(existing.imported_libraries) if existing else [])
-    description = body.get("description", existing.description if existing else None)
-    determinism = body.get("determinismLevel", existing.determinism_level if existing else None)
+    imported = body_or_existing(body, "importedLibraries", existing, "imported_libraries", [])
 
     return RoutineMeta(
         project_id=project_id,
         dataset_id=dataset_id,
         routine_id=routine_id,
-        routine_type=routine_type,
-        language=language,
-        definition_body=definition,
+        routine_type=body_or_existing(
+            body, "routineType", existing, "routine_type", "SCALAR_FUNCTION"
+        ),
+        language=body_or_existing(body, "language", existing, "language", "SQL"),
+        definition_body=body_or_existing(body, "definitionBody", existing, "definition_body", ""),
         arguments=args,
-        return_type=return_type,
+        return_type=body_or_existing(body, "returnType", existing, "return_type", None),
         imported_libraries=tuple(imported),
-        description=description,
-        determinism_level=determinism,
-        creation_time=existing.creation_time if existing else now,
+        description=body_or_existing(body, "description", existing, "description", None),
+        determinism_level=body_or_existing(
+            body, "determinismLevel", existing, "determinism_level", None
+        ),
+        creation_time=existing_attr_or(existing, "creation_time", now),
         last_modified_time=now,
         etag=generate_etag(project_id, dataset_id, routine_id, str(now)),
     )

--- a/src/bqemulator/api/routes/tables.py
+++ b/src/bqemulator/api/routes/tables.py
@@ -53,6 +53,18 @@ def _field_to_rest(field: TableFieldSchema) -> dict[str, Any]:
     return out
 
 
+def _time_partitioning_to_rest(tp: Any) -> dict[str, Any]:
+    """Serialize a time-partitioning spec to the BigQuery REST shape."""
+    part_body: dict[str, Any] = {"type": tp.type}
+    if tp.field:
+        part_body["field"] = tp.field
+    if tp.expiration_ms is not None:
+        part_body["expirationMs"] = str(tp.expiration_ms)
+    if tp.require_partition_filter:
+        part_body["requirePartitionFilter"] = True
+    return part_body
+
+
 def _table_to_rest(t: TableMeta) -> dict[str, Any]:
     """Serialize a ``TableMeta`` to the BigQuery REST shape."""
     ref = {
@@ -89,15 +101,7 @@ def _table_to_rest(t: TableMeta) -> dict[str, Any]:
     if t.labels:
         body["labels"] = t.labels
     if t.time_partitioning:
-        tp = t.time_partitioning
-        part_body: dict[str, Any] = {"type": tp.type}
-        if tp.field:
-            part_body["field"] = tp.field
-        if tp.expiration_ms is not None:
-            part_body["expirationMs"] = str(tp.expiration_ms)
-        if tp.require_partition_filter:
-            part_body["requirePartitionFilter"] = True
-        body["timePartitioning"] = part_body
+        body["timePartitioning"] = _time_partitioning_to_rest(t.time_partitioning)
     if t.clustering:
         body["clustering"] = {"fields": list(t.clustering.fields)}
     return body

--- a/src/bqemulator/api/routes/tables.py
+++ b/src/bqemulator/api/routes/tables.py
@@ -53,7 +53,7 @@ def _field_to_rest(field: TableFieldSchema) -> dict[str, Any]:
     return out
 
 
-def _time_partitioning_to_rest(tp: Any) -> dict[str, Any]:
+def _time_partitioning_to_rest(tp: TimePartitioning) -> dict[str, Any]:
     """Serialize a time-partitioning spec to the BigQuery REST shape."""
     part_body: dict[str, Any] = {"type": tp.type}
     if tp.field:


### PR DESCRIPTION
## Summary

**PR-2 of the cyclomatic-complexity C→B initiative** — REST request/response mappers.

Takes the three C-ranked DTO mappers in `api/routes` down to **rank B or better**, fully behavior-preserving:

| Block | Before | After | How |
|---|:--:|:--:|---|
| `routes/datasets._rest_to_dataset_meta` | C(11) | **A(4)** | shared `body_or_existing` coalesce collapses the repeated `body.get(key, existing.attr if existing else default)` ternaries |
| `routes/routines._rest_to_routine_meta` | C(14) | **B(6)** | same shared coalesce |
| `routes/tables._table_to_rest` | C(11) | **B(8)** | extract `_time_partitioning_to_rest` (the dense nested partitioning block) |

The two upsert mappers share the *exact* "body → existing → default" pattern, so the helpers live in a new `api/routes/_rest_helpers.py` (`body_or_existing` / `existing_attr_or`) — DRY, won't trip jscpd, and the helpers themselves are A(2) each.

**Repo-wide C-block count: 55 → 52.** Gate stays at `--max-absolute C`; the C→B flip lands only after every group is cleared.

## Test plan

- [x] `radon cc --min C` empty on all 4 files
- [x] `xenon --max-absolute B` passes on all 4 files
- [x] `make quality-complexity` (real repo gate) passes
- [x] **265 tests** pass — 215 api-unit + 50 route-unit/CRUD-integration (including the create-then-update PATCH path that exercises the coalesce end-to-end)
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI: docker-build + e2e

No CHANGELOG (release-time authoring). Not a release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized REST request field handling for datasets and routines, ensuring explicit request values (including null) consistently take precedence over existing or default values.
  * Simplified time-partitioning serialization in table responses for clearer and more consistent output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->