### PR TITLE
refactor(complexity): drop misc leaf blocks below rank C

### DIFF
--- a/src/bqemulator/cli.py
+++ b/src/bqemulator/cli.py
@@ -121,36 +121,34 @@ def start(
     admin_enabled: bool | None,
 ) -> None:
     """Start the emulator (REST + gRPC)."""
-    # This command is inherently complex because it is a transparent
-    # pass-through from CLI flags to the ``Settings`` constructor. Every
-    # ``if flag is not None`` branch is required to preserve env-var /
-    # ``.bqemu.toml`` precedence (CLI > env > file > defaults). Extracting
-    # to a loop would not meaningfully reduce the branch count.
-    overrides: dict[str, object] = {}
-    if rest_host is not None:
-        overrides["rest_host"] = rest_host
-    if rest_port is not None:
-        overrides["rest_port"] = rest_port
-    if grpc_host is not None:
-        overrides["grpc_host"] = grpc_host
-    if grpc_port is not None:
-        overrides["grpc_port"] = grpc_port
+    # CLI flags pass through to the ``Settings`` constructor. The
+    # ``is not None`` guards preserve env-var / ``.bqemu.toml``
+    # precedence (CLI > env > file > defaults). Simple value→key
+    # passthroughs iterate once below; flags that carry a transform or
+    # side-effect (``ephemeral`` tri-state, ``data_dir`` implying
+    # persistent mode, the ``log_level`` / ``log_format`` enum casts)
+    # stay inline.
+    passthroughs = (
+        (rest_host, "rest_host"),
+        (rest_port, "rest_port"),
+        (grpc_host, "grpc_host"),
+        (grpc_port, "grpc_port"),
+        (default_project_id, "default_project_id"),
+        (admin_enabled, "admin_enabled"),
+    )
+    overrides: dict[str, object] = {key: value for value, key in passthroughs if value is not None}
     if ephemeral is True:
         overrides["persistence_mode"] = PersistenceMode.EPHEMERAL
     elif ephemeral is False:
         overrides["persistence_mode"] = PersistenceMode.PERSISTENT
     if data_dir is not None:
         overrides["data_dir"] = data_dir
-        # If a data_dir was given without explicit --persistent, infer persistent.
+        # ``--data-dir`` without explicit ``--persistent`` infers persistent.
         overrides.setdefault("persistence_mode", PersistenceMode.PERSISTENT)
-    if default_project_id is not None:
-        overrides["default_project_id"] = default_project_id
     if log_level is not None:
         overrides["log_level"] = LogLevel(log_level.lower())
     if log_format is not None:
         overrides["log_format"] = LogFormat(log_format.lower())
-    if admin_enabled is not None:
-        overrides["admin_enabled"] = admin_enabled
 
     # Env-var + .bqemu.toml resolution still happens; the overrides here
     # take highest priority (CLI flags). mypy cannot resolve **kwargs

--- a/src/bqemulator/row_access/matcher.py
+++ b/src/bqemulator/row_access/matcher.py
@@ -36,37 +36,18 @@ def grantee_matches(grantee: str, caller: CallerIdentity) -> bool:
     g = grantee.strip()
     if not g:
         return False
-
     if g == "allUsers":
         return True
-
     if g == "allAuthenticatedUsers":
         return caller.is_authenticated
-
     if ":" not in g:
         return False
-
     kind, value = g.split(":", 1)
     value = value.strip()
     if not value:
         return False
-
-    if kind in ("user", "serviceAccount"):
-        return _email_matches(value, caller, kind)
-
-    if kind == "domain":
-        host = value.lower()
-        caller_domain = caller.domain
-        return caller_domain is not None and caller_domain == host
-
-    if kind == "group":
-        # caller.groups is treated case-sensitively on the local part
-        # to match the user/serviceAccount rule. The host is normalised
-        # to lower-case in the matcher.
-        norm_value = _normalise_email(value)
-        return any(_normalise_email(g) == norm_value for g in caller.groups)
-
-    return False
+    matcher = _KIND_MATCHERS.get(kind)
+    return matcher(value, caller) if matcher is not None else False
 
 
 def _email_matches(email: str, caller: CallerIdentity, expect_kind: str) -> bool:
@@ -85,6 +66,35 @@ def _normalise_email(email: str) -> str:
         return email
     local, host = email.split("@", 1)
     return f"{local}@{host.lower()}"
+
+
+def _domain_matches(host: str, caller: CallerIdentity) -> bool:
+    """Match a ``domain:<host>`` grantee against the caller's email host."""
+    caller_domain = caller.domain
+    return caller_domain is not None and caller_domain == host.lower()
+
+
+def _group_matches(value: str, caller: CallerIdentity) -> bool:
+    """Match a ``group:<email>`` grantee against the caller's ``groups`` list.
+
+    Local part is compared case-sensitively (to match the user /
+    serviceAccount rule); the host is normalised to lower-case via
+    :func:`_normalise_email`.
+    """
+    norm_value = _normalise_email(value)
+    return any(_normalise_email(g) == norm_value for g in caller.groups)
+
+
+#: Kind prefix → matcher dispatch for :func:`grantee_matches`. Each
+#: matcher takes ``(value, caller)`` and returns whether the grantee
+#: applies. ``user`` / ``serviceAccount`` share :func:`_email_matches`
+#: with the kind name pinned.
+_KIND_MATCHERS = {
+    "user": lambda v, c: _email_matches(v, c, "user"),
+    "serviceAccount": lambda v, c: _email_matches(v, c, "serviceAccount"),
+    "domain": _domain_matches,
+    "group": _group_matches,
+}
 
 
 class GranteeMatcher:

--- a/src/bqemulator/udf/js_udf.py
+++ b/src/bqemulator/udf/js_udf.py
@@ -337,24 +337,34 @@ def _asyncio_loop_running() -> bool:
     return True
 
 
+def _coerce_datetime_for_json(value: datetime) -> str:
+    """Render a ``datetime`` as its ISO-8601 string, defaulting naive values to UTC."""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.isoformat()
+
+
+#: Type → coercer dispatch for :func:`_to_json_value`. Order matters where
+#: a more specific subclass precedes its parent — ``datetime`` is a
+#: ``date`` subclass, so it must be matched first to apply tz-aware
+#: handling before the bare ``(date, time)`` branch sees it.
+_JSON_COERCERS: tuple[tuple[Any, Any], ...] = (
+    (bytes, lambda v: base64.b64encode(v).decode("ascii")),
+    (Decimal, str),
+    (datetime, _coerce_datetime_for_json),
+    ((date, time), lambda v: v.isoformat()),
+    ((list, tuple), lambda v: [_to_json_value(x) for x in v]),
+    (dict, lambda v: {str(k): _to_json_value(x) for k, x in v.items()}),
+)
+
+
 def _to_json_value(value: Any) -> Any:
     """Coerce a DuckDB-side Python value for JSON → V8 transport."""
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
-    if isinstance(value, bytes):
-        return base64.b64encode(value).decode("ascii")
-    if isinstance(value, Decimal):
-        return str(value)
-    if isinstance(value, datetime):
-        if value.tzinfo is None:
-            value = value.replace(tzinfo=UTC)
-        return value.isoformat()
-    if isinstance(value, (date, time)):
-        return value.isoformat()
-    if isinstance(value, (list, tuple)):
-        return [_to_json_value(v) for v in value]
-    if isinstance(value, dict):
-        return {str(k): _to_json_value(v) for k, v in value.items()}
+    for types, coercer in _JSON_COERCERS:
+        if isinstance(value, types):
+            return coercer(value)
     # Fallback — orjson-style default: round-trip through JSON.
     return json.loads(json.dumps(value, default=str))
 


### PR DESCRIPTION
## Summary

**PR-3 of the cyclomatic-complexity C→B initiative** — three small leaf functions spread across the CLI, the row-access matcher, and the JS-UDF coercer.

| Block | Before | After | How |
|---|:--:|:--:|---|
| `cli.start` | C(12) | **B(8)** | collapse the six simple value→key passthroughs into a `(value, key)` tuple + a one-shot dict comprehension; keep the special-case transforms inline |
| `row_access.matcher.grantee_matches` | C(11) | **B(7)** | kind-prefix → matcher dispatch dict (`_KIND_MATCHERS`); extract `_domain_matches` / `_group_matches` helpers |
| `udf.js_udf._to_json_value` | C(12) | **A(5)** | `(type, coercer)` dispatch tuple; ordering pins `datetime` ahead of `(date, time)` (datetime is a date subclass) |

Extracted helpers are all A(2–5). Replaces a stale comment in `cli.start` that claimed loop extraction wouldn't reduce branch count — radon dropped 4 points.

**Repo-wide C-block count: 52 → 49.** Gate stays at `--max-absolute C`; the C→B flip lands only after every group is cleared.

## Test plan

- [x] `radon cc --min C` empty on all 3 files
- [x] `xenon --max-absolute B` passes on all 3 files
- [x] `make quality-complexity` (real repo gate) passes
- [x] **64 tests** pass — `test_cli.py` + `test_matcher.py` + `test_js_udf_audit.py`
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI: docker-build + e2e

No CHANGELOG (release-time authoring). Not a release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code maintainability by consolidating configuration handling, access control matching logic, and JSON value coercion processes through streamlined dispatch mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->