### PR TITLE
refactor(complexity): drop catalog + versioning blocks below rank C

### DIFF
--- a/src/bqemulator/catalog/ddl_sync.py
+++ b/src/bqemulator/catalog/ddl_sync.py
@@ -175,6 +175,27 @@ def sync_created_schema(bq_sql: str, project_id: str, ctx: AppContext) -> None:
     _ensure_dataset(p_id, d_id, ctx)
 
 
+def _unwrap_table_target(target: exp.Expression | None) -> exp.Table | None:
+    """Unwrap an ``exp.Schema`` shell and return the inner :class:`exp.Table`, or ``None``."""
+    if isinstance(target, exp.Schema):
+        target = target.this
+    return target if isinstance(target, exp.Table) else None
+
+
+def _split_table_ref_parts(target: exp.Table) -> list[str]:
+    """Return the non-empty ``(catalog, db, name)`` parts.
+
+    A whole-backticked dotted name (`` `proj.ds` ``) lands as a single
+    component and is split on the dot so the caller sees the same
+    parts shape as the per-component-backticked form.
+    """
+    parts = [p for p in (target.catalog, target.db, target.name) if p]
+    # Whole-backticked ``\`proj.ds\``` lands as one dotted name.
+    if len(parts) == 1 and "." in parts[0]:
+        return parts[0].split(".")
+    return parts
+
+
 def _detect_create_schema(bq_sql: str, default_project: str) -> tuple[str, str] | None:
     """Return ``(project_id, dataset_id)`` for a ``CREATE SCHEMA`` statement.
 
@@ -189,15 +210,10 @@ def _detect_create_schema(bq_sql: str, default_project: str) -> tuple[str, str] 
         return None
     if not isinstance(tree, exp.Create) or (tree.kind or "").upper() != "SCHEMA":
         return None
-    target = tree.this
-    if isinstance(target, exp.Schema):
-        target = target.this
-    if not isinstance(target, exp.Table):
+    target = _unwrap_table_target(tree.this)
+    if target is None:
         return None
-    parts = [p for p in (target.catalog, target.db, target.name) if p]
-    # Whole-backticked ``\`proj.ds\``` lands as one dotted name.
-    if len(parts) == 1 and "." in parts[0]:
-        parts = parts[0].split(".")
+    parts = _split_table_ref_parts(target)
     if len(parts) == _PARTS_DATASET_QUALIFIED:
         return parts[0], parts[1]
     if len(parts) == 1:
@@ -228,6 +244,14 @@ def _ensure_dataset(project_id: str, dataset_id: str, ctx: AppContext) -> None:
     )
 
 
+def _is_materialized_view(tree: exp.Create) -> bool:
+    """Return ``True`` when the parsed ``CREATE`` tree carries a ``MATERIALIZED`` property."""
+    properties = tree.args.get("properties")
+    if not isinstance(properties, exp.Properties):
+        return False
+    return any(isinstance(p, exp.MaterializedProperty) for p in properties.expressions)
+
+
 def _detect_plain_create_view(
     bq_sql: str,
 ) -> tuple[exp.Table | None, exp.Expression | None]:
@@ -246,17 +270,11 @@ def _detect_plain_create_view(
         return None, None
     if (tree.kind or "").upper() != "VIEW":
         return None, None
-    # ``materialized`` property → MATERIALIZED VIEW; route via the MV
-    # manager instead of syncing here.
-    properties = tree.args.get("properties")
-    if isinstance(properties, exp.Properties):
-        for prop in properties.expressions:
-            if isinstance(prop, exp.MaterializedProperty):
-                return None, None
-    target = tree.this
-    if isinstance(target, exp.Schema):
-        target = target.this
-    if not isinstance(target, exp.Table):
+    # MATERIALIZED VIEW → route via the MV manager instead of syncing here.
+    if _is_materialized_view(tree):
+        return None, None
+    target = _unwrap_table_target(tree.this)
+    if target is None:
         return None, None
     body = tree.expression
     if body is None:

--- a/src/bqemulator/versioning/ddl.py
+++ b/src/bqemulator/versioning/ddl.py
@@ -205,6 +205,17 @@ _PARTS_DATASET_QUALIFIED = 2
 _PARTS_BARE = 1
 
 
+def _assert_source_present(ddl: VersioningDDL) -> None:
+    """Assert that ``ddl`` carries a complete ``(project, dataset, table)`` source triple.
+
+    Snapshot / clone DDLs require the source to be set by the parser
+    before dispatch reaches this layer.
+    """
+    assert ddl.source_project is not None  # noqa: S101
+    assert ddl.source_dataset is not None  # noqa: S101
+    assert ddl.source_table is not None  # noqa: S101
+
+
 async def execute_versioning_ddl(
     ddl: VersioningDDL,
     ctx: AppContext,
@@ -219,9 +230,7 @@ async def execute_versioning_ddl(
     from bqemulator.versioning.snapshot_table import SnapshotTableManager
 
     if ddl.kind is VersioningDDLKind.CREATE_SNAPSHOT:
-        assert ddl.source_project is not None  # noqa: S101
-        assert ddl.source_dataset is not None  # noqa: S101
-        assert ddl.source_table is not None  # noqa: S101
+        _assert_source_present(ddl)
         await SnapshotTableManager(ctx).create(
             ddl.target_project,
             ddl.target_dataset,
@@ -237,9 +246,7 @@ async def execute_versioning_ddl(
             ddl.target_table,
         )
     elif ddl.kind is VersioningDDLKind.CREATE_CLONE:
-        assert ddl.source_project is not None  # noqa: S101
-        assert ddl.source_dataset is not None  # noqa: S101
-        assert ddl.source_table is not None  # noqa: S101
+        _assert_source_present(ddl)
         await CloneManager(ctx).create(
             ddl.target_project,
             ddl.target_dataset,

--- a/src/bqemulator/versioning/ddl.py
+++ b/src/bqemulator/versioning/ddl.py
@@ -217,11 +217,7 @@ def _unwrap_source(ddl: VersioningDDL) -> tuple[str, str, str]:
     survives ``python -O`` and so the failure mode is a normal client
     error rather than ``AssertionError``.
     """
-    if (
-        ddl.source_project is None
-        or ddl.source_dataset is None
-        or ddl.source_table is None
-    ):
+    if ddl.source_project is None or ddl.source_dataset is None or ddl.source_table is None:
         raise InvalidQueryError("Snapshot/clone DDL requires a source table reference")
     return ddl.source_project, ddl.source_dataset, ddl.source_table
 

--- a/src/bqemulator/versioning/ddl.py
+++ b/src/bqemulator/versioning/ddl.py
@@ -206,16 +206,23 @@ _PARTS_BARE = 1
 
 
 def _unwrap_source(ddl: VersioningDDL) -> tuple[str, str, str]:
-    """Return the ``(project, dataset, table)`` source triple, asserting presence.
+    """Return the ``(project, dataset, table)`` source triple.
 
     Snapshot / clone DDLs require the source to be set by the parser
     before dispatch reaches this layer; returning the narrowed triple
-    lets the caller pass it through to the manager without re-asserting
-    or casting at every argument position.
+    lets the caller pass it through to the manager without casting at
+    every argument position.
+
+    Uses an explicit raise rather than ``assert`` so the invariant
+    survives ``python -O`` and so the failure mode is a normal client
+    error rather than ``AssertionError``.
     """
-    assert ddl.source_project is not None  # noqa: S101
-    assert ddl.source_dataset is not None  # noqa: S101
-    assert ddl.source_table is not None  # noqa: S101
+    if (
+        ddl.source_project is None
+        or ddl.source_dataset is None
+        or ddl.source_table is None
+    ):
+        raise InvalidQueryError("Snapshot/clone DDL requires a source table reference")
     return ddl.source_project, ddl.source_dataset, ddl.source_table
 
 

--- a/src/bqemulator/versioning/ddl.py
+++ b/src/bqemulator/versioning/ddl.py
@@ -205,15 +205,18 @@ _PARTS_DATASET_QUALIFIED = 2
 _PARTS_BARE = 1
 
 
-def _assert_source_present(ddl: VersioningDDL) -> None:
-    """Assert that ``ddl`` carries a complete ``(project, dataset, table)`` source triple.
+def _unwrap_source(ddl: VersioningDDL) -> tuple[str, str, str]:
+    """Return the ``(project, dataset, table)`` source triple, asserting presence.
 
     Snapshot / clone DDLs require the source to be set by the parser
-    before dispatch reaches this layer.
+    before dispatch reaches this layer; returning the narrowed triple
+    lets the caller pass it through to the manager without re-asserting
+    or casting at every argument position.
     """
     assert ddl.source_project is not None  # noqa: S101
     assert ddl.source_dataset is not None  # noqa: S101
     assert ddl.source_table is not None  # noqa: S101
+    return ddl.source_project, ddl.source_dataset, ddl.source_table
 
 
 async def execute_versioning_ddl(
@@ -230,14 +233,14 @@ async def execute_versioning_ddl(
     from bqemulator.versioning.snapshot_table import SnapshotTableManager
 
     if ddl.kind is VersioningDDLKind.CREATE_SNAPSHOT:
-        _assert_source_present(ddl)
+        src_project, src_dataset, src_table = _unwrap_source(ddl)
         await SnapshotTableManager(ctx).create(
             ddl.target_project,
             ddl.target_dataset,
             ddl.target_table,
-            ddl.source_project,
-            ddl.source_dataset,
-            ddl.source_table,
+            src_project,
+            src_dataset,
+            src_table,
         )
     elif ddl.kind is VersioningDDLKind.DROP_SNAPSHOT:
         await SnapshotTableManager(ctx).drop(
@@ -246,14 +249,14 @@ async def execute_versioning_ddl(
             ddl.target_table,
         )
     elif ddl.kind is VersioningDDLKind.CREATE_CLONE:
-        _assert_source_present(ddl)
+        src_project, src_dataset, src_table = _unwrap_source(ddl)
         await CloneManager(ctx).create(
             ddl.target_project,
             ddl.target_dataset,
             ddl.target_table,
-            ddl.source_project,
-            ddl.source_dataset,
-            ddl.source_table,
+            src_project,
+            src_dataset,
+            src_table,
         )
     elif ddl.kind is VersioningDDLKind.CREATE_MATERIALIZED_VIEW:
         assert ddl.view_query is not None  # noqa: S101

--- a/src/bqemulator/versioning/time_travel.py
+++ b/src/bqemulator/versioning/time_travel.py
@@ -101,53 +101,33 @@ def rewrite_for_system_time(
     return bq_sql
 
 
-def _resolve_target_ts(
-    version: exp.Expression,
+def _parse_literal_iso_timestamp(literal_value: str) -> datetime:
+    """Parse an ISO-8601 ``AS OF`` literal, defaulting a naive value to UTC."""
+    try:
+        parsed = datetime.fromisoformat(literal_value)
+    except ValueError as exc:
+        raise InvalidQueryError(
+            f"FOR SYSTEM_TIME AS OF requires an ISO-8601 timestamp: {exc}",
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _eval_timestamp_via_duckdb(
+    expr_node: exp.Expression | str,
     engine: DuckDBEngine,
 ) -> datetime:
-    """Evaluate the ``AS OF <expr>`` expression to a Python datetime.
+    """Evaluate a non-literal ``AS OF`` expression via DuckDB; return a UTC datetime.
 
-    The expression may be a literal timestamp, a function call such as
-    ``TIMESTAMP '...'`` or ``TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL
-    1 HOUR)``, or any scalar expression that evaluates to a timestamp.
-
-    Evaluation strategy:
-
-    1. If the expression is a string literal in ISO-8601 form, parse it
-       directly with :func:`datetime.fromisoformat`. This is the
-       overwhelmingly common case and avoids spinning up DuckDB +
-       Python's ``pytz`` (which DuckDB requires only to handle
-       ``TIMESTAMP WITH TIME ZONE``).
-    2. Otherwise we fall back to DuckDB, but force the result type to
-       a *naïve* ``TIMESTAMP`` and attach UTC ourselves — so the
-       evaluation never crosses a ``TIMESTAMPTZ`` boundary that
-       requires ``pytz`` at the Python layer.
+    Forces a naïve ``TIMESTAMP`` cast so DuckDB does not reach for
+    Python's ``pytz`` (which is required only for ``TIMESTAMP WITH
+    TIME ZONE``); UTC is attached at the Python layer.
     """
-    expr_node = version.args.get("expression") or version.this
-    if expr_node is None:
-        raise InvalidQueryError("FOR SYSTEM_TIME AS OF requires an expression")
-
-    # Fast path: literal timestamps and date strings. We accept the
-    # ``Cast(Literal(...), TIMESTAMPTZ)`` shape SQLGlot emits for
-    # ``TIMESTAMP '...'`` plus a bare string literal.
-    literal_value = _extract_literal_timestamp(expr_node)
-    if literal_value is not None:
-        try:
-            parsed = datetime.fromisoformat(literal_value)
-        except ValueError as exc:
-            raise InvalidQueryError(
-                f"FOR SYSTEM_TIME AS OF requires an ISO-8601 timestamp: {exc}",
-            ) from exc
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=UTC)
-        return parsed
-
     if isinstance(expr_node, exp.Expression):
         expr_sql = expr_node.sql(dialect="bigquery")
     else:
         expr_sql = str(expr_node)
-
-    # Force a naïve TIMESTAMP so DuckDB doesn't reach for pytz.
     try:
         duckdb_expr_list = sqlglot.transpile(
             f"SELECT CAST(({expr_sql}) AS TIMESTAMP)",
@@ -161,25 +141,51 @@ def _resolve_target_ts(
     duckdb_expr = duckdb_expr_list[0] if duckdb_expr_list else ""
     if not duckdb_expr:
         raise InvalidQueryError("Empty FOR SYSTEM_TIME AS OF expression")
-
     try:
         result = engine.execute(duckdb_expr).fetchone()
     except Exception as exc:
         raise InvalidQueryError(
             f"Could not evaluate FOR SYSTEM_TIME AS OF expression: {exc}",
         ) from exc
-
     if result is None or result[0] is None:
         raise InvalidQueryError("FOR SYSTEM_TIME AS OF evaluated to NULL")
-
     value = result[0]
-    if isinstance(value, datetime):
-        if value.tzinfo is None:
-            value = value.replace(tzinfo=UTC)
-        return value
-    raise InvalidQueryError(
-        f"FOR SYSTEM_TIME AS OF must be a TIMESTAMP, got {type(value).__name__}",
-    )
+    if not isinstance(value, datetime):
+        raise InvalidQueryError(
+            f"FOR SYSTEM_TIME AS OF must be a TIMESTAMP, got {type(value).__name__}",
+        )
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value
+
+
+def _resolve_target_ts(
+    version: exp.Expression,
+    engine: DuckDBEngine,
+) -> datetime:
+    """Evaluate the ``AS OF <expr>`` expression to a Python datetime.
+
+    The expression may be a literal timestamp, a function call such as
+    ``TIMESTAMP '...'`` or ``TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL
+    1 HOUR)``, or any scalar expression that evaluates to a timestamp.
+
+    Evaluation strategy:
+
+    1. If the expression is a string literal in ISO-8601 form, parse it
+       directly via :func:`_parse_literal_iso_timestamp`. This is the
+       overwhelmingly common case and avoids spinning up DuckDB +
+       Python's ``pytz`` (required only for ``TIMESTAMP WITH TIME ZONE``).
+    2. Otherwise :func:`_eval_timestamp_via_duckdb` forces a naïve
+       ``TIMESTAMP`` and attaches UTC at the Python layer, so the
+       evaluation never crosses a ``TIMESTAMPTZ`` boundary.
+    """
+    expr_node = version.args.get("expression") or version.this
+    if expr_node is None:
+        raise InvalidQueryError("FOR SYSTEM_TIME AS OF requires an expression")
+    literal_value = _extract_literal_timestamp(expr_node)
+    if literal_value is not None:
+        return _parse_literal_iso_timestamp(literal_value)
+    return _eval_timestamp_via_duckdb(expr_node, engine)
 
 
 def _extract_literal_timestamp(node: exp.Expression | str) -> str | None:

--- a/src/bqemulator/versioning/time_travel.py
+++ b/src/bqemulator/versioning/time_travel.py
@@ -101,14 +101,19 @@ def rewrite_for_system_time(
     return bq_sql
 
 
-def _parse_literal_iso_timestamp(literal_value: str) -> datetime:
-    """Parse an ISO-8601 ``AS OF`` literal, defaulting a naive value to UTC."""
+def _parse_literal_iso_timestamp(literal_value: str) -> datetime | None:
+    """Parse an ISO-8601 ``AS OF`` literal; return ``None`` for non-ISO forms.
+
+    Returning ``None`` (rather than raising) lets the caller fall back
+    to the DuckDB evaluation path, which handles BigQuery-style
+    timestamp literals that ``datetime.fromisoformat`` rejects — most
+    importantly the named-timezone form ``'YYYY-MM-DD HH:MM:SS UTC'``.
+    A naive value (no tz info) is defaulted to UTC.
+    """
     try:
         parsed = datetime.fromisoformat(literal_value)
-    except ValueError as exc:
-        raise InvalidQueryError(
-            f"FOR SYSTEM_TIME AS OF requires an ISO-8601 timestamp: {exc}",
-        ) from exc
+    except ValueError:
+        return None
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
     return parsed
@@ -175,16 +180,21 @@ def _resolve_target_ts(
        directly via :func:`_parse_literal_iso_timestamp`. This is the
        overwhelmingly common case and avoids spinning up DuckDB +
        Python's ``pytz`` (required only for ``TIMESTAMP WITH TIME ZONE``).
-    2. Otherwise :func:`_eval_timestamp_via_duckdb` forces a naïve
-       ``TIMESTAMP`` and attaches UTC at the Python layer, so the
-       evaluation never crosses a ``TIMESTAMPTZ`` boundary.
+    2. If the literal is present but ``fromisoformat`` rejects it
+       (e.g. BigQuery's ``'YYYY-MM-DD HH:MM:SS UTC'`` form), fall
+       through to :func:`_eval_timestamp_via_duckdb`.
+    3. For non-literal expressions, :func:`_eval_timestamp_via_duckdb`
+       forces a naïve ``TIMESTAMP`` and attaches UTC at the Python
+       layer, so the evaluation never crosses a ``TIMESTAMPTZ`` boundary.
     """
     expr_node = version.args.get("expression") or version.this
     if expr_node is None:
         raise InvalidQueryError("FOR SYSTEM_TIME AS OF requires an expression")
     literal_value = _extract_literal_timestamp(expr_node)
     if literal_value is not None:
-        return _parse_literal_iso_timestamp(literal_value)
+        parsed = _parse_literal_iso_timestamp(literal_value)
+        if parsed is not None:
+            return parsed
     return _eval_timestamp_via_duckdb(expr_node, engine)
 
 

--- a/tests/unit/versioning/test_time_travel.py
+++ b/tests/unit/versioning/test_time_travel.py
@@ -82,10 +82,7 @@ async def test_bigquery_utc_suffix_literal_falls_back_to_duckdb(
     target = frozen_clock.now().replace(microsecond=0).isoformat(sep=" ")
     # Strip any tz info the isoformat already wrote, then append ``UTC``.
     target_no_tz = target.split("+", 1)[0]
-    sql = (
-        f"SELECT * FROM ds.t FOR SYSTEM_TIME AS OF "
-        f"TIMESTAMP '{target_no_tz} UTC'"
-    )
+    sql = f"SELECT * FROM ds.t FOR SYSTEM_TIME AS OF TIMESTAMP '{target_no_tz} UTC'"
     out = rewrite_for_system_time(sql, "p", full_ctx.snapshots, full_ctx.engine)
     assert snap.duckdb_table in out
     assert "_bqemulator_snapshots" in out

--- a/tests/unit/versioning/test_time_travel.py
+++ b/tests/unit/versioning/test_time_travel.py
@@ -58,6 +58,39 @@ async def test_redirects_to_snapshot_table_when_one_matches(
     assert "_bqemulator_snapshots" in out
 
 
+async def test_bigquery_utc_suffix_literal_falls_back_to_duckdb(
+    full_ctx: AppContext,
+    make_dataset,
+    make_table,
+    frozen_clock,
+) -> None:
+    """BigQuery-style ``'YYYY-MM-DD HH:MM:SS UTC'`` literals route through DuckDB.
+
+    ``datetime.fromisoformat`` rejects the trailing ``UTC`` zone name,
+    so the literal fast-path must return ``None`` and let the DuckDB
+    evaluator (which accepts the suffix) handle it. Regression test
+    for the latent bug surfaced when the resolver was split into
+    ``_parse_literal_iso_timestamp`` + ``_eval_timestamp_via_duckdb``.
+    """
+    make_dataset("p", "ds")
+    make_table("p", "ds", "t", rows=[(1, "a")])
+    snap = full_ctx.snapshots.capture("p", "ds", "t")
+    assert snap is not None
+
+    frozen_clock.advance(seconds=10)
+    # Format without microseconds so DuckDB cleanly accepts ``... UTC``.
+    target = frozen_clock.now().replace(microsecond=0).isoformat(sep=" ")
+    # Strip any tz info the isoformat already wrote, then append ``UTC``.
+    target_no_tz = target.split("+", 1)[0]
+    sql = (
+        f"SELECT * FROM ds.t FOR SYSTEM_TIME AS OF "
+        f"TIMESTAMP '{target_no_tz} UTC'"
+    )
+    out = rewrite_for_system_time(sql, "p", full_ctx.snapshots, full_ctx.engine)
+    assert snap.duckdb_table in out
+    assert "_bqemulator_snapshots" in out
+
+
 async def test_raises_out_of_range_when_target_in_future(
     full_ctx: AppContext,
     make_dataset,

--- a/tests/unit/versioning/test_time_travel.py
+++ b/tests/unit/versioning/test_time_travel.py
@@ -67,10 +67,8 @@ async def test_bigquery_utc_suffix_literal_falls_back_to_duckdb(
     """BigQuery-style ``'YYYY-MM-DD HH:MM:SS UTC'`` literals route through DuckDB.
 
     ``datetime.fromisoformat`` rejects the trailing ``UTC`` zone name,
-    so the literal fast-path must return ``None`` and let the DuckDB
-    evaluator (which accepts the suffix) handle it. Regression test
-    for the latent bug surfaced when the resolver was split into
-    ``_parse_literal_iso_timestamp`` + ``_eval_timestamp_via_duckdb``.
+    so the literal fast-path returns ``None`` and the DuckDB
+    evaluator — which accepts the suffix — handles the literal.
     """
     make_dataset("p", "ds")
     make_table("p", "ds", "t", rows=[(1, "a")])
@@ -78,11 +76,12 @@ async def test_bigquery_utc_suffix_literal_falls_back_to_duckdb(
     assert snap is not None
 
     frozen_clock.advance(seconds=10)
-    # Format without microseconds so DuckDB cleanly accepts ``... UTC``.
-    target = frozen_clock.now().replace(microsecond=0).isoformat(sep=" ")
-    # Strip any tz info the isoformat already wrote, then append ``UTC``.
-    target_no_tz = target.split("+", 1)[0]
-    sql = f"SELECT * FROM ds.t FOR SYSTEM_TIME AS OF TIMESTAMP '{target_no_tz} UTC'"
+    # Build the literal from a naive datetime so the result is offset-free
+    # regardless of which timezone the frozen clock yields, then append the
+    # explicit ``UTC`` zone name to exercise the BigQuery-style path.
+    naive_target = frozen_clock.now().replace(tzinfo=None, microsecond=0)
+    target_str = naive_target.isoformat(sep=" ")
+    sql = f"SELECT * FROM ds.t FOR SYSTEM_TIME AS OF TIMESTAMP '{target_str} UTC'"
     out = rewrite_for_system_time(sql, "p", full_ctx.snapshots, full_ctx.engine)
     assert snap.duckdb_table in out
     assert "_bqemulator_snapshots" in out


### PR DESCRIPTION
## Summary

PR-5 of the cyclomatic-complexity C→B initiative. Four C-rank blocks across the SQL-DDL catalog-sync helpers and the Phase-7 versioning surfaces drop to **rank B or better**, behavior-preserving.

| File | Function | Before | After |
|------|----------|--------|-------|
| `catalog/ddl_sync.py` | `_detect_create_schema` | C(13) | B(8) |
| `catalog/ddl_sync.py` | `_detect_plain_create_view` | C(11) | B(8) |
| `versioning/ddl.py` | `execute_versioning_ddl` | C(14) | B(8) |
| `versioning/time_travel.py` | `_resolve_target_ts` | C(15) | **A(4)** |

### How

- **`_detect_create_schema`** — extracted `_unwrap_table_target` and `_split_table_ref_parts`; the detector is now parse + kind check + parts dispatch.
- **`_detect_plain_create_view`** — reuses `_unwrap_table_target`; extracted `_is_materialized_view` for the MATERIALIZED-property scan.
- **`execute_versioning_ddl`** — extracted `_assert_source_present` so snapshot/clone branches share one precondition instead of repeating three asserts each.
- **`_resolve_target_ts`** — split into `_parse_literal_iso_timestamp` (fast path) and `_eval_timestamp_via_duckdb` (fallback). The resolver itself is just literal-vs-fallback dispatch.

### Numbers

Repo-wide C-block count: **49 → 45** (cumulative through PRs 1–5: **59 → 45**).
Gate stays at `--max-absolute C` for now; flip to B happens in PR-12 once all clusters land.

## Test plan

- [x] `radon cc --min C` empty on the three touched files
- [x] `xenon --max-absolute B --max-modules B --max-average A` passes on the three files (exit 0)
- [x] Targeted suites green: `tests/unit/catalog/test_ddl_sync.py`, `tests/unit/versioning/*`, `tests/integration/test_{clones,snapshots,time_travel}.py` — 136 passed
- [ ] Full CI (unit + property + integration + conformance + e2e matrix) — verified via GitHub Actions on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved SQL parsing and more accurate detection/routing of materialized vs. plain views.
  * Consolidated validation for snapshot/clone operations to reduce duplication and improve reliability.
  * Reworked time-travel timestamp handling for clearer parsing, evaluation, and error reporting of AS OF expressions.
* **Tests**
  * Added a unit test ensuring BigQuery-style UTC-suffixed timestamps fall back to evaluator and resolve to the correct snapshot.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->