### PR TITLE
refactor(complexity): drop SQL rewriter blocks below rank C

### DIFF
--- a/src/bqemulator/sql/rewriter/alter_table_set_options.py
+++ b/src/bqemulator/sql/rewriter/alter_table_set_options.py
@@ -53,23 +53,38 @@ def _strip_leading_comments(sql: str) -> int:
         if ch.isspace():
             i += 1
             continue
-        # Line comment: ``-- …\n``.
-        if ch == "-" and i + 1 < n and sql[i + 1] == "-":
-            i += 2
-            while i < n and sql[i] != "\n":
-                i += 1
-            if i < n:
-                i += 1  # consume the newline itself
+        if ch == "-" and _starts_with(sql, i, "--"):
+            i = _skip_line_comment(sql, i + 2)
             continue
-        # Block comment: ``/* … */``.
-        if ch == "/" and i + 1 < n and sql[i + 1] == "*":
-            end = sql.find("*/", i + 2)
-            if end == -1:
-                return n  # unterminated — treat the whole thing as comment
-            i = end + 2
+        if ch == "/" and _starts_with(sql, i, "/*"):
+            i = _skip_block_comment(sql, i + 2)
             continue
         return i
     return n
+
+
+def _starts_with(sql: str, index: int, marker: str) -> bool:
+    """Return True if ``sql[index:]`` begins with ``marker`` without overrunning."""
+    return index + len(marker) <= len(sql) and sql[index : index + len(marker)] == marker
+
+
+def _skip_line_comment(sql: str, start: int) -> int:
+    r"""Advance past a ``-- …\n`` comment body and return the post-newline index."""
+    n = len(sql)
+    i = start
+    while i < n and sql[i] != "\n":
+        i += 1
+    if i < n:
+        i += 1  # consume the newline itself
+    return i
+
+
+def _skip_block_comment(sql: str, start: int) -> int:
+    """Advance past a ``/* … */`` block; an unterminated block consumes to EOF."""
+    end = sql.find("*/", start)
+    if end == -1:
+        return len(sql)
+    return end + 2
 
 
 def _peek_word(sql: str, start: int) -> tuple[str, int]:
@@ -110,66 +125,97 @@ def rewrite_alter_table_set_options(bq_sql: str) -> str:
     regexes (one for the comment prefix, one for the keyword + body
     walk). A scanner is both faster and ReDoS-immune by construction.
     """
-    # 1. Skip leading whitespace + SQL comments.
-    cursor = _strip_leading_comments(bq_sql)
-    if cursor >= len(bq_sql):
+    cursor = _match_alter_table_header(bq_sql)
+    if cursor is None:
         return bq_sql
+    cursor = _advance_past_table_ref_to_set(bq_sql, cursor)
+    if cursor is None:
+        return bq_sql
+    cursor = _match_options_keyword(bq_sql, cursor)
+    if cursor is None:
+        return bq_sql
+    close = _match_balanced_parens(bq_sql, cursor)
+    if close is None:
+        return bq_sql
+    if not _is_trailing_whitespace_or_semicolon(bq_sql, close + 1):
+        return bq_sql
+    return "SELECT 1"
 
-    # 2. Expect ``ALTER`` (case-insensitive).
-    word, cursor = _peek_word(bq_sql, cursor)
+
+def _match_alter_table_header(sql: str) -> int | None:
+    """Skip leading comments + match ``ALTER TABLE``; return the cursor after, or None."""
+    cursor = _strip_leading_comments(sql)
+    if cursor >= len(sql):
+        return None
+    word, cursor = _peek_word(sql, cursor)
     if word.casefold() != _ALTER:
-        return bq_sql
-
-    # 3. Expect ``TABLE``.
-    cursor = _skip_ws(bq_sql, cursor)
-    word, cursor = _peek_word(bq_sql, cursor)
+        return None
+    cursor = _skip_ws(sql, cursor)
+    word, cursor = _peek_word(sql, cursor)
     if word.casefold() != _TABLE:
-        return bq_sql
+        return None
+    return cursor
 
-    # 4. Walk word-by-word until we see ``SET`` (the table reference
-    #    between TABLE and SET can be one or more whitespace-delimited
-    #    tokens — backticked, dotted, etc.). Bail if we run out.
-    while cursor < len(bq_sql):
-        cursor = _skip_ws(bq_sql, cursor)
-        word, cursor = _peek_word(bq_sql, cursor)
+
+def _advance_past_table_ref_to_set(sql: str, cursor: int) -> int | None:
+    """Walk word-by-word until the ``SET`` keyword; return the cursor after it.
+
+    BigQuery's table reference between TABLE and SET can be one or
+    more whitespace-delimited tokens (backticked, dotted, …). Returns
+    ``None`` when the input is exhausted before ``SET`` is seen.
+    """
+    n = len(sql)
+    while cursor < n:
+        cursor = _skip_ws(sql, cursor)
+        word, cursor = _peek_word(sql, cursor)
         if not word:
-            return bq_sql
+            return None
         if word.casefold() == _SET:
-            break
+            return cursor
+    return None
 
-    # 5. Expect ``OPTIONS``.
-    cursor = _skip_ws(bq_sql, cursor)
-    word, after_options = _peek_word(bq_sql, cursor)
-    # ``OPTIONS`` may butt directly up against ``(``, so peek_word
-    # could capture ``OPTIONS(...``; trim the parenthesis if so.
+
+def _match_options_keyword(sql: str, cursor: int) -> int | None:
+    """Match the literal ``OPTIONS`` token after ``SET``; return the cursor after it.
+
+    ``OPTIONS`` may butt directly up against ``(``, so the peeked word
+    can capture ``OPTIONS(``; the parenthesis is trimmed off and the
+    cursor is set to point at the opening paren.
+    """
+    cursor = _skip_ws(sql, cursor)
+    word, after_options = _peek_word(sql, cursor)
     keyword = word
     paren_offset = keyword.find("(")
     if paren_offset != -1:
         after_options = cursor + paren_offset
         keyword = keyword[:paren_offset]
     if keyword.casefold() != _OPTIONS:
-        return bq_sql
+        return None
+    return after_options
 
-    # 6. The next non-whitespace char must be ``(``. Then find the
-    #    matching ``)`` (BigQuery option values are scalars/strings/
-    #    arrays — no nested function calls, so single-level balance
-    #    is enough).
-    cursor = _skip_ws(bq_sql, after_options)
-    if cursor >= len(bq_sql) or bq_sql[cursor] != "(":
-        return bq_sql
-    close = bq_sql.find(")", cursor + 1)
+
+def _match_balanced_parens(sql: str, cursor: int) -> int | None:
+    """Verify ``(`` at ``cursor`` (after optional WS) + return index of matching ``)``.
+
+    BigQuery option bodies are scalars/strings/arrays — no nested
+    function calls, so a single-level find is enough.
+    """
+    cursor = _skip_ws(sql, cursor)
+    if cursor >= len(sql) or sql[cursor] != "(":
+        return None
+    close = sql.find(")", cursor + 1)
     if close == -1:
-        return bq_sql
+        return None
+    return close
 
-    # 7. Everything after ``)`` must be whitespace + optional ``;``.
-    tail = _skip_ws(bq_sql, close + 1)
-    if tail < len(bq_sql) and bq_sql[tail] == ";":
+
+def _is_trailing_whitespace_or_semicolon(sql: str, start: int) -> bool:
+    """Return True if the slice from ``start`` is just whitespace + at most one ``;``."""
+    tail = _skip_ws(sql, start)
+    if tail < len(sql) and sql[tail] == ";":
         tail += 1
-    tail = _skip_ws(bq_sql, tail)
-    if tail != len(bq_sql):
-        return bq_sql
-
-    return "SELECT 1"
+    tail = _skip_ws(sql, tail)
+    return tail == len(sql)
 
 
 __all__ = ["rewrite_alter_table_set_options"]

--- a/src/bqemulator/sql/rewriter/create_table_schema_ctas.py
+++ b/src/bqemulator/sql/rewriter/create_table_schema_ctas.py
@@ -80,6 +80,12 @@ def _apply_schema_ctas_rewrite(create: exp.Create) -> bool:
     schema = create.this
     if not isinstance(schema, exp.Schema):
         return False
+    # ``Schema.this`` is *typically* a Table per SQLGlot's docs but the
+    # attribute is loosely typed; guard explicitly so a malformed AST
+    # doesn't blow up on the ``.copy()`` below.
+    table_ref = schema.this
+    if not isinstance(table_ref, exp.Table):
+        return False
     # CTAS body may be a bare SELECT or a UNION [ALL] chain. DuckDB
     # derives table column types from the FIRST SELECT, so only that
     # one needs cast projections.
@@ -97,7 +103,7 @@ def _apply_schema_ctas_rewrite(create: exp.Create) -> bool:
     # Replace ``Schema(table, columns)`` with the bare Table — DuckDB
     # then sees ``CREATE [OR REPLACE] TABLE <ref> AS SELECT CAST(...)
     # AS col, ...`` which it accepts.
-    create.set("this", schema.this.copy())
+    create.set("this", table_ref.copy())
     return True
 
 

--- a/src/bqemulator/sql/rewriter/create_table_schema_ctas.py
+++ b/src/bqemulator/sql/rewriter/create_table_schema_ctas.py
@@ -58,53 +58,68 @@ def rewrite_create_table_schema_ctas(bq_sql: str) -> str:
 
     modified = False
     for create in tree.find_all(exp.Create):
-        if (create.args.get("kind") or "").upper() != "TABLE":
-            continue
-        schema = create.this
-        if not isinstance(schema, exp.Schema):
-            continue
-        # CTAS body may be a bare ``SELECT`` or a ``UNION [ALL]`` chain
-        # of SELECT clauses. DuckDB derives the table's column types
-        # from the FIRST SELECT in the chain, so we only need to cast
-        # that one.
-        first_select = _first_select(create.expression)
-        if first_select is None:
-            continue
-        col_defs = [e for e in schema.expressions if isinstance(e, exp.ColumnDef)]
-        projections = first_select.expressions
-        if not col_defs:
-            continue
-        if len(col_defs) != len(projections):
-            # Column-count mismatch — leave the SQL alone so the user
-            # sees whatever error the downstream parser produces.
-            continue
-
-        new_projections: list[exp.Expression] = []
-        for col_def, proj in zip(col_defs, projections, strict=True):
-            value = proj.this if isinstance(proj, exp.Alias) else proj
-            kind = col_def.kind
-            if kind is None:
-                # Schema entry without a declared type — preserve the
-                # projection unchanged so DuckDB infers the type.
-                new_projections.append(proj.copy())
-                continue
-            cast_expr = exp.Cast(this=value.copy(), to=kind.copy())
-            new_projections.append(
-                exp.Alias(this=cast_expr, alias=col_def.this.copy()),
-            )
-
-        first_select.set("expressions", new_projections)
-
-        # Replace the Schema(table, columns) wrapper with the bare
-        # Table — DuckDB then sees ``CREATE [OR REPLACE] TABLE <ref>
-        # AS SELECT CAST(...) AS col, ...`` which it accepts.
-        table = schema.this.copy()
-        create.set("this", table)
-        modified = True
+        if _apply_schema_ctas_rewrite(create):
+            modified = True
 
     if not modified:
         return bq_sql
     return tree.sql(dialect="bigquery")
+
+
+def _apply_schema_ctas_rewrite(create: exp.Create) -> bool:
+    """Rewrite a single ``CREATE TABLE (schema) AS SELECT …`` to bare CTAS.
+
+    Returns ``True`` when the create node was rewritten in place;
+    ``False`` for any other shape (different ``kind``, no ``Schema``,
+    body without a leaf ``Select``, no ``ColumnDef`` entries, or a
+    column-count mismatch — the latter is left to the downstream
+    parser to surface as a clean error).
+    """
+    if (create.args.get("kind") or "").upper() != "TABLE":
+        return False
+    schema = create.this
+    if not isinstance(schema, exp.Schema):
+        return False
+    # CTAS body may be a bare SELECT or a UNION [ALL] chain. DuckDB
+    # derives table column types from the FIRST SELECT, so only that
+    # one needs cast projections.
+    first_select = _first_select(create.expression)
+    if first_select is None:
+        return False
+    col_defs = [e for e in schema.expressions if isinstance(e, exp.ColumnDef)]
+    if not col_defs:
+        return False
+    projections = first_select.expressions
+    if len(col_defs) != len(projections):
+        return False
+
+    first_select.set("expressions", _cast_projections_to_schema(col_defs, projections))
+    # Replace ``Schema(table, columns)`` with the bare Table — DuckDB
+    # then sees ``CREATE [OR REPLACE] TABLE <ref> AS SELECT CAST(...)
+    # AS col, ...`` which it accepts.
+    create.set("this", schema.this.copy())
+    return True
+
+
+def _cast_projections_to_schema(
+    col_defs: list[exp.ColumnDef],
+    projections: list[exp.Expression],
+) -> list[exp.Expression]:
+    """Wrap each projection in ``CAST(<value> AS <col_def.kind>) AS <col_def.name>``.
+
+    A ``ColumnDef`` without a declared ``kind`` (DuckDB infers the
+    type) carries the original projection through unchanged.
+    """
+    casts: list[exp.Expression] = []
+    for col_def, proj in zip(col_defs, projections, strict=True):
+        value = proj.this if isinstance(proj, exp.Alias) else proj
+        kind = col_def.kind
+        if kind is None:
+            casts.append(proj.copy())
+            continue
+        cast_expr = exp.Cast(this=value.copy(), to=kind.copy())
+        casts.append(exp.Alias(this=cast_expr, alias=col_def.this.copy()))
+    return casts
 
 
 def _first_select(body: exp.Expression | None) -> exp.Select | None:

--- a/src/bqemulator/sql/rewriter/datetime_helpers.py
+++ b/src/bqemulator/sql/rewriter/datetime_helpers.py
@@ -49,8 +49,13 @@ transpile and is not touched here.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import sqlglot
 from sqlglot import exp
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _DATE_RETURNING_FUNCTIONS = (exp.DateAdd, exp.DateSub, exp.DateFromUnixDate)
 
@@ -66,11 +71,8 @@ def rewrite_datetime_helpers(bq_sql: str) -> str:
     Parse failures are tolerated: we return the original SQL so the
     downstream SQLGlot transpile surfaces its own parse error message.
     """
-    upper = bq_sql.upper()
-    needs_last_day = "LAST_DAY" in upper and "WEEK" in upper
-    needs_date_cast = "DATE_ADD" in upper or "DATE_SUB" in upper or "DATE_FROM_UNIX_DATE" in upper
-    needs_timestamp_micros_millis = "TIMESTAMP_MICROS" in upper or "TIMESTAMP_MILLIS" in upper
-    if not (needs_last_day or needs_date_cast or needs_timestamp_micros_millis):
+    needs = _detect_rewrite_needs(bq_sql.upper())
+    if not any(needs.values()):
         return bq_sql
 
     try:
@@ -79,15 +81,30 @@ def rewrite_datetime_helpers(bq_sql: str) -> str:
         return bq_sql
 
     modified = False
-    if needs_last_day:
-        modified |= _rewrite_last_day_week(parsed)
-    if needs_date_cast:
-        modified |= _rewrite_date_function_results(parsed)
-    if needs_timestamp_micros_millis:
-        modified |= _rewrite_timestamp_micros_millis(parsed)
+    for key, rewriter in _DATETIME_REWRITE_PASSES:
+        if needs[key]:
+            modified |= rewriter(parsed)
     if not modified:
         return bq_sql
     return parsed.sql(dialect="bigquery")
+
+
+def _detect_rewrite_needs(upper_sql: str) -> dict[str, bool]:
+    """Return a ``{pass_key: bool}`` map of which datetime passes are needed.
+
+    Splitting the cheap-but-branchy marker checks out of the main
+    entry-point keeps that function's cyclomatic complexity low; the
+    string scans here are still ``O(len(sql))`` and run only once.
+    """
+    return {
+        "last_day_week": "LAST_DAY" in upper_sql and "WEEK" in upper_sql,
+        "date_cast": (
+            "DATE_ADD" in upper_sql or "DATE_SUB" in upper_sql or "DATE_FROM_UNIX_DATE" in upper_sql
+        ),
+        "timestamp_micros_millis": (
+            "TIMESTAMP_MICROS" in upper_sql or "TIMESTAMP_MILLIS" in upper_sql
+        ),
+    }
 
 
 def _rewrite_date_function_results(tree: exp.Expression) -> bool:
@@ -245,6 +262,17 @@ def _name(node: exp.Expression) -> str:
     if isinstance(node, exp.Literal):
         return str(node.this)
     return node.name or str(node.this or "")
+
+
+#: Ordered dispatch of (needs-key, rewriter) pairs. Matches the order
+#: of ``_detect_rewrite_needs``'s output keys. Order is presentation-
+#: only — each rewriter targets a distinct AST shape so ordering does
+#: not affect the outcome.
+_DATETIME_REWRITE_PASSES: tuple[tuple[str, Callable[[exp.Expression], bool]], ...] = (
+    ("last_day_week", _rewrite_last_day_week),
+    ("date_cast", _rewrite_date_function_results),
+    ("timestamp_micros_millis", _rewrite_timestamp_micros_millis),
+)
 
 
 __all__ = ["rewrite_datetime_helpers"]

--- a/src/bqemulator/sql/rewriter/information_schema.py
+++ b/src/bqemulator/sql/rewriter/information_schema.py
@@ -722,33 +722,60 @@ def _columns_as_values(
             else {}
         )
         for ordinal, field in enumerate(t.schema_.fields, start=1):
-            col_name = _sql_literal(field.name)
-            is_nullable = _sql_literal("YES" if field.mode != "REQUIRED" else "NO")
-            data_type = _sql_literal(_render_data_type(field))
-            is_generated = _sql_literal("NEVER")
-            generation_expr = "NULL"
-            is_stored = _sql_literal("NEVER")
-            is_hidden = _sql_literal("NO")
-            is_updatable = _sql_literal("YES" if t.table_type == "TABLE" else "NO")
-            is_system_defined = _sql_literal("NO")
-            is_partitioning = _sql_literal(
-                "YES" if partition_field is not None and field.name == partition_field else "NO",
-            )
-            clust_pos = (
-                str(clustering_fields[field.name]) if field.name in clustering_fields else "NULL"
-            )
-            coll = _sql_literal(field.collation) if field.collation else "NULL"
             rows.append(
-                f"({pid}, {did}, {tid}, {col_name}, {ordinal}, {is_nullable}, "
-                f"{data_type}, {is_generated}, {generation_expr}, {is_stored}, "
-                f"{is_hidden}, {is_updatable}, {is_system_defined}, "
-                f"{is_partitioning}, {clust_pos}, {coll})",
+                _column_row_literal(
+                    pid=pid,
+                    did=did,
+                    tid=tid,
+                    ordinal=ordinal,
+                    table=t,
+                    field=field,
+                    partition_field=partition_field,
+                    clustering_fields=clustering_fields,
+                ),
             )
     if not rows:
         return _empty_columns_values_subquery()
     col_list = ", ".join(_COLUMNS_COLUMNS)
     joined = ", ".join(rows)
     return f"(SELECT * FROM (VALUES {joined}) AS v({col_list}))"
+
+
+def _column_row_literal(
+    *,
+    pid: str,
+    did: str,
+    tid: str,
+    ordinal: int,
+    table: TableMeta,
+    field: TableFieldSchema,
+    partition_field: str | None,
+    clustering_fields: dict[str, int],
+) -> str:
+    """Render one row of the ``INFORMATION_SCHEMA.COLUMNS`` VALUES literal.
+
+    The column ordering matches :data:`_COLUMNS_COLUMNS` exactly — the
+    caller stitches the rows together inside ``(VALUES ...)``.
+    """
+    col_name = _sql_literal(field.name)
+    is_nullable = _sql_literal("YES" if field.mode != "REQUIRED" else "NO")
+    data_type = _sql_literal(_render_data_type(field))
+    is_updatable = _sql_literal("YES" if table.table_type == "TABLE" else "NO")
+    is_partitioning = _sql_literal(
+        "YES" if partition_field is not None and field.name == partition_field else "NO",
+    )
+    clust_pos = str(clustering_fields[field.name]) if field.name in clustering_fields else "NULL"
+    coll = _sql_literal(field.collation) if field.collation else "NULL"
+    is_generated = _sql_literal("NEVER")
+    is_stored = _sql_literal("NEVER")
+    is_hidden = _sql_literal("NO")
+    is_system_defined = _sql_literal("NO")
+    return (
+        f"({pid}, {did}, {tid}, {col_name}, {ordinal}, {is_nullable}, "
+        f"{data_type}, {is_generated}, NULL, {is_stored}, "
+        f"{is_hidden}, {is_updatable}, {is_system_defined}, "
+        f"{is_partitioning}, {clust_pos}, {coll})"
+    )
 
 
 def _empty_columns_values_subquery() -> str:

--- a/src/bqemulator/sql/rewriter/specialized_types.py
+++ b/src/bqemulator/sql/rewriter/specialized_types.py
@@ -44,10 +44,13 @@ names and call shapes need rewriting.
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import sqlglot
 from sqlglot import exp
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from bqemulator.types.interval import parse_interval_literal, parts_to_duckdb_expr
 from bqemulator.types.range_type import END_FIELD, START_FIELD
@@ -68,10 +71,21 @@ def rewrite_specialized_types(bq_sql: str) -> str:
     in its own clean format.
     """
     upper = bq_sql.upper()
+    upper_nospace = upper.replace(" ", "")
     needs_interval = "INTERVAL" in upper and "TO" in upper
-    needs_range_ctor = "RANGE(" in upper.replace(" ", "")
-    needs_range_literal = "RANGE<" in upper.replace(" ", "")
-    if not (needs_interval or needs_range_ctor or needs_range_literal):
+    needs_range_ctor = "RANGE(" in upper_nospace
+    needs_range_literal = "RANGE<" in upper_nospace
+    # The column-type pass and the literal pass share the same gate
+    # (any RANGE<T> mention triggers both). The literal pass must run
+    # first so any ``Cast(literal, RANGE<T>)`` is fully replaced before
+    # the column-type pass walks the remaining ``DataType.RANGE`` nodes.
+    passes: list[tuple[bool, Callable[[exp.Expression], bool]]] = [
+        (needs_interval, _rewrite_intervals),
+        (needs_range_ctor, _rewrite_range_constructor),
+        (needs_range_literal, _rewrite_range_literals),
+        (needs_range_literal, _rewrite_range_data_types),
+    ]
+    if not any(needed for needed, _ in passes):
         return bq_sql
 
     try:
@@ -79,18 +93,11 @@ def rewrite_specialized_types(bq_sql: str) -> str:
     except sqlglot.errors.ParseError:
         return bq_sql
 
-    modified_interval = _rewrite_intervals(parsed) if needs_interval else False
-    modified_range_ctor = _rewrite_range_constructor(parsed) if needs_range_ctor else False
-    modified_range_literal = _rewrite_range_literals(parsed) if needs_range_literal else False
-    # The column-type pass runs after the literal pass so any
-    # ``Cast(literal, RANGE<T>)`` shape has already been replaced with
-    # a ``STRUCT(...)`` expression (the literal handler replaces the
-    # entire Cast node, not just the type). Whatever ``DataType.RANGE``
-    # nodes remain belong to column definitions or non-literal CASTs.
-    modified_range_type = _rewrite_range_data_types(parsed) if needs_range_literal else False
-    if not (
-        modified_interval or modified_range_ctor or modified_range_literal or modified_range_type
-    ):
+    modified = False
+    for needed, rewriter in passes:
+        if needed:
+            modified |= rewriter(parsed)
+    if not modified:
         return bq_sql
     return parsed.sql(dialect="bigquery")
 

--- a/src/bqemulator/sql/rewriter/timestamp_iso_helpers.py
+++ b/src/bqemulator/sql/rewriter/timestamp_iso_helpers.py
@@ -59,49 +59,7 @@ def rewrite_timestamp_iso_helpers(bq_sql: str) -> str:
 
     modified = False
     for node in list(parsed.walk()):
-        replacement: exp.Expression | None = None
-        if isinstance(node, exp.TimeToStr):
-            # SQLGlot maps both FORMAT_TIMESTAMP and FORMAT_DATETIME to
-            # ``TimeToStr``. We only intervene when a zone arg is set
-            # (FORMAT_TIMESTAMP with explicit zone) or the format
-            # carries a ``%E`` specifier (any FORMAT_* call).
-            fmt = node.args.get("format")
-            zone = node.args.get("zone")
-            needs_helper = zone is not None or (
-                isinstance(fmt, exp.Literal) and fmt.is_string and "%E" in str(fmt.this)
-            )
-            if needs_helper and fmt is not None:
-                ts = node.this
-                if ts is None:
-                    continue
-                zone_arg: exp.Expression = (
-                    zone.copy() if zone is not None else exp.Literal.string("UTC")
-                )
-                replacement = exp.Anonymous(
-                    this="bqemu_format_timestamp_iso",
-                    expressions=[fmt.copy(), ts.copy(), zone_arg],
-                )
-        elif isinstance(node, exp.StrToTime):
-            # PARSE_TIMESTAMP / PARSE_DATETIME — both arrive as
-            # ``StrToTime``. We only intervene when the format carries
-            # a BigQuery-only ``%Ez`` or a ``%Z`` named-zone token.
-            fmt = node.args.get("format")
-            if not _format_has_ez_or_z(fmt) or fmt is None:
-                continue
-            value = node.this
-            if value is None:
-                continue
-            helper_call = exp.Anonymous(
-                this="bqemu_parse_timestamp_iso",
-                expressions=[fmt.copy(), value.copy()],
-            )
-            # Wrap in ``timezone('UTC', …)`` so the wire-format
-            # renderer surfaces the result as ``TIMESTAMP`` (matching
-            # :class:`ParseTimestampUtcRule`'s contract).
-            replacement = exp.Anonymous(
-                this="timezone",
-                expressions=[exp.Literal.string("UTC"), helper_call],
-            )
+        replacement = _rewrite_node(node)
         if replacement is not None:
             node.replace(replacement)
             modified = True
@@ -109,6 +67,69 @@ def rewrite_timestamp_iso_helpers(bq_sql: str) -> str:
     if not modified:
         return bq_sql
     return parsed.sql(dialect="bigquery")
+
+
+def _rewrite_node(node: exp.Expression) -> exp.Expression | None:
+    """Dispatch a single AST node to the matching rewrite helper.
+
+    Returns the replacement expression or ``None`` when the node is
+    not eligible (wrong type, missing args, or format string without
+    a `%Ez` / `%Z` token).
+    """
+    if isinstance(node, exp.TimeToStr):
+        return _rewrite_format_timestamp(node)
+    if isinstance(node, exp.StrToTime):
+        return _rewrite_parse_timestamp(node)
+    return None
+
+
+def _rewrite_format_timestamp(node: exp.TimeToStr) -> exp.Expression | None:
+    """Build the ``bqemu_format_timestamp_iso`` call for a ``FORMAT_*`` node.
+
+    SQLGlot maps both ``FORMAT_TIMESTAMP`` and ``FORMAT_DATETIME`` to
+    :class:`exp.TimeToStr`. We rewrite when either the call carries a
+    zone argument (``FORMAT_TIMESTAMP`` with explicit zone) or the
+    format string contains a ``%E`` specifier (every ``FORMAT_*`` call).
+    """
+    fmt = node.args.get("format")
+    if fmt is None:
+        return None
+    zone = node.args.get("zone")
+    fmt_has_e = isinstance(fmt, exp.Literal) and fmt.is_string and "%E" in str(fmt.this)
+    if zone is None and not fmt_has_e:
+        return None
+    ts = node.this
+    if ts is None:
+        return None
+    zone_arg: exp.Expression = zone.copy() if zone is not None else exp.Literal.string("UTC")
+    return exp.Anonymous(
+        this="bqemu_format_timestamp_iso",
+        expressions=[fmt.copy(), ts.copy(), zone_arg],
+    )
+
+
+def _rewrite_parse_timestamp(node: exp.StrToTime) -> exp.Expression | None:
+    """Build the ``timezone('UTC', bqemu_parse_timestamp_iso(...))`` call.
+
+    Triggered when the format carries a BigQuery-only ``%Ez`` or a
+    ``%Z`` named-zone token. The outer ``timezone('UTC', …)`` wrap
+    surfaces the result as ``TIMESTAMP`` on the wire, matching
+    :class:`ParseTimestampUtcRule`.
+    """
+    fmt = node.args.get("format")
+    if fmt is None or not _format_has_ez_or_z(fmt):
+        return None
+    value = node.this
+    if value is None:
+        return None
+    helper_call = exp.Anonymous(
+        this="bqemu_parse_timestamp_iso",
+        expressions=[fmt.copy(), value.copy()],
+    )
+    return exp.Anonymous(
+        this="timezone",
+        expressions=[exp.Literal.string("UTC"), helper_call],
+    )
 
 
 __all__ = ["rewrite_timestamp_iso_helpers"]

--- a/src/bqemulator/sql/rewriter/unnest_offset.py
+++ b/src/bqemulator/sql/rewriter/unnest_offset.py
@@ -34,40 +34,55 @@ def rewrite_unnest_offset(bq_sql: str) -> str:
     except Exception:  # noqa: BLE001
         return bq_sql
 
-    offset_names: set[str] = set()
-    for unnest in tree.find_all(exp.Unnest):
-        offset_expr = unnest.args.get("offset")
-        if isinstance(offset_expr, exp.Identifier):
-            offset_names.add(offset_expr.name)
-        elif offset_expr is True:
-            # BigQuery allows ``WITH OFFSET`` without a name; default is
-            # ``offset``. We handle that case too.
-            offset_names.add("offset")
-
+    offset_names = _collect_offset_names(tree)
     if not offset_names:
         return bq_sql
 
+    if not _rebase_offset_columns(tree, offset_names):
+        return bq_sql
+    return tree.sql(dialect="bigquery")
+
+
+def _collect_offset_names(tree: exp.Expression) -> set[str]:
+    """Return every offset column name introduced by a ``WITH OFFSET`` clause.
+
+    Falls back to ``"offset"`` for the un-aliased ``WITH OFFSET`` form
+    (BigQuery's documented default).
+    """
+    names: set[str] = set()
+    for unnest in tree.find_all(exp.Unnest):
+        offset_expr = unnest.args.get("offset")
+        if isinstance(offset_expr, exp.Identifier):
+            names.add(offset_expr.name)
+        elif offset_expr is True:
+            names.add("offset")
+    return names
+
+
+def _rebase_offset_columns(tree: exp.Expression, offset_names: set[str]) -> bool:
+    """Replace every ``Column(name in offset_names)`` with ``(col - 1)``.
+
+    Skips the column reference that sits inside an Unnest's own offset
+    slot (where it names the alias, not a usage). Preserves wrapping
+    ``Alias`` nodes so ``WITH OFFSET AS off`` projections retain their
+    alias on the rebased expression.
+
+    Returns ``True`` when at least one column was rebased.
+    """
     modified = False
     for col in list(tree.find_all(exp.Column)):
         if col.name not in offset_names:
             continue
-        # Skip the Column that sits inside the Unnest's own offset slot.
         if col.find_ancestor(exp.Unnest) is not None and col.parent_select is None:
             continue
-        # Replace ``col`` with ``col - 1``.
-        parent = col.parent
         replacement = exp.Paren(this=exp.Sub(this=col.copy(), expression=exp.Literal.number(1)))
-        # Preserve aliasing: if the column sits inside an Alias, leave the
-        # alias unchanged but swap its inner expression.
+        parent = col.parent
         if isinstance(parent, exp.Alias):
             parent.set("this", replacement)
         else:
             col.replace(replacement)
         modified = True
-
-    if not modified:
-        return bq_sql
-    return tree.sql(dialect="bigquery")
+    return modified
 
 
 __all__ = ["rewrite_unnest_offset"]

--- a/src/bqemulator/sql/rewriter/wildcard_expander.py
+++ b/src/bqemulator/sql/rewriter/wildcard_expander.py
@@ -151,38 +151,70 @@ def _apply_table_suffix_pushdown(
 
     pairs = [(tid[len(prefix) :], tid) for tid in table_ids]
 
-    # _TABLE_SUFFIX = 'x'
+    for filter_fn in _SUFFIX_PUSHDOWN_FILTERS:
+        match_result = filter_fn(bq_sql, pairs)
+        if match_result is not None:
+            return match_result
+    return table_ids
+
+
+def _suffix_equals_filter(
+    bq_sql: str,
+    pairs: list[tuple[str, str]],
+) -> list[str] | None:
+    """Match ``_TABLE_SUFFIX = 'x'`` and filter to the single matching suffix."""
     m = re.search(
         r"_TABLE_SUFFIX\s*=\s*(['\"])([^'\"]+)\1",
         bq_sql,
         flags=re.IGNORECASE,
     )
-    if m:
-        target = m.group(2)
-        return [tid for s, tid in pairs if s == target]
+    if m is None:
+        return None
+    target = m.group(2)
+    return [tid for s, tid in pairs if s == target]
 
-    # _TABLE_SUFFIX IN ('a', 'b')
+
+def _suffix_in_filter(
+    bq_sql: str,
+    pairs: list[tuple[str, str]],
+) -> list[str] | None:
+    """Match ``_TABLE_SUFFIX IN ('a', 'b', …)`` and filter to the listed suffixes."""
     m = re.search(
         r"_TABLE_SUFFIX\s+IN\s*\(([^)]+)\)",
         bq_sql,
         flags=re.IGNORECASE,
     )
-    if m:
-        values = re.findall(r"['\"]([^'\"]+)['\"]", m.group(1))
-        return [tid for s, tid in pairs if s in values]
+    if m is None:
+        return None
+    values = re.findall(r"['\"]([^'\"]+)['\"]", m.group(1))
+    return [tid for s, tid in pairs if s in values]
 
-    # _TABLE_SUFFIX BETWEEN 'a' AND 'b'
+
+def _suffix_between_filter(
+    bq_sql: str,
+    pairs: list[tuple[str, str]],
+) -> list[str] | None:
+    """Match ``_TABLE_SUFFIX BETWEEN 'a' AND 'b'`` and filter to the inclusive range."""
     m = re.search(
         r"_TABLE_SUFFIX\s+BETWEEN\s+(['\"])([^'\"]+)\1\s+AND\s+(['\"])([^'\"]+)\3",
         bq_sql,
         flags=re.IGNORECASE,
     )
-    if m:
-        low = m.group(2)
-        high = m.group(4)
-        return [tid for s, tid in pairs if low <= s <= high]
+    if m is None:
+        return None
+    low, high = m.group(2), m.group(4)
+    return [tid for s, tid in pairs if low <= s <= high]
 
-    # Single-sided inequality: >= / > / <= / <
+
+def _suffix_inequality_filter(
+    bq_sql: str,
+    pairs: list[tuple[str, str]],
+) -> list[str] | None:
+    """Match ``_TABLE_SUFFIX >= 'x'`` / ``>`` / ``<=`` / ``<`` and apply the comparator.
+
+    The dispatch order tries ``>=`` and ``<=`` before ``>`` and ``<``
+    so the regex engine doesn't mis-match the two-char operators.
+    """
     compare_fns: list[tuple[str, Callable[[str, str], bool]]] = [
         (r">=", lambda s, v: s >= v),
         (r"<=", lambda s, v: s <= v),
@@ -198,8 +230,20 @@ def _apply_table_suffix_pushdown(
         if m:
             target = m.group(2)
             return [tid for s, tid in pairs if op_fn(s, target)]
+    return None
 
-    return table_ids
+
+#: Pushdown filter dispatch table. Each entry takes the raw SQL + the
+#: ``(suffix, table_id)`` pair list and returns either a narrowed
+#: ``table_ids`` list (filter matched) or ``None`` (didn't match —
+#: try the next filter). The first match wins; if none match, the
+#: caller falls back to the full ``table_ids``.
+_SUFFIX_PUSHDOWN_FILTERS: tuple[Callable[[str, list[tuple[str, str]]], list[str] | None], ...] = (
+    _suffix_equals_filter,
+    _suffix_in_filter,
+    _suffix_between_filter,
+    _suffix_inequality_filter,
+)
 
 
 __all__ = ["expand_wildcard_tables"]


### PR DESCRIPTION
## Summary

PR-7 of the cyclomatic-complexity C→B initiative. Nine C-rank blocks across `src/bqemulator/sql/rewriter/*` (8 files) drop to **rank B or better**, behaviour-preserving.

| File | Function | Before | After | Strategy |
|------|----------|--------|-------|----------|
| `datetime_helpers.py` | `rewrite_datetime_helpers` | C(13) | **B(6)** | Extract `_detect_rewrite_needs` + module-level `(key, rewriter)` dispatch tuple |
| `unnest_offset.py` | `rewrite_unnest_offset` | C(13) | **A(5)** | Extract `_collect_offset_names` + `_rebase_offset_columns` |
| `timestamp_iso_helpers.py` | `rewrite_timestamp_iso_helpers` | C(19) | **A(5)** | Per-node-type extraction (`_rewrite_format_timestamp` + `_rewrite_parse_timestamp`) via `_rewrite_node` dispatch |
| `alter_table_set_options.py` | `_strip_leading_comments` | C(13) | **A(4)** | Extract `_starts_with` + `_skip_line_comment` + `_skip_block_comment` |
| `alter_table_set_options.py` | `rewrite_alter_table_set_options` | C(15) | **A(4)** | Break into 5 step-matchers (`_match_alter_table_header`, etc.) |
| `specialized_types.py` | `rewrite_specialized_types` | C(14) | **A(5)** | Same dispatch-list pattern as `datetime_helpers` |
| `create_table_schema_ctas.py` | `rewrite_create_table_schema_ctas` | C(15) | **A(4)** | Extract `_apply_schema_ctas_rewrite` + `_cast_projections_to_schema` |
| `wildcard_expander.py` | `_apply_table_suffix_pushdown` | C(16) | **A(4)** | Per-shape filter helpers via `_SUFFIX_PUSHDOWN_FILTERS` dispatch tuple |
| `information_schema.py` | `_columns_as_values` | C(13) | **A(4)** | Extract `_column_row_literal` for the per-field VALUES row |

### Numbers

Repo-wide C-block count: **34 → 25** (cumulative through PRs 1–7: **59 → 25**).
Gate stays at `--max-absolute C`; flip to B in PR-12.

## Test plan

- [x] `radon cc --min C` empty across `src/bqemulator/sql/rewriter/`
- [x] `xenon --max-absolute B --max-modules B --max-average A` passes (exit 0)
- [x] `ruff check` clean · `ruff format --check` clean · `mypy` clean
- [x] All 929 `tests/unit/sql/*` tests pass — no regressions
- [ ] Full CI (unit + property + integration + conformance + e2e matrix) — verified via GitHub Actions on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal SQL rewriting logic reorganized across multiple modules for clearer, more modular processing.
  * Behavior and public APIs remain unchanged; rewrites preserve existing SQL behavior and error-tolerance.
  * Improvements target maintainability, readability, and reliability of SQL transformations without altering user-visible outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->