### PR TITLE
build(deps): pin starlette<1.0 to keep httpx-backed TestClient working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,11 @@ dependencies = [
     # (FastAPI's TestClient + our explicit httpx>=0.27 dep). Pinning
     # to the 0.x line keeps the existing testclient working until that
     # migration is planned and landed in its own PR.
-    "starlette<1.0",
+    #
+    # The floor matches FastAPI 0.135's own ``starlette>=0.46`` floor:
+    # explicit so any future loosening of FastAPI's transitive
+    # constraint doesn't open a security-drift window on starlette.
+    "starlette>=0.46,<1.0",
     "alembic>=1.13",
     # Floor pin on alembic's transitive Mako dep to dodge CVE-2026-44307
     # (template-injection in the Babel string-extractor). 1.3.12 is the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,14 @@ dependencies = [
     "prometheus-client>=0.20",
     "orjson>=3.10",
     "httpx>=0.27",
+    # Ceiling pin on starlette to dodge the 1.0.0 release line's switch
+    # from ``httpx`` to ``httpx2`` in starlette.testclient (FastAPI's
+    # TestClient relies on this). Adopting starlette 1.x cleanly needs
+    # a coordinated httpx -> httpx2 migration across the dep graph
+    # (FastAPI's TestClient + our explicit httpx>=0.27 dep). Pinning
+    # to the 0.x line keeps the existing testclient working until that
+    # migration is planned and landed in its own PR.
+    "starlette<1.0",
     "alembic>=1.13",
     # Floor pin on alembic's transitive Mako dep to dodge CVE-2026-44307
     # (template-injection in the Babel string-extractor). 1.3.12 is the


### PR DESCRIPTION
## Summary

Hotfix: Starlette 1.0.0 (released today, 2026-05-28) switched ``starlette.testclient`` from ``httpx`` to ``httpx2``. Every test that builds a FastAPI ``TestClient`` (which wraps ``starlette.testclient``) now fails at import with:

```
ModuleNotFoundError: No module named 'httpx2'
```

This is breaking **every PR** opened since the 1.0.0 release landed on PyPI. PR #96's CI failure is the canary.

## Why pin, not migrate

Adopting starlette 1.x cleanly requires coordinating an `httpx → httpx2` migration across:
- the explicit `httpx>=0.27` dep in this `pyproject.toml`
- FastAPI's `TestClient` (transitive via starlette — needs a compatible FastAPI floor)
- any first-party code that imports from `httpx`

Pinning `starlette<1.0` here is the minimal-scope unblock. The migration can land later as its own coordinated PR once FastAPI publishes a release that targets starlette 1.x + httpx2.

## Test plan

- [ ] CI passes (the failure mode this PR addresses is at the test-collection stage, so a green collection is sufficient signal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a version constraint limiting Starlette to below 1.0.
  * Included explanatory comments alongside the constraint describing expected compatibility and behavior implications for HTTP client and test interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->