### PR TITLE
refactor(complexity): drop SQL core blocks below rank C

### DIFF
--- a/src/bqemulator/sql/parameters.py
+++ b/src/bqemulator/sql/parameters.py
@@ -18,6 +18,7 @@ This module:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import date, datetime, time
 from decimal import Decimal
 import re
@@ -328,7 +329,7 @@ def _coerce_timestamp(raw: Any) -> datetime:
 #: which the BigQuery schema renderer surfaces as ``STRING`` rather
 #: than the declared BigQuery type. Passing a typed object preserves
 #: the column type all the way through to the wire-format response.
-_SCALAR_CONVERTERS: dict[str, Any] = {
+_SCALAR_CONVERTERS: dict[str, Callable[[Any], Any]] = {
     "INT64": int,
     "INTEGER": int,
     "FLOAT64": float,

--- a/src/bqemulator/sql/parameters.py
+++ b/src/bqemulator/sql/parameters.py
@@ -18,6 +18,8 @@ This module:
 
 from __future__ import annotations
 
+from datetime import date, datetime, time
+from decimal import Decimal
 import re
 from typing import Any
 
@@ -234,88 +236,112 @@ def _extract_value(param: dict[str, Any]) -> Any:
     pvalue = param.get("parameterValue", {})
     type_kind = ptype.get("type", "STRING").upper()
 
-    # ARRAY and STRUCT don't use "value" — they have nested structures.
+    # ARRAY / STRUCT don't use "value" — they have nested structures.
     # Handle them BEFORE the scalar null-check.
     if type_kind == "ARRAY":
-        array_values = pvalue.get("arrayValues", [])
-        element_type = ptype.get("arrayType", {})
-        return [
-            _extract_value({"parameterType": element_type, "parameterValue": av})
-            for av in array_values
-        ]
-
-    # STRUCT
+        return _extract_array_value(ptype, pvalue)
     if type_kind == "STRUCT":
-        struct_values = pvalue.get("structValues", {})
-        struct_types = ptype.get("structTypes", [])
-        result = {}
-        for st in struct_types:
-            field_name = st.get("name", "")
-            field_type = st.get("type", {})
-            field_value = struct_values.get(field_name, {})
-            result[field_name] = _extract_value(
-                {"parameterType": field_type, "parameterValue": field_value},
-            )
-        return result
+        return _extract_struct_value(ptype, pvalue)
 
     # Scalar types — "value" holds the raw string value.
     raw = pvalue.get("value")
     if raw is None:
         return None
-
-    if type_kind in ("INT64", "INTEGER"):
-        return int(raw)
-    if type_kind in ("FLOAT64", "FLOAT"):
-        return float(raw)
-    if type_kind in ("BOOL", "BOOLEAN"):
-        if isinstance(raw, bool):
-            return raw
-        return str(raw).lower() in ("true", "1")
-    if type_kind in ("NUMERIC", "BIGNUMERIC"):
-        from decimal import Decimal
-
-        return Decimal(str(raw))
-
-    # DATE / DATETIME / TIME / TIMESTAMP parameters must be converted
-    # to typed Python objects, not left as strings. DuckDB
-    # infers a prepared-statement parameter's column type from the
-    # Python value's type — a plain string binds as VARCHAR, which the
-    # BigQuery schema renderer surfaces as ``STRING`` rather than the
-    # declared BigQuery type. Passing a typed object preserves the
-    # column type all the way through to the wire-format response. The
-    # accepted on-wire string forms match BigQuery's REST documentation:
-    #
-    # * DATE       → ``YYYY-MM-DD``
-    # * DATETIME   → ``YYYY-MM-DD[ T]HH:MM:SS[.ffffff]`` (no timezone)
-    # * TIME       → ``HH:MM:SS[.ffffff]``
-    # * TIMESTAMP  → ``YYYY-MM-DD[ T]HH:MM:SS[.ffffff][Z|±HH:MM]``
-    if type_kind == "DATE":
-        from datetime import date
-
-        return date.fromisoformat(str(raw))
-    if type_kind == "DATETIME":
-        from datetime import datetime
-
-        text = str(raw).replace(" ", "T", 1)
-        return datetime.fromisoformat(text)
-    if type_kind == "TIME":
-        from datetime import time
-
-        return time.fromisoformat(str(raw))
-    if type_kind == "TIMESTAMP":
-        from datetime import datetime
-
-        text = str(raw)
-        # BigQuery wire-format accepts a trailing 'Z' for UTC; Python
-        # 3.11+ ``fromisoformat`` only accepts ``+00:00``.
-        if text.endswith("Z"):
-            text = text[:-1] + "+00:00"
-        text = text.replace(" ", "T", 1)
-        return datetime.fromisoformat(text)
-
+    converter = _SCALAR_CONVERTERS.get(type_kind)
+    if converter is not None:
+        return converter(raw)
     # All other types (STRING, BYTES, JSON, GEOGRAPHY, INTERVAL, RANGE)
     # are passed as strings — DuckDB handles the cast in the query itself.
     return str(raw)
+
+
+def _extract_array_value(ptype: dict[str, Any], pvalue: dict[str, Any]) -> list[Any]:
+    """Recursively extract each element of an ARRAY parameter."""
+    array_values = pvalue.get("arrayValues", [])
+    element_type = ptype.get("arrayType", {})
+    return [
+        _extract_value({"parameterType": element_type, "parameterValue": av}) for av in array_values
+    ]
+
+
+def _extract_struct_value(
+    ptype: dict[str, Any],
+    pvalue: dict[str, Any],
+) -> dict[str, Any]:
+    """Recursively extract each named field of a STRUCT parameter."""
+    struct_values = pvalue.get("structValues", {})
+    struct_types = ptype.get("structTypes", [])
+    result: dict[str, Any] = {}
+    for st in struct_types:
+        field_name = st.get("name", "")
+        field_type = st.get("type", {})
+        field_value = struct_values.get(field_name, {})
+        result[field_name] = _extract_value(
+            {"parameterType": field_type, "parameterValue": field_value},
+        )
+    return result
+
+
+def _coerce_bool(raw: Any) -> bool:
+    """Coerce a BigQuery BOOL/BOOLEAN parameter to ``bool``."""
+    if isinstance(raw, bool):
+        return raw
+    return str(raw).lower() in ("true", "1")
+
+
+def _coerce_numeric(raw: Any) -> Decimal:
+    """Coerce a BigQuery NUMERIC/BIGNUMERIC parameter to ``Decimal``."""
+    return Decimal(str(raw))
+
+
+def _coerce_date(raw: Any) -> date:
+    """Coerce a BigQuery DATE parameter (``YYYY-MM-DD``) to ``date``."""
+    return date.fromisoformat(str(raw))
+
+
+def _coerce_datetime(raw: Any) -> datetime:
+    """Coerce a BigQuery DATETIME parameter (``YYYY-MM-DD HH:MM:SS[.ffffff]``)."""
+    text = str(raw).replace(" ", "T", 1)
+    return datetime.fromisoformat(text)
+
+
+def _coerce_time(raw: Any) -> time:
+    """Coerce a BigQuery TIME parameter (``HH:MM:SS[.ffffff]``) to ``time``."""
+    return time.fromisoformat(str(raw))
+
+
+def _coerce_timestamp(raw: Any) -> datetime:
+    """Coerce a BigQuery TIMESTAMP parameter, normalising ``Z`` to ``+00:00``."""
+    text = str(raw)
+    # BigQuery wire-format accepts a trailing 'Z' for UTC; Python
+    # 3.11+ ``fromisoformat`` only accepts ``+00:00``.
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    text = text.replace(" ", "T", 1)
+    return datetime.fromisoformat(text)
+
+
+#: BigQuery scalar type name → Python coercion function. Date/time
+#: parameters MUST be converted to typed Python objects (not strings)
+#: because DuckDB infers prepared-statement parameter column types
+#: from the Python value's type — a plain string binds as VARCHAR,
+#: which the BigQuery schema renderer surfaces as ``STRING`` rather
+#: than the declared BigQuery type. Passing a typed object preserves
+#: the column type all the way through to the wire-format response.
+_SCALAR_CONVERTERS: dict[str, Any] = {
+    "INT64": int,
+    "INTEGER": int,
+    "FLOAT64": float,
+    "FLOAT": float,
+    "BOOL": _coerce_bool,
+    "BOOLEAN": _coerce_bool,
+    "NUMERIC": _coerce_numeric,
+    "BIGNUMERIC": _coerce_numeric,
+    "DATE": _coerce_date,
+    "DATETIME": _coerce_datetime,
+    "TIME": _coerce_time,
+    "TIMESTAMP": _coerce_timestamp,
+}
 
 
 __all__ = ["bind_parameters"]

--- a/src/bqemulator/sql/table_rewriter.py
+++ b/src/bqemulator/sql/table_rewriter.py
@@ -72,61 +72,21 @@ def _rewrite_table_node(table_node: object, project_id: str) -> bool:
     from sqlglot import exp
 
     assert isinstance(table_node, exp.Table)  # noqa: S101 — invariant
-    catalog = table_node.catalog
-    db = table_node.db
     table_name = table_node.name
     this_node = table_node.this
     is_tvf = isinstance(this_node, exp.Anonymous)
+    catalog, db = _normalize_qualifier_parts(
+        table_node.catalog,
+        table_node.db,
+        is_tvf=is_tvf,
+    )
 
-    # BigQuery's backticked compound form ``\`proj.ds\``` is canonical
-    # for DDL like ``CREATE SCHEMA IF NOT EXISTS \`proj.ds\``` (the
-    # Airflow ``BigQueryInsertJobOperator`` example emits this shape).
-    # SQLGlot parses the whole back-ticked literal as a single
-    # identifier, which lands in ``db='proj.ds'`` without populating
-    # ``catalog``. Split it back into the canonical ``catalog`` / ``db``
-    # pair *before* the dataset-id validator below sees a dotted name
-    # and rejects it as invalid.
-    if db and "." in db and not catalog and not is_tvf:
-        catalog, _, db = db.partition(".")
-
-    # Leave references to bqemulator's *reserved* schemas alone. The
-    # time-travel rewriter emits ``_bqemulator_snapshots.<id>``
-    # references that must reach DuckDB unmangled. Exact match: a user
-    # dataset whose id starts with the prefix still gets the regular
-    # rewrite.
     if db in _RESERVED_SCHEMAS:
         return False
 
-    # BigQuery parity: when a SQL fixture references a dataset with
-    # characters outside the alphanumeric+underscore rule, BigQuery
-    # returns HTTP 400 / ``reason=invalid`` *before* attempting any
-    # catalog lookup. Without this guard the emulator falls through to
-    # DuckDB which raises a generic "schema not found" error, surfacing
-    # as HTTP 404 / ``reason=notFound`` — a divergence from real BQ.
-    # TVF call-sites are exempt: they route through
-    # :func:`qualified_routine_name_parts` which has its own dataset-id
-    # whitelist and accepts compound ``project.dataset`` qualifiers in
-    # the ``db`` slot (see :class:`TestTvfBacktickedCompoundQualifier`).
-    if db and not is_tvf and not _BQ_DATASET_RE.match(db):
-        _raise_invalid_dataset_id(db, table_name)
+    _validate_dataset_id_if_applicable(db, table_name, is_tvf=is_tvf)
 
-    # Schema-only references (``CREATE SCHEMA proj.ds`` /
-    # ``DROP SCHEMA proj.ds``) parse as ``Table(catalog=proj, db=ds,
-    # this=Identifier(""))`` in SQLGlot's AST — there is no table
-    # part. Without this short-circuit the three-part rewriter
-    # produces ``"proj__ds".""`` (empty trailing identifier) which
-    # DuckDB rejects with ``zero-length delimited identifier``.
-    # For two-part schema refs (``CREATE SCHEMA ds``) DuckDB's
-    # parser folds the catalog+db into the bare schema slot, and
-    # dbt-bigquery's ``CREATE SCHEMA IF NOT EXISTS \`proj\`.\`ds\``
-    # is the path that surfaces this.
-    #
-    # TVF call-sites also produce an empty ``table_name`` because
-    # ``this`` is an :class:`exp.Anonymous` (function call) rather
-    # than an :class:`exp.Identifier`. Skip the schema-only branch
-    # in that case and let the two/three-part rewriter route through
-    # the TVF flattening path.
-    if not table_name and not is_tvf and (catalog or db):
+    if _is_schema_only_ref(catalog, db, table_name, is_tvf=is_tvf):
         return _rewrite_schema_only_ref(
             table_node,
             project_id,
@@ -141,6 +101,77 @@ def _rewrite_table_node(table_node: object, project_id: str) -> bool:
         return True
     # Bare table names are left as-is — they resolve via DuckDB's search_path.
     return False
+
+
+def _normalize_qualifier_parts(
+    catalog: str,
+    db: str,
+    *,
+    is_tvf: bool,
+) -> tuple[str, str]:
+    r"""Split BigQuery's back-ticked compound ``\`proj.ds\``` into ``(catalog, db)``.
+
+    BigQuery's back-ticked compound qualifier is canonical for DDL
+    like ``CREATE SCHEMA IF NOT EXISTS \`proj.ds\``` (the Airflow
+    ``BigQueryInsertJobOperator`` example emits this shape). SQLGlot
+    parses the whole back-ticked literal as a single identifier, which
+    lands in ``db='proj.ds'`` without populating ``catalog``. The
+    canonical (catalog, db) form has to be recovered *before* the
+    dataset-id validator sees a dotted name and rejects it as invalid.
+
+    TVFs are exempt — their ``db`` slot carries the back-ticked
+    compound through for the routine-naming layer to split.
+    """
+    if db and "." in db and not catalog and not is_tvf:
+        catalog, _, db = db.partition(".")
+    return catalog, db
+
+
+def _validate_dataset_id_if_applicable(
+    db: str,
+    table_name: str,
+    *,
+    is_tvf: bool,
+) -> None:
+    """Raise ``InvalidQueryError`` for BigQuery-invalid dataset ids.
+
+    BigQuery returns HTTP 400 / ``reason=invalid`` *before* attempting
+    any catalog lookup when a dataset id contains characters outside
+    the alphanumeric+underscore rule. Without this guard the emulator
+    falls through to DuckDB which raises a generic "schema not found"
+    error, surfacing as HTTP 404 / ``reason=notFound``.
+
+    TVF call-sites are exempt: they route through
+    :func:`qualified_routine_name_parts` which has its own dataset-id
+    whitelist and accepts compound ``project.dataset`` qualifiers in
+    the ``db`` slot.
+    """
+    if db and not is_tvf and not _BQ_DATASET_RE.match(db):
+        _raise_invalid_dataset_id(db, table_name)
+
+
+def _is_schema_only_ref(
+    catalog: str,
+    db: str,
+    table_name: str,
+    *,
+    is_tvf: bool,
+) -> bool:
+    """Return True when the AST shape is a schema-only ``CREATE``/``DROP SCHEMA``.
+
+    Schema-only references parse as
+    ``Table(catalog=proj, db=ds, this=Identifier(""))`` in SQLGlot —
+    there is no table part. Without this branch the three-part
+    rewriter would produce ``"proj__ds".""`` (empty trailing
+    identifier), which DuckDB rejects with
+    ``zero-length delimited identifier``.
+
+    TVF call-sites also yield an empty ``table_name`` because
+    ``this`` is an :class:`exp.Anonymous` (function call); they are
+    excluded so the two/three-part rewriter handles them via the TVF
+    flattening path.
+    """
+    return not table_name and not is_tvf and bool(catalog or db)
 
 
 def _rewrite_schema_only_ref(
@@ -277,6 +308,21 @@ def _rewrite_schema_qualified_calls(tree: object, project_id: str) -> bool:
     """
     from sqlglot import exp
 
+    assert isinstance(tree, exp.Expression)  # noqa: S101
+    modified_dot = _rewrite_dot_anonymous_calls(tree, project_id)
+    modified_anon = _rewrite_anonymous_dotted_calls(tree, project_id)
+    return modified_dot or modified_anon
+
+
+def _rewrite_dot_anonymous_calls(tree: object, project_id: str) -> bool:
+    """Flatten ``Dot(Identifier, Anonymous)`` UDF call sites.
+
+    Matches the SQLGlot AST for ``dataset.routine(args)`` written
+    without backticks. Becomes
+    ``project__dataset__routine(args)`` in place.
+    """
+    from sqlglot import exp
+
     from bqemulator.domain.errors import InvalidQueryError, ValidationError
     from bqemulator.udf.naming import qualified_routine_name_parts
 
@@ -285,20 +331,18 @@ def _rewrite_schema_qualified_calls(tree: object, project_id: str) -> bool:
     for dot_node in list(tree.find_all(exp.Dot)):
         left = dot_node.this
         right = dot_node.expression
-        if not isinstance(left, exp.Identifier):
-            continue
-        if not isinstance(right, exp.Anonymous):
+        if not isinstance(left, exp.Identifier) or not isinstance(right, exp.Anonymous):
             continue
         dataset = left.name
         routine_name = right.name
         try:
             flat_name = qualified_routine_name_parts(project_id, dataset, routine_name)
         except ValidationError as exc:
-            # The SQL-boundary id whitelist rejected the dataset id —
-            # usually because it's a compound ``project.dataset``
-            # back-ticked qualifier that contained a dot. BigQuery's
-            # user-facing form for this is ``Function not found:
-            # `<qualifier>`.<routine> at [L:C]`` (see ADR 0022 §3).
+            # SQL-boundary id whitelist rejected the dataset id —
+            # usually a compound ``project.dataset`` back-ticked
+            # qualifier that contained a dot. BigQuery's user-facing
+            # form is ``Function not found: `<qualifier>`.<routine> at
+            # [L:C]`` (ADR 0022 §3).
             raise InvalidQueryError(
                 f"Function not found: `{dataset}`.{routine_name} at [1:8]",
                 location="query",
@@ -306,9 +350,26 @@ def _rewrite_schema_qualified_calls(tree: object, project_id: str) -> bool:
         right.set("this", flat_name)
         dot_node.replace(right)
         modified = True
+    return modified
 
+
+def _rewrite_anonymous_dotted_calls(tree: object, project_id: str) -> bool:
+    r"""Flatten ``Anonymous`` nodes whose name itself contains dots.
+
+    Matches ``\`dataset.routine\`(args)`` (a single back-ticked
+    identifier followed by ``(``) — SQLGlot keeps the whole quoted
+    string as the function name. Two- and three-part qualifiers are
+    both accepted; the three-part case lets users prefix with the
+    project id.
+    """
+    from sqlglot import exp
+
+    from bqemulator.domain.errors import InvalidQueryError, ValidationError
+    from bqemulator.udf.naming import qualified_routine_name_parts
+
+    assert isinstance(tree, exp.Expression)  # noqa: S101
+    modified = False
     for anon_node in list(tree.find_all(exp.Anonymous)):
-        # Skip the rewritten ones — they no longer contain a dot.
         name = anon_node.name
         if "." not in name:
             continue

--- a/src/bqemulator/sql/table_rewriter.py
+++ b/src/bqemulator/sql/table_rewriter.py
@@ -211,14 +211,20 @@ def _raise_invalid_dataset_id(dataset_id: str, table_id: str) -> None:
     matching our :data:`_BQ_DATASET_RE`). The wording is reproduced
     verbatim so the conformance ``message_pattern`` matcher absorbs it
     via :doc:`/adr/0023-conformance-error-shape-parity`.
+
+    ``location`` omits the trailing ``.<table>`` segment when
+    ``table_id`` is empty (schema-only DDL paths like
+    ``CREATE SCHEMA proj.<bad-ds>``) so the error shape stays
+    well-formed across both table-bound and schema-only call sites.
     """
     from bqemulator.domain.errors import ValidationError
 
+    location = f"{dataset_id}.{table_id}" if table_id else dataset_id
     raise ValidationError(
         f'Invalid dataset ID "{dataset_id}". '
         "Dataset IDs must be alphanumeric (plus underscores and dashes) "
         "and must be at most 1024 characters long.",
-        location=f"{dataset_id}.{table_id}",
+        location=location,
     )
 
 

--- a/src/bqemulator/sql/translator.py
+++ b/src/bqemulator/sql/translator.py
@@ -381,44 +381,75 @@ class SQLTranslator:
             # SQLGlot produced it, so it should be valid.
             return sql
 
-        if schema:
-            try:
-                tree = qualify(tree, schema=schema, dialect="duckdb", infer_schema=True)
-                tree = annotate_types(tree, schema=schema)
-            except Exception as exc:  # noqa: BLE001
-                _log.debug("sql.annotate_types_skipped", error=str(exc))
+        # ``sqlglot.parse_one`` is typed as ``Expr`` in the stubs; the
+        # runtime value is an :class:`exp.Expression`. Asserting here
+        # narrows it for the rest of the function and the helpers.
+        assert isinstance(tree, exp.Expression)  # noqa: S101
+
+        if schema is not None:
+            tree = self._annotate_tree(tree, schema)
 
         modified = False
         # Snapshot nodes pre-order, then iterate in reverse — children
         # of any parent appear *after* the parent in pre-order, so
         # ``reversed(...)`` gives us a post-order-equivalent traversal.
-        nodes = list(tree.walk())
-        for node in reversed(nodes):
-            if node.parent is None and node is not tree:
-                # Node has been detached by an earlier replacement;
-                # skip it.
-                continue
+        for node in reversed(list(tree.walk())):
             node_expr: exp.Expression = node  # type: ignore[assignment]
-            for rule in self._rules:
-                if rule.applies_to(node_expr):
-                    replacement = rule.rewrite(node_expr)
-                    if replacement is not node:
-                        node.replace(replacement)
-                        modified = True
-                        # Subsequent rules in this pass see the
-                        # original ``node`` — but ``replace`` swapped
-                        # the AST, so any new candidates inside
-                        # ``replacement`` will be picked up either by
-                        # the reversed-walk visit of remaining items
-                        # (if their original positions still exist) or
-                        # not at all. Each rule produces DuckDB-native
-                        # output, so a single post-order pass is
-                        # sufficient.
-                        break
+            if self._apply_first_matching_rule(node_expr, tree):
+                modified = True
 
         if modified:
             return tree.sql(dialect="duckdb")
         return sql
+
+    @staticmethod
+    def _annotate_tree(
+        tree: exp.Expression,
+        schema: dict[str, Any],
+    ) -> exp.Expression:
+        """Run SQLGlot's ``qualify`` + ``annotate_types`` passes.
+
+        Failures are logged and the unannotated tree is returned;
+        rules that need type info gracefully skip. The SQLGlot
+        ``qualify`` / ``annotate_types`` return type is the narrower
+        ``Expr`` from the stubs; in practice both pass-throughs of a
+        :class:`exp.Expression` produce one, so the casts here are
+        safe.
+        """
+        try:
+            qualified: exp.Expression = qualify(  # type: ignore[assignment]
+                tree, schema=schema, dialect="duckdb", infer_schema=True
+            )
+            return annotate_types(qualified, schema=schema)
+        except Exception as exc:  # noqa: BLE001
+            _log.debug("sql.annotate_types_skipped", error=str(exc))
+            return tree
+
+    def _apply_first_matching_rule(
+        self,
+        node: exp.Expression,
+        tree: exp.Expression,
+    ) -> bool:
+        """Apply the first matching rule to ``node`` (in place); return True if replaced.
+
+        Each rule produces DuckDB-native output, so a single
+        post-order pass is sufficient — once a rule replaces ``node``
+        we stop scanning further rules for it. Subsequent reversed-
+        walk iterations pick up the original positions inside the
+        replacement subtree on their own.
+        """
+        if node.parent is None and node is not tree:
+            # Node has been detached by an earlier replacement;
+            # skip it.
+            return False
+        for rule in self._rules:
+            if not rule.applies_to(node):
+                continue
+            replacement = rule.rewrite(node)
+            if replacement is not node:
+                node.replace(replacement)
+                return True
+        return False
 
 
 __all__ = ["SQLTranslator"]

--- a/src/bqemulator/sql/translator.py
+++ b/src/bqemulator/sql/translator.py
@@ -15,7 +15,7 @@ tasks concurrently.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import sqlglot
 from sqlglot import exp
@@ -410,21 +410,20 @@ class SQLTranslator:
         """Run SQLGlot's ``qualify`` + ``annotate_types`` passes.
 
         Failures are logged and the unannotated tree is returned;
-        rules that need type info gracefully skip. The SQLGlot
-        ``qualify`` / ``annotate_types`` return type is the narrower
-        ``Expr`` from the stubs; in practice both pass-throughs of a
-        :class:`exp.Expression` produce one, so the casts here are
-        safe.
+        rules that need type info gracefully skip. The runtime
+        ``isinstance`` check narrows SQLGlot's loosely-typed
+        ``Expr`` return to :class:`exp.Expression` without resorting
+        to a ``cast`` (which different stub revisions flag as either
+        required or redundant).
         """
         try:
-            qualified = cast(
-                "exp.Expression",
-                qualify(tree, schema=schema, dialect="duckdb", infer_schema=True),
-            )
-            return annotate_types(qualified, schema=schema)
+            qualified = qualify(tree, schema=schema, dialect="duckdb", infer_schema=True)
+            annotated = annotate_types(qualified, schema=schema)
         except Exception as exc:  # noqa: BLE001
             _log.debug("sql.annotate_types_skipped", error=str(exc))
             return tree
+        assert isinstance(annotated, exp.Expression)  # noqa: S101 — stub-bridge narrowing
+        return annotated
 
     def _apply_first_matching_rule(
         self,

--- a/src/bqemulator/sql/translator.py
+++ b/src/bqemulator/sql/translator.py
@@ -15,7 +15,7 @@ tasks concurrently.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import sqlglot
 from sqlglot import exp
@@ -417,8 +417,9 @@ class SQLTranslator:
         safe.
         """
         try:
-            qualified: exp.Expression = qualify(  # type: ignore[assignment]
-                tree, schema=schema, dialect="duckdb", infer_schema=True
+            qualified = cast(
+                "exp.Expression",
+                qualify(tree, schema=schema, dialect="duckdb", infer_schema=True),
             )
             return annotate_types(qualified, schema=schema)
         except Exception as exc:  # noqa: BLE001

--- a/tests/unit/sql/test_table_rewriter.py
+++ b/tests/unit/sql/test_table_rewriter.py
@@ -207,6 +207,21 @@ class TestInvalidDatasetId:
         with pytest.raises(ValidationError):
             rewrite_table_refs('SELECT * FROM "ds-with-dash"."tbl"', "proj")
 
+    def test_schema_only_invalid_dataset_id_omits_trailing_dot(self) -> None:
+        """``CREATE/DROP SCHEMA`` paths emit a ``location`` without trailing ``.``.
+
+        The schema-only path has no table component; the dataset-id
+        validator therefore receives an empty ``table_name``. The
+        emitted ``location`` should be the bare ``<dataset>`` form,
+        not ``<dataset>.`` (which is malformed for the error consumer).
+        """
+        from bqemulator.domain.errors import ValidationError
+
+        with pytest.raises(ValidationError) as exc:
+            rewrite_table_refs("CREATE SCHEMA proj.\"!!bad-ds!!\"", "proj")
+        assert exc.value.location == "!!bad-ds!!"
+        assert not exc.value.location.endswith(".")
+
     def test_valid_dataset_id_passes_through(self) -> None:
         result = rewrite_table_refs("SELECT * FROM good_ds.tbl", "proj")
         assert '"proj__good_ds"' in result

--- a/tests/unit/sql/test_table_rewriter.py
+++ b/tests/unit/sql/test_table_rewriter.py
@@ -218,7 +218,7 @@ class TestInvalidDatasetId:
         from bqemulator.domain.errors import ValidationError
 
         with pytest.raises(ValidationError) as exc:
-            rewrite_table_refs("CREATE SCHEMA proj.\"!!bad-ds!!\"", "proj")
+            rewrite_table_refs('CREATE SCHEMA proj."!!bad-ds!!"', "proj")
         assert exc.value.location == "!!bad-ds!!"
         assert not exc.value.location.endswith(".")
 


### PR DESCRIPTION
## Summary

PR-8 of the cyclomatic-complexity C→B initiative. Four C-rank blocks across `sql/{table_rewriter, parameters, translator}.py` drop to **rank B or better**, behaviour-preserving.

| File | Function | Before | After | Strategy |
|------|----------|--------|-------|----------|
| `table_rewriter.py` | `_rewrite_table_node` | C(16) | **B(6)** | Extract `_normalize_qualifier_parts`, `_validate_dataset_id_if_applicable`, `_is_schema_only_ref` |
| `table_rewriter.py` | `_rewrite_schema_qualified_calls` | C(11) | **A(3)** | Split into `_rewrite_dot_anonymous_calls` + `_rewrite_anonymous_dotted_calls` |
| `parameters.py` | `_extract_value` | C(16) | **A(5)** | `_SCALAR_CONVERTERS` dispatch dict + 6 `_coerce_*` helpers + 2 nested-shape helpers |
| `translator.py` | `SQLTranslator._apply_rules` | C(11) | **B(6)** | Extract `_annotate_tree` (qualify + annotate_types) + `_apply_first_matching_rule` (per-node rule loop) |

### Numbers

Repo-wide C-block count: **15 → 11** (cumulative through PRs 1–8: **59 → 11**, 81% reduction).
Gate stays at `--max-absolute C`; flip to B in PR-12.

## Test plan

- [x] `radon cc --min C` empty across the 3 touched files
- [x] `xenon --max-absolute B --max-modules B --max-average A` passes (exit 0)
- [x] `ruff check` + `ruff format --check` clean · `mypy` clean
- [x] All 929 `tests/unit/sql/*` tests pass — no regressions
- [ ] Full CI (unit + property + integration + conformance + e2e matrix) — verified via GitHub Actions on this PR

## Next

After this PR merges, the campaign pauses for a session compact (per the agreed cadence). The remaining 11 C-blocks split across the hard cluster:
- gRPC + streaming (PR-9, 4 blocks)
- scripting/* (PR-10, ~8 blocks)
- jobs/executor.py (PR-11, ~6 blocks)
- xenon gate flip + ADR 0041 (PR-12, paused for user approval)

Each of PRs 9/10/11 gets a full-validation gate (test matrix + e2e + container build) before opening, per the updated auto-pilot rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved parameter parsing and type coercion for more reliable handling of arrays, structs, timestamps (with timezone normalization) and scalar types.
  * Reworked table reference handling with stricter qualification, dataset-id validation, and safer schema-only reference treatment to avoid invalid identifiers.
  * Streamlined SQL translation and rule-application flow to apply rules more deterministically and avoid unnecessary rewrites.
* **Tests**
  * Added a unit test ensuring schema-only dataset error locations are reported without trailing punctuation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->