### PR TITLE
refactor(complexity): drop gRPC + streaming blocks below rank C

### DIFF
--- a/src/bqemulator/grpc_api/read_servicer.py
+++ b/src/bqemulator/grpc_api/read_servicer.py
@@ -144,6 +144,108 @@ def _build_read_sql(
     return sql
 
 
+def _resolve_read_target(
+    read_session: Any,
+    context: grpc.ServicerContext,
+) -> tuple[str, str, str, str, list[str] | None] | None:
+    """Parse + validate the read session's table reference.
+
+    Returns ``(project_id, dataset_id, table_id, target_ref,
+    selected_fields)`` or ``None`` on validation failure (the caller
+    short-circuits with an empty response; ``context`` status is
+    already set with INVALID_ARGUMENT).
+    """
+    parsed = _parse_table_path(read_session.table)
+    if parsed is None:
+        context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+        context.set_details(f"Invalid table path: {read_session.table}")
+        return None
+    project_id, dataset_id, table_id = parsed
+
+    try:
+        target_ref = quoted_table_ref(project_id, dataset_id, table_id)
+        selected_fields = _selected_fields(read_session)
+    except ValidationError as exc:
+        context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+        context.set_details(str(exc))
+        return None
+    return project_id, dataset_id, table_id, target_ref, selected_fields
+
+
+def _resolve_data_format(
+    read_session: Any,
+    context: grpc.ServicerContext,
+) -> tuple[str, Any] | None:
+    """Map the raw ``data_format`` proto enum to (session_format, wire_format).
+
+    The Java BQ Storage Read client defaults to AVRO; Python / Go /
+    Node default to ARROW. The proto3 default for an unset
+    ``DataFormat`` is 0 (``DATA_FORMAT_UNSPECIFIED``) — match real
+    BQ's behaviour and treat that as ARROW. Any other value (a
+    hypothetical future PROTO format) gets INVALID_ARGUMENT.
+
+    Read the raw underlying-pb int rather than the proto-plus
+    property so an unknown enum value doesn't trip proto-plus's
+    warnings-as-errors path under the test runner.
+
+    Returns ``None`` on an unsupported format with ``context`` already
+    set to INVALID_ARGUMENT.
+    """
+    from google.cloud.bigquery_storage_v1 import types
+
+    raw_format = read_session._pb.data_format  # noqa: SLF001
+    if raw_format in (
+        int(types.DataFormat.DATA_FORMAT_UNSPECIFIED),
+        int(types.DataFormat.ARROW),
+    ):
+        return FORMAT_ARROW, types.DataFormat.ARROW
+    if raw_format == int(types.DataFormat.AVRO):
+        return FORMAT_AVRO, types.DataFormat.AVRO
+    context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+    context.set_details(
+        f"Unsupported data_format: {raw_format!r}; supported: ARROW, AVRO",
+    )
+    return None
+
+
+def _build_read_session_response(
+    *,
+    state: Any,
+    read_session: Any,
+    session_format: str,
+    wire_format: Any,
+    arrow_table: pa.Table,
+) -> Any:
+    """Build the ReadSession response proto.
+
+    Real BigQuery echoes ``read_options`` back on the session so
+    clients can confirm the projection / filter / compression they
+    asked for; the wire-format conformance suite asserts that shape.
+    The schema field carried on the session depends on the chosen
+    wire format — Arrow sessions carry ``arrow_schema``, Avro
+    sessions carry ``avro_schema`` (proto oneof).
+    """
+    from google.cloud.bigquery_storage_v1 import types
+
+    session_kwargs: dict[str, Any] = {
+        "name": state.session_name,
+        "table": read_session.table,
+        "data_format": wire_format,
+        "streams": [types.ReadStream(name=s.name) for s in state.streams],
+        "estimated_total_bytes_scanned": arrow_table.nbytes,
+        "read_options": read_session.read_options or None,
+    }
+    if session_format == FORMAT_AVRO:
+        session_kwargs["avro_schema"] = types.AvroSchema(
+            schema=state.avro_schema_json,
+        )
+    else:
+        session_kwargs["arrow_schema"] = types.ArrowSchema(
+            serialized_schema=state.arrow_schema_bytes,
+        )
+    return types.ReadSession(**session_kwargs)
+
+
 if TYPE_CHECKING:
     from bqemulator.api.dependencies import AppContext
 
@@ -207,7 +309,7 @@ class BigQueryReadHandler(grpc.GenericRpcHandler):
             )
         return None
 
-    def _handle_create_read_session(  # noqa: PLR0915 — linear gRPC dispatch
+    def _handle_create_read_session(
         self,
         request_bytes: bytes,
         context: grpc.ServicerContext,
@@ -218,20 +320,10 @@ class BigQueryReadHandler(grpc.GenericRpcHandler):
         request = types.CreateReadSessionRequest.deserialize(request_bytes)
         read_session = request.read_session
 
-        parsed = _parse_table_path(read_session.table)
-        if parsed is None:
-            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-            context.set_details(f"Invalid table path: {read_session.table}")
+        target = _resolve_read_target(read_session, context)
+        if target is None:
             return b""
-        project_id, dataset_id, table_id = parsed
-
-        try:
-            target_ref = quoted_table_ref(project_id, dataset_id, table_id)
-            selected_fields = _selected_fields(read_session)
-        except ValidationError as exc:
-            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-            context.set_details(str(exc))
-            return b""
+        project_id, dataset_id, table_id, target_ref, selected_fields = target
 
         # Resolve the caller from gRPC metadata up-front so both the
         # row_restriction filter pre-pass (inside ``_build_read_sql``)
@@ -248,129 +340,126 @@ class BigQueryReadHandler(grpc.GenericRpcHandler):
         )
 
         sql = _build_read_sql(target_ref, selected_fields, read_session, caller=caller)
-
-        # Enforce row access policies on the Storage Read path. The
-        # caller was already resolved above. The rewriter wraps the
-        # protected table in a derived subquery with the policy's
-        # filter (or WHERE FALSE on no-match). We then run that
-        # rewritten SQL against DuckDB. Tables with no policies
-        # short-circuit at the rewriter so the cheap-path keeps the
-        # original DuckDB SQL.
-        if self._ctx.catalog.list_all_row_access_policies():
-            bq_sql = self._build_bq_read_sql(
-                project_id,
-                dataset_id,
-                table_id,
-                selected_fields,
-                read_session,
-            )
-            rewritten = rewrite_for_row_access(
-                bq_sql,
-                project_id=project_id,
-                caller=caller,
-                catalog=self._ctx.catalog,
-            )
-            if rewritten != bq_sql:
-                from bqemulator.sql.table_rewriter import rewrite_table_refs
-                from bqemulator.sql.translator import SQLTranslator
-
-                translate_result = SQLTranslator().translate(rewritten, caller=caller)
-                if hasattr(translate_result, "value"):
-                    duckdb_sql = translate_result.value
-                else:  # pragma: no cover — translator returned an Err
-                    context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-                    context.set_details("row-access rewrite failed to translate")
-                    return b""
-                sql = rewrite_table_refs(duckdb_sql, project_id)
+        sql_after_rap = self._apply_row_access_rewrite(
+            sql=sql,
+            project_id=project_id,
+            dataset_id=dataset_id,
+            table_id=table_id,
+            selected_fields=selected_fields,
+            read_session=read_session,
+            caller=caller,
+            context=context,
+        )
+        if sql_after_rap is None:
+            return b""
 
         try:
-            arrow_table = self._ctx.engine.fetch_arrow(sql)
+            arrow_table = self._ctx.engine.fetch_arrow(sql_after_rap)
         except Exception as exc:  # noqa: BLE001 — DuckDB can throw various exceptions
             context.set_code(grpc.StatusCode.NOT_FOUND)
             context.set_details(f"Table read failed: {exc}")
             return b""
 
-        # Decide the wire format. The Java BQ Storage Read client
-        # defaults to AVRO; Python / Go / Node default to ARROW. The
-        # proto3 default for an unset DataFormat is 0 (DATA_FORMAT_
-        # UNSPECIFIED) — match real BQ's behaviour and treat that as
-        # ARROW. Any other value (a hypothetical future PROTO format)
-        # gets INVALID_ARGUMENT.
-        #
-        # Read the raw underlying-pb int rather than the proto-plus
-        # property so an unknown enum value doesn't trip proto-plus's
-        # warnings-as-errors path under the test runner.
-        raw_format = read_session._pb.data_format  # noqa: SLF001
-        if raw_format in (
-            int(types.DataFormat.DATA_FORMAT_UNSPECIFIED),
-            int(types.DataFormat.ARROW),
-        ):
-            session_format = FORMAT_ARROW
-            wire_format = types.DataFormat.ARROW
-        elif raw_format == int(types.DataFormat.AVRO):
-            session_format = FORMAT_AVRO
-            wire_format = types.DataFormat.AVRO
-        else:
-            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-            context.set_details(
-                f"Unsupported data_format: {raw_format!r}; supported: ARROW, AVRO",
-            )
+        formats = _resolve_data_format(read_session, context)
+        if formats is None:
             return b""
-
-        # Look up the source table's catalog metadata so the Avro
-        # schema emitter can honour ``mode='REQUIRED'``. DuckDB's
-        # query-result schema marks every column nullable regardless
-        # of the source-table REQUIRED flag — without this lookup,
-        # the Storage Read Avro path would wrap every column in a
-        # ``["null", T]`` union and diverge from real BigQuery's
-        # canonical schema. Falls back gracefully when the table is
-        # not in the catalog (synthetic / temp / dry-run queries).
-        required_field_names: frozenset[str] | None = None
-        catalog_table = self._ctx.catalog.get_table(project_id, dataset_id, table_id)
-        if catalog_table is not None:
-            required_field_names = frozenset(
-                f.name for f in catalog_table.schema_.fields if f.mode == "REQUIRED"
-            )
+        session_format, wire_format = formats
 
         # Create the read session.
-        max_streams = request.max_stream_count or 1
         state = create_read_session(
             project_id=project_id,
             table_ref=read_session.table,
             arrow_table=arrow_table,
-            max_streams=max_streams,
+            max_streams=request.max_stream_count or 1,
             selected_fields=selected_fields,
             data_format=session_format,
-            required_field_names=required_field_names,
+            required_field_names=self._required_field_names(
+                project_id,
+                dataset_id,
+                table_id,
+            ),
         )
 
-        # Build the response. Real BigQuery echoes ``read_options`` back on
-        # the session so clients can confirm the projection / filter /
-        # compression they asked for; the wire-format conformance suite
-        # asserts that shape. The schema field carried on the session
-        # depends on the chosen wire format — Arrow sessions carry
-        # ``arrow_schema``, Avro sessions carry ``avro_schema`` (proto
-        # oneof).
-        session_kwargs: dict[str, Any] = {
-            "name": state.session_name,
-            "table": read_session.table,
-            "data_format": wire_format,
-            "streams": [types.ReadStream(name=s.name) for s in state.streams],
-            "estimated_total_bytes_scanned": arrow_table.nbytes,
-            "read_options": read_session.read_options or None,
-        }
-        if session_format == FORMAT_AVRO:
-            session_kwargs["avro_schema"] = types.AvroSchema(
-                schema=state.avro_schema_json,
-            )
-        else:
-            session_kwargs["arrow_schema"] = types.ArrowSchema(
-                serialized_schema=state.arrow_schema_bytes,
-            )
-        response = types.ReadSession(**session_kwargs)
-
+        response = _build_read_session_response(
+            state=state,
+            read_session=read_session,
+            session_format=session_format,
+            wire_format=wire_format,
+            arrow_table=arrow_table,
+        )
         self._ctx.metrics.read_streams_active.inc(len(state.streams))
         return types.ReadSession.serialize(response)
+
+    def _apply_row_access_rewrite(
+        self,
+        *,
+        sql: str,
+        project_id: str,
+        dataset_id: str,
+        table_id: str,
+        selected_fields: list[str] | None,
+        read_session: Any,
+        caller: CallerIdentity,
+        context: grpc.ServicerContext,
+    ) -> str | None:
+        """Apply row-access-policy rewrite if any policies are registered.
+
+        Returns the (possibly unchanged) SQL or ``None`` on rewrite
+        failure — the caller short-circuits with an empty response in
+        that case (context status is already set).
+
+        Tables with no registered policies short-circuit at the
+        rewriter so the cheap-path keeps the original DuckDB SQL.
+        """
+        if not self._ctx.catalog.list_all_row_access_policies():
+            return sql
+
+        bq_sql = self._build_bq_read_sql(
+            project_id,
+            dataset_id,
+            table_id,
+            selected_fields,
+            read_session,
+        )
+        rewritten = rewrite_for_row_access(
+            bq_sql,
+            project_id=project_id,
+            caller=caller,
+            catalog=self._ctx.catalog,
+        )
+        if rewritten == bq_sql:
+            return sql
+
+        from bqemulator.sql.table_rewriter import rewrite_table_refs
+        from bqemulator.sql.translator import SQLTranslator
+
+        translate_result = SQLTranslator().translate(rewritten, caller=caller)
+        if not hasattr(translate_result, "value"):  # pragma: no cover — translator Err
+            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+            context.set_details("row-access rewrite failed to translate")
+            return None
+        return rewrite_table_refs(translate_result.value, project_id)
+
+    def _required_field_names(
+        self,
+        project_id: str,
+        dataset_id: str,
+        table_id: str,
+    ) -> frozenset[str] | None:
+        """Return REQUIRED column names from the catalog for the Avro emitter.
+
+        DuckDB's query-result schema marks every column nullable
+        regardless of the source-table REQUIRED flag — without this
+        lookup, the Storage Read Avro path would wrap every column in
+        a ``["null", T]`` union and diverge from real BigQuery's
+        canonical schema. Returns ``None`` when the table is not in
+        the catalog (synthetic / temp / dry-run queries) so the Avro
+        emitter falls through to its nullable-by-default behaviour.
+        """
+        catalog_table = self._ctx.catalog.get_table(project_id, dataset_id, table_id)
+        if catalog_table is None:
+            return None
+        return frozenset(f.name for f in catalog_table.schema_.fields if f.mode == "REQUIRED")
 
     def _handle_read_rows(
         self,

--- a/src/bqemulator/grpc_api/write_servicer.py
+++ b/src/bqemulator/grpc_api/write_servicer.py
@@ -468,10 +468,9 @@ class BigQueryWriteHandler(grpc.GenericRpcHandler):
         """
         from google.cloud.bigquery_storage_v1 import types
 
+        bound_ctx: tuple[WriteStream, pa.Schema] | None = None
         proto_decoder: ProtoRowDecoder | None = None
         arrow_schema_bytes: bytes | None = None
-        bound_stream: WriteStream | None = None
-        target_schema: pa.Schema | None = None
 
         max_request_bytes = self._ctx.settings.write_api_max_request_bytes
         max_buffered_rows = self._ctx.settings.write_api_max_stream_rows
@@ -481,45 +480,22 @@ class BigQueryWriteHandler(grpc.GenericRpcHandler):
             # deserialising so a malicious producer can't OOM the server
             # with a single giant Arrow/proto payload.
             if len(request_bytes) > max_request_bytes:
-                yield _error_response(
-                    bound_stream.name if bound_stream else "",
-                    (
-                        f"AppendRowsRequest exceeds the "
-                        f"{max_request_bytes}-byte size cap "
-                        f"({len(request_bytes)} bytes). "
-                        "Split the payload into smaller batches."
-                    ),
-                    status_code=grpc.StatusCode.RESOURCE_EXHAUSTED,
+                yield _oversize_error_response(
+                    request_bytes_len=len(request_bytes),
+                    max_bytes=max_request_bytes,
+                    bound_ctx=bound_ctx,
                 )
                 continue
 
             request = types.AppendRowsRequest.deserialize(request_bytes)
-            stream_name = request.write_stream
-
-            # Resolve the stream on first message (or whenever it changes —
-            # the real service requires a single stream per connection, but
-            # we resolve defensively).
-            if bound_stream is None or bound_stream.name != stream_name:
-                bound_stream = self._resolve_append_stream(stream_name, context)
-                if bound_stream is None:
-                    return
-                table_meta = self._ctx.catalog.get_table(
-                    bound_stream.project_id,
-                    bound_stream.dataset_id,
-                    bound_stream.table_id,
-                )
-                if table_meta is None:
-                    context.set_code(grpc.StatusCode.NOT_FOUND)
-                    context.set_details(
-                        f"Table gone: {bound_stream.project_id}."
-                        f"{bound_stream.dataset_id}.{bound_stream.table_id}",
-                    )
-                    return
-                target_schema = _table_arrow_schema(table_meta)
-
-            # bound_stream and target_schema are both set after the branch above.
-            if bound_stream is None or target_schema is None:  # pragma: no cover
+            bound_ctx = self._ensure_stream_bound(
+                request.write_stream,
+                bound_ctx,
+                context,
+            )
+            if bound_ctx is None:
                 return
+            bound_stream, target_schema = bound_ctx
 
             # Convert rows to a pyarrow.Table in the target schema.
             try:
@@ -533,37 +509,93 @@ class BigQueryWriteHandler(grpc.GenericRpcHandler):
                 yield _error_response(bound_stream.name, str(exc))
                 continue
 
-            strategy = select_strategy(bound_stream.stream_type)
             # proto-plus auto-unwraps Int64Value → int; presence is tracked
             # on the underlying protobuf message — accessed via the
             # public ``proto.Message.pb()`` classmethod.
             offset = int(request.offset) if _has_offset(request) else None
+            yield self._perform_append(
+                bound_stream,
+                rows_table,
+                offset,
+                max_buffered_rows,
+            )
 
-            # Serialise AppendRows per-stream so a misbehaving client that
-            # opens two connections on one stream can't race ``next_offset``
-            # or ``buffer``. Real BigQuery documents that only one
-            # connection may be open per stream; we enforce the invariant
-            # defensively.
-            with bound_stream.lock:
-                outcome = strategy.append(
-                    bound_stream,
-                    rows_table,
-                    offset,
-                    max_buffered_rows=max_buffered_rows,
+    def _ensure_stream_bound(
+        self,
+        stream_name: str,
+        bound_ctx: tuple[WriteStream, pa.Schema] | None,
+        context: grpc.ServicerContext,
+    ) -> tuple[WriteStream, pa.Schema] | None:
+        """Return the current bound context or rebind to ``stream_name``.
+
+        Returns ``None`` to signal a terminal error (``context`` already
+        carries the gRPC status code). Real BigQuery requires a single
+        stream per connection, but we rebind defensively if the client
+        switches streams mid-stream.
+        """
+        if bound_ctx is not None and bound_ctx[0].name == stream_name:
+            return bound_ctx
+        return self._bind_stream_to_target(stream_name, context)
+
+    def _bind_stream_to_target(
+        self,
+        stream_name: str,
+        context: grpc.ServicerContext,
+    ) -> tuple[WriteStream, pa.Schema] | None:
+        """Resolve a stream and pull its target Arrow schema.
+
+        Returns ``None`` when either the stream can't be resolved or its
+        target table is gone (``context`` already carries the gRPC
+        status code).
+        """
+        bound = self._resolve_append_stream(stream_name, context)
+        if bound is None:
+            return None
+        table_meta = self._ctx.catalog.get_table(
+            bound.project_id,
+            bound.dataset_id,
+            bound.table_id,
+        )
+        if table_meta is None:
+            context.set_code(grpc.StatusCode.NOT_FOUND)
+            context.set_details(
+                f"Table gone: {bound.project_id}.{bound.dataset_id}.{bound.table_id}",
+            )
+            return None
+        return bound, _table_arrow_schema(table_meta)
+
+    def _perform_append(
+        self,
+        bound_stream: WriteStream,
+        rows_table: pa.Table,
+        offset: int | None,
+        max_buffered_rows: int,
+    ) -> bytes:
+        """Append ``rows_table`` under the per-stream lock and return the response.
+
+        Serialise AppendRows per-stream so a misbehaving client that
+        opens two connections on one stream can't race ``next_offset``
+        or ``buffer``. Real BigQuery documents that only one
+        connection may be open per stream; we enforce the invariant
+        defensively.
+        """
+        strategy = select_strategy(bound_stream.stream_type)
+        with bound_stream.lock:
+            outcome = strategy.append(
+                bound_stream,
+                rows_table,
+                offset,
+                max_buffered_rows=max_buffered_rows,
+            )
+            if outcome.status is not AppendStatus.OK:
+                return _error_response(
+                    bound_stream.name,
+                    outcome.detail,
+                    status_code=_proto_to_grpc_status(outcome.status),
                 )
-
-                if outcome.status is not AppendStatus.OK:
-                    yield _error_response(
-                        bound_stream.name,
-                        outcome.detail,
-                        status_code=_proto_to_grpc_status(outcome.status),
-                    )
-                    continue
-
-                if outcome.committed_rows is not None and outcome.committed_rows.num_rows > 0:
-                    self._flush_to_target(bound_stream, outcome.committed_rows)
-
-            yield _ok_response(bound_stream.name, outcome)
+            if outcome.committed_rows is not None and outcome.committed_rows.num_rows > 0:
+                self._flush_to_target(bound_stream, outcome.committed_rows)
+        return _ok_response(bound_stream.name, outcome)
 
     # -- helpers -------------------------------------------------------------
 
@@ -776,6 +808,30 @@ def _ok_response(stream_name: str, outcome: AppendOutcome) -> bytes:
         write_stream=stream_name,
     )
     return types.AppendRowsResponse.serialize(response)
+
+
+def _oversize_error_response(
+    *,
+    request_bytes_len: int,
+    max_bytes: int,
+    bound_ctx: tuple[WriteStream, pa.Schema] | None,
+) -> bytes:
+    """Build the RESOURCE_EXHAUSTED response for an over-size AppendRows request.
+
+    The stream-name field on the response carries the active stream
+    when one is bound (so the client correlates the error to its
+    open writer); on a not-yet-bound connection it stays empty.
+    """
+    stream_name = bound_ctx[0].name if bound_ctx else ""
+    return _error_response(
+        stream_name,
+        (
+            f"AppendRowsRequest exceeds the {max_bytes}-byte size cap "
+            f"({request_bytes_len} bytes). "
+            "Split the payload into smaller batches."
+        ),
+        status_code=grpc.StatusCode.RESOURCE_EXHAUSTED,
+    )
 
 
 def _error_response(

--- a/src/bqemulator/streaming/read_session.py
+++ b/src/bqemulator/streaming/read_session.py
@@ -20,6 +20,7 @@ the same format without re-deriving it from the request.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 import io
 from uuid import uuid4
@@ -74,6 +75,95 @@ _SESSIONS: dict[str, ReadSessionState] = {}
 _SMALL_TABLE_BYTE_THRESHOLD = 1_000_000
 
 
+def _project_columns(
+    arrow_table: pa.Table,
+    selected_fields: list[str] | None,
+) -> pa.Table:
+    """Apply ``selected_fields`` column projection if any non-missing columns survive."""
+    if not selected_fields:
+        return arrow_table
+    available = set(arrow_table.column_names)
+    cols = [c for c in selected_fields if c in available]
+    if not cols:
+        return arrow_table
+    return arrow_table.select(cols)
+
+
+def _compute_stream_layout(
+    num_rows: int,
+    table_bytes: int,
+    max_streams: int,
+) -> tuple[int, int]:
+    """Return ``(effective_streams, chunk_size)`` for a session.
+
+    Real BigQuery treats ``max_stream_count`` as an upper bound and
+    returns fewer streams when the table is too small to benefit from
+    parallel reads — empirically, tables under ~1 MB get 1 stream
+    regardless. The 10-stream ceiling mirrors observed wire behaviour
+    on the gRPC-corpus conformance suite.
+    """
+    requested = max(max_streams, 1)
+    if table_bytes < _SMALL_TABLE_BYTE_THRESHOLD:
+        # Small-table cap: 1 stream regardless of max_stream_count.
+        effective_streams = 1 if num_rows > 0 else 0
+    else:
+        effective_streams = min(requested, 10, max(num_rows, 1))
+    chunk_size = max(num_rows // effective_streams, 1) if effective_streams > 0 else 0
+    return effective_streams, chunk_size
+
+
+def _build_streams(
+    session_name: str,
+    effective_streams: int,
+    chunk_size: int,
+    num_rows: int,
+) -> list[ReadStream]:
+    """Mint ``effective_streams`` :class:`ReadStream` entries covering ``num_rows``."""
+    streams: list[ReadStream] = []
+    for i in range(effective_streams):
+        start = i * chunk_size
+        end = (i + 1) * chunk_size if i < effective_streams - 1 else num_rows
+        if start >= num_rows:
+            break
+        stream_name = f"{session_name}/streams/{i}"
+        streams.append(ReadStream(name=stream_name, start_row=start, end_row=end))
+    return streams
+
+
+def _serialise_arrow_schema(schema: pa.Schema) -> bytes:
+    """Return the Arrow IPC ``Schema`` message bytes for ``schema``.
+
+    pyarrow 24.x stubs mark ``pa.ipc.new_stream`` as untyped; earlier
+    versions ship a proper signature. ``unused-ignore`` keeps the
+    suppression cross-version-compatible.
+    """
+    schema_sink = io.BytesIO()
+    writer = pa.ipc.new_stream(schema_sink, schema)  # type: ignore[no-untyped-call,unused-ignore]
+    writer.close()
+    return schema_sink.getvalue()
+
+
+def _avro_schema_for(
+    arrow_schema: pa.Schema,
+    data_format: str,
+    required_field_names: frozenset[str] | None,
+) -> str:
+    """Return the Avro JSON schema string for AVRO sessions; empty for ARROW.
+
+    Pre-computed once at session creation so every :func:`ReadRows`
+    call (and any split-stream child) serves the same schema without
+    re-deriving it.
+    """
+    if data_format != FORMAT_AVRO:
+        return ""
+    from bqemulator.streaming.avro_serializer import arrow_schema_to_avro_json
+
+    return arrow_schema_to_avro_json(
+        arrow_schema,
+        required_field_names=required_field_names,
+    )
+
+
 def create_read_session(
     project_id: str,
     table_ref: str,  # noqa: ARG001 — used for session naming context in future
@@ -107,59 +197,24 @@ def create_read_session(
         A :class:`ReadSessionState` with the materialized data and
         stream assignments.
     """
-    # Apply column projection if requested.
-    if selected_fields:
-        available = set(arrow_table.column_names)
-        cols = [c for c in selected_fields if c in available]
-        if cols:
-            arrow_table = arrow_table.select(cols)
+    arrow_table = _project_columns(arrow_table, selected_fields)
 
     session_id = uuid4().hex[:16]
     session_name = f"projects/{project_id}/locations/US/sessions/{session_id}"
 
-    # Split rows across streams. Real BigQuery treats
-    # ``max_stream_count`` as an upper bound and returns fewer streams
-    # when the table is too small to benefit from parallel reads —
-    # empirically, tables under ~1 MB get 1 stream regardless. Match
-    # that contract so the gRPC-corpus wire-format diff holds.
     num_rows = arrow_table.num_rows
-    table_bytes = arrow_table.nbytes
-    requested = max(max_streams, 1)
-    if table_bytes < _SMALL_TABLE_BYTE_THRESHOLD:
-        # Small-table cap: 1 stream regardless of max_stream_count.
-        effective_streams = 1 if num_rows > 0 else 0
-    else:
-        effective_streams = min(requested, 10, max(num_rows, 1))
-    chunk_size = max(num_rows // effective_streams, 1) if effective_streams > 0 else 0
-
-    streams: list[ReadStream] = []
-    for i in range(effective_streams):
-        start = i * chunk_size
-        end = (i + 1) * chunk_size if i < effective_streams - 1 else num_rows
-        if start >= num_rows:
-            break
-        stream_name = f"{session_name}/streams/{i}"
-        streams.append(ReadStream(name=stream_name, start_row=start, end_row=end))
-
-    # pyarrow 24.x stubs mark ``pa.ipc.new_stream`` as untyped; earlier
-    # versions ship a proper signature. ``unused-ignore`` keeps the
-    # suppression cross-version-compatible.
-    schema_sink = io.BytesIO()
-    writer = pa.ipc.new_stream(schema_sink, arrow_table.schema)  # type: ignore[no-untyped-call,unused-ignore]
-    writer.close()
-    schema_bytes = schema_sink.getvalue()
-
-    # Pre-compute the Avro schema JSON for AVRO sessions so every
-    # ReadRows call (and any split-stream child) serves the same
-    # schema without re-deriving it. Arrow sessions skip this.
-    avro_schema_json = ""
-    if data_format == FORMAT_AVRO:
-        from bqemulator.streaming.avro_serializer import arrow_schema_to_avro_json
-
-        avro_schema_json = arrow_schema_to_avro_json(
-            arrow_table.schema,
-            required_field_names=required_field_names,
-        )
+    effective_streams, chunk_size = _compute_stream_layout(
+        num_rows,
+        arrow_table.nbytes,
+        max_streams,
+    )
+    streams = _build_streams(session_name, effective_streams, chunk_size, num_rows)
+    schema_bytes = _serialise_arrow_schema(arrow_table.schema)
+    avro_schema_json = _avro_schema_for(
+        arrow_table.schema,
+        data_format,
+        required_field_names,
+    )
 
     state = ReadSessionState(
         session_name=session_name,
@@ -242,6 +297,50 @@ def split_stream(stream_name: str, fraction: float) -> tuple[str, str] | None:
     return primary_name, remainder_name
 
 
+def _is_any_list_type(arrow_type: pa.DataType) -> bool:
+    """True for list, large_list, or fixed_size_list (single-value-type containers)."""
+    return (
+        pa.types.is_list(arrow_type)
+        or pa.types.is_large_list(arrow_type)
+        or pa.types.is_fixed_size_list(arrow_type)
+    )
+
+
+def _list_child_types(arrow_type: pa.DataType) -> Iterable[pa.DataType]:
+    yield arrow_type.value_type
+
+
+def _map_child_types(arrow_type: pa.DataType) -> Iterable[pa.DataType]:
+    yield arrow_type.key_type
+    yield arrow_type.item_type
+
+
+def _struct_or_union_child_types(arrow_type: pa.DataType) -> Iterable[pa.DataType]:
+    for field_ in arrow_type:
+        yield field_.type
+
+
+#: Dispatch table for ``_type_contains_dictionary``. Each entry pairs a
+#: matcher with a child-type generator; the first matching entry decides
+#: whether any nested child carries a dictionary. Keeping the dispatch
+#: as data instead of inlined ``if`` branches drops the function's
+#: cyclomatic complexity below the C-rank ceiling without changing the
+#: traversal contract (top-level dict short-circuits; everything else
+#: walks its children).
+_NESTED_TYPE_DISPATCH: tuple[
+    tuple[
+        Callable[[pa.DataType], bool],
+        Callable[[pa.DataType], Iterable[pa.DataType]],
+    ],
+    ...,
+] = (
+    (pa.types.is_struct, _struct_or_union_child_types),
+    (_is_any_list_type, _list_child_types),
+    (pa.types.is_map, _map_child_types),
+    (pa.types.is_union, _struct_or_union_child_types),
+)
+
+
 def _type_contains_dictionary(arrow_type: pa.DataType) -> bool:
     """Return ``True`` if ``arrow_type`` or any nested child is dict-encoded.
 
@@ -252,20 +351,9 @@ def _type_contains_dictionary(arrow_type: pa.DataType) -> bool:
     """
     if pa.types.is_dictionary(arrow_type):
         return True
-    if pa.types.is_struct(arrow_type):
-        return any(_type_contains_dictionary(f.type) for f in arrow_type)
-    if (
-        pa.types.is_list(arrow_type)
-        or pa.types.is_large_list(arrow_type)
-        or pa.types.is_fixed_size_list(arrow_type)
-    ):
-        return _type_contains_dictionary(arrow_type.value_type)
-    if pa.types.is_map(arrow_type):
-        return _type_contains_dictionary(arrow_type.key_type) or _type_contains_dictionary(
-            arrow_type.item_type
-        )
-    if pa.types.is_union(arrow_type):
-        return any(_type_contains_dictionary(f.type) for f in arrow_type)
+    for matcher, child_types_fn in _NESTED_TYPE_DISPATCH:
+        if matcher(arrow_type):
+            return any(_type_contains_dictionary(t) for t in child_types_fn(arrow_type))
     return False
 
 


### PR DESCRIPTION
## Summary

PR-9 of the C→B cyclomatic-complexity refactor campaign (gates flip in PR-12). Decomposes the four C-rank blocks in the gRPC servicer + streaming modules into smaller helpers so they fit under the upcoming B ceiling. Pure structural refactor — no behaviour change.

## Refactors

| Symbol | Before | After |
| --- | --- | --- |
| ``BigQueryReadHandler._handle_create_read_session`` | C(17) | B(7) |
| ``BigQueryWriteHandler._handle_append_rows`` | C(15) | B(6) |
| ``streaming.create_read_session`` | C(12) | A(1) |
| ``streaming._type_contains_dictionary`` | C(11) | A(5) |

### ``_handle_create_read_session`` (read_servicer.py)
Extracted five helpers:
- ``_resolve_read_target`` — table-path + selected-fields validation
- ``_resolve_data_format`` — proto-enum → (session_format, wire_format) pair
- ``_apply_row_access_rewrite`` — RAP rewrite path with translator round-trip
- ``_required_field_names`` — catalog REQUIRED lookup for the Avro emitter
- ``_build_read_session_response`` — response proto assembly

### ``_handle_append_rows`` (write_servicer.py)
- Collapsed ``bound_stream`` + ``target_schema`` into a single ``bound_ctx`` tuple state — eliminates the defensive ``pragma: no cover`` narrowing check.
- Extracted ``_ensure_stream_bound`` (no-op-on-same-stream short-circuit), ``_bind_stream_to_target`` (resolve + table-meta lookup), ``_perform_append`` (locked append + flush + response).
- Module-level ``_oversize_error_response`` builder for the size-guard branch.

### ``create_read_session`` (streaming/read_session.py)
Extracted ``_project_columns``, ``_compute_stream_layout``, ``_build_streams``, ``_serialise_arrow_schema``, and ``_avro_schema_for`` so the orchestrator is straight-line.

### ``_type_contains_dictionary`` (streaming/read_session.py)
Replaced the if/elif/else cascade over nested Arrow types with a ``_NESTED_TYPE_DISPATCH`` data table of ``(matcher, child-types-fn)`` pairs.

## Validation

- ``make verify`` — lint + complexity + unit + integration + matrices + docker-build clean.
- 187 storage tests pass (unit + integration; one pre-existing skip for ``avro-tools``).
- E2E nodejs failures (admin/* + GCS Avro round-trip) confirmed pre-existing on ``main`` — they require ``BQEMU_ADMIN_ENABLED`` and ``BQEMU_GCS_LOCAL_ROOT`` env config that the local container fixture doesn't set; CI provides them.
- Remaining C-block count: **21 → 17** (PR-10 targets scripting/*; PR-11 targets jobs/*).

## Test plan

- [ ] CI green across the full matrix (lint, type, unit, property, integration, e2e × 5 clients, conformance, coverage)
- [ ] CodeRabbit clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for BigQuery read request processing with better separation of concerns for validation and response handling.
  * Enhanced write stream management with more efficient append operations and better error handling for oversized requests.
  * Streamlined session creation and type detection logic to improve system reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->