### PR TITLE
refactor(complexity): drop scripting/* blocks below rank C

### DIFF
--- a/src/bqemulator/scripting/interpreter.py
+++ b/src/bqemulator/scripting/interpreter.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import contextlib
 from dataclasses import dataclass
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 import uuid
 
 import pyarrow as pa
@@ -186,46 +186,59 @@ class ScriptInterpreter:
 
     # -- Dispatch --------------------------------------------------------
 
+    #: ``(stmt_subclass, method_name)`` pairs consulted by
+    #: :meth:`_exec_statement`. Storing method *names* instead of bound
+    #: functions sidesteps two pitfalls: (1) referencing unbound
+    #: ``ScriptInterpreter._exec_*`` in the class body would trip the
+    #: ``SLF001`` private-access lint at every call site, and (2) the
+    #: per-handler argument-type variance (``DeclareStmt`` etc.) can't
+    #: be expressed as a uniform ``Callable`` slot without per-entry
+    #: casts. The dispatch is order-stable: the first ``isinstance``
+    #: match wins. ``BreakStmt`` / ``ContinueStmt`` / ``SqlStmt`` route
+    #: through tiny adapter methods below so every entry shares the
+    #: ``(self, stmt) -> None`` shape.
+    _STATEMENT_DISPATCH: ClassVar[tuple[tuple[type[Statement], str], ...]] = (
+        (DeclareStmt, "_exec_declare"),
+        (SetStmt, "_exec_set"),
+        (IfStmt, "_exec_if"),
+        (WhileStmt, "_exec_while"),
+        (LoopStmt, "_exec_loop"),
+        (ForStmt, "_exec_for"),
+        (BreakStmt, "_exec_break_stmt"),
+        (ContinueStmt, "_exec_continue_stmt"),
+        (ReturnStmt, "_exec_return"),
+        (BeginStmt, "_exec_begin"),
+        (CallStmt, "_exec_call"),
+        (ExecuteImmediateStmt, "_exec_execute_immediate"),
+        (RaiseStmt, "_exec_raise"),
+        (CreateFunctionStmt, "_exec_create_function"),
+        (CreateProcedureStmt, "_exec_create_procedure"),
+        (SqlStmt, "_exec_sql_stmt"),
+    )
+
     async def _exec_statement(self, stmt: Statement) -> None:
         self._statements_executed += 1
         if self._statements_executed > self._max_statements:
             raise QuotaExceededError(
                 f"Script exceeded maximum statement count ({self._max_statements})",
             )
-        if isinstance(stmt, DeclareStmt):
-            await self._exec_declare(stmt)
-        elif isinstance(stmt, SetStmt):
-            await self._exec_set(stmt)
-        elif isinstance(stmt, IfStmt):
-            await self._exec_if(stmt)
-        elif isinstance(stmt, WhileStmt):
-            await self._exec_while(stmt)
-        elif isinstance(stmt, LoopStmt):
-            await self._exec_loop(stmt)
-        elif isinstance(stmt, ForStmt):
-            await self._exec_for(stmt)
-        elif isinstance(stmt, BreakStmt):
-            raise BreakSignal
-        elif isinstance(stmt, ContinueStmt):
-            raise ContinueSignal
-        elif isinstance(stmt, ReturnStmt):
-            await self._exec_return(stmt)
-        elif isinstance(stmt, BeginStmt):
-            await self._exec_begin(stmt)
-        elif isinstance(stmt, CallStmt):
-            await self._exec_call(stmt)
-        elif isinstance(stmt, ExecuteImmediateStmt):
-            await self._exec_execute_immediate(stmt)
-        elif isinstance(stmt, RaiseStmt):
-            await self._exec_raise(stmt)
-        elif isinstance(stmt, CreateFunctionStmt):
-            await self._exec_create_function(stmt)
-        elif isinstance(stmt, CreateProcedureStmt):
-            await self._exec_create_procedure(stmt)
-        elif isinstance(stmt, SqlStmt):
-            await self._exec_sql(stmt.sql)
-        else:
-            raise InvalidQueryError(f"Unknown statement type: {type(stmt).__name__}")
+        for stmt_type, method_name in self._STATEMENT_DISPATCH:
+            if isinstance(stmt, stmt_type):
+                await getattr(self, method_name)(stmt)
+                return
+        raise InvalidQueryError(f"Unknown statement type: {type(stmt).__name__}")
+
+    async def _exec_break_stmt(self, _stmt: BreakStmt) -> None:
+        """Dispatch adapter: ``BreakStmt`` raises the ``BreakSignal`` sentinel."""
+        raise BreakSignal
+
+    async def _exec_continue_stmt(self, _stmt: ContinueStmt) -> None:
+        """Dispatch adapter: ``ContinueStmt`` raises the ``ContinueSignal`` sentinel."""
+        raise ContinueSignal
+
+    async def _exec_sql_stmt(self, stmt: SqlStmt) -> None:
+        """Dispatch adapter: route ``SqlStmt`` to :meth:`_exec_sql` with its raw SQL."""
+        await self._exec_sql(stmt.sql)
 
     # -- Individual constructs -------------------------------------------
 
@@ -371,43 +384,86 @@ class ScriptInterpreter:
         if stmt.routine_ref.upper() == "BQ.REFRESH_MATERIALIZED_VIEW":
             await self._exec_call_refresh_mv(stmt)
             return
-        project_id, dataset_id, routine_id = self._resolve_ref(stmt.routine_ref)
-        routine = self._ctx.catalog.get_routine(project_id, dataset_id, routine_id)
-        if routine is None or routine.routine_type != "PROCEDURE":
-            raise resource_not_found(
-                ResourceRef("routine", project_id, dataset_id, routine_id),
-            )
+        routine = self._resolve_call_routine(stmt.routine_ref)
         if len(stmt.arg_exprs) != len(routine.arguments):
             raise InvalidQueryError(
                 f"Procedure {routine.routine_id} expects {len(routine.arguments)} "
                 f"arguments, got {len(stmt.arg_exprs)}",
             )
-        # Evaluate IN/INOUT args; remember OUT/INOUT slots (by caller
-        # variable name) so the procedure's frame values can be copied
-        # back to the caller's frame after the body returns. OUT
-        # parameters are not evaluated — the caller's variable is
-        # untouched on the way in (BigQuery initialises the procedure's
-        # local with NULL).
+        arg_values, writeback_names = await self._evaluate_call_arguments(
+            routine.arguments,
+            stmt.arg_exprs,
+        )
+        callee_frame = await self._invoke_procedure(routine, arg_values)
+        self._apply_callee_writebacks(writeback_names, routine.arguments, callee_frame)
+
+    def _resolve_call_routine(self, routine_ref: str) -> RoutineMeta:
+        """Resolve a routine reference and assert it's a PROCEDURE.
+
+        Raises ``resource_not_found`` when the routine doesn't exist or
+        isn't a procedure (functions can't be CALLed in BigQuery scripts).
+        """
+        project_id, dataset_id, routine_id = self._resolve_ref(routine_ref)
+        routine = self._ctx.catalog.get_routine(project_id, dataset_id, routine_id)
+        if routine is None or routine.routine_type != "PROCEDURE":
+            raise resource_not_found(
+                ResourceRef("routine", project_id, dataset_id, routine_id),
+            )
+        return routine
+
+    async def _evaluate_call_arguments(
+        self,
+        params: list[Any],
+        arg_exprs: list[str],
+    ) -> tuple[list[Any], list[str | None]]:
+        """Evaluate IN/INOUT args and capture OUT/INOUT writeback slots.
+
+        OUT parameters are not evaluated — BigQuery initialises the
+        callee's local with NULL. INOUT parameters are evaluated and
+        also receive a writeback. IN parameters are evaluated with no
+        writeback. The returned ``writeback_names`` list mirrors the
+        argument order, with ``None`` for slots that don't write back.
+        """
         arg_values: list[Any] = []
         writeback_names: list[str | None] = []
-        for param, expr in zip(routine.arguments, stmt.arg_exprs, strict=True):
-            mode = param.mode.upper() if param.mode else "IN"
-            caller_var = expr.strip()
-            is_bare_ident = caller_var.isidentifier()
-            if mode == "OUT":
-                arg_values.append(None)
-                writeback_names.append(caller_var if is_bare_ident else None)
-            elif mode == "INOUT":
-                arg_values.append(await self._eval_expr_scalar(expr))
-                writeback_names.append(caller_var if is_bare_ident else None)
-            else:
-                arg_values.append(await self._eval_expr_scalar(expr))
-                writeback_names.append(None)
-        callee_frame = await self._invoke_procedure(routine, arg_values)
-        for name, param in zip(writeback_names, routine.arguments, strict=True):
+        for param, expr in zip(params, arg_exprs, strict=True):
+            value, writeback = await self._evaluate_one_argument(param, expr)
+            arg_values.append(value)
+            writeback_names.append(writeback)
+        return arg_values, writeback_names
+
+    async def _evaluate_one_argument(
+        self,
+        param: Any,
+        expr: str,
+    ) -> tuple[Any, str | None]:
+        """Evaluate a single argument expression honouring its mode."""
+        mode = param.mode.upper() if param.mode else "IN"
+        caller_var = expr.strip()
+        writeback = caller_var if caller_var.isidentifier() else None
+        if mode == "OUT":
+            return None, writeback
+        value = await self._eval_expr_scalar(expr)
+        if mode == "INOUT":
+            return value, writeback
+        return value, None
+
+    def _apply_callee_writebacks(
+        self,
+        writeback_names: list[str | None],
+        params: list[Any],
+        callee_frame: dict[str, Any] | None,
+    ) -> None:
+        """Copy OUT/INOUT callee locals back to the caller frame.
+
+        ``callee_frame`` is None when the procedure body raised before
+        the writeback frame was published — there's nothing to
+        propagate in that case.
+        """
+        if callee_frame is None:
+            return
+        for name, param in zip(writeback_names, params, strict=True):
             if name is None:
-                continue
-            if callee_frame is None:
                 continue
             if param.name in callee_frame:
                 self._frames.set(name, callee_frame[param.name])
@@ -926,59 +982,100 @@ def _rewrite_vars_to_params(
 
     params: list[Any] = []
     replaced_any = False
-
-    def _next_placeholder(value: Any) -> exp.Placeholder:
-        params.append(value)
-        return exp.Placeholder(this=str(len(params)))
-
     for col in tree.find_all(exp.Column):
-        name = col.name
-        table = col.table
-        if table:
-            if table in visible:
-                container = visible[table].value
-                if isinstance(container, dict) and name in container:
-                    col.replace(_next_placeholder(container[name]))
-                    replaced_any = True
-            continue
-        if name not in visible:
-            continue
-        var_value = visible[name].value
-        var_type = visible[name].type_name
-        placeholder: exp.Expression = _next_placeholder(var_value)
-        # Preserve the declared variable type when DEFAULT NULL leaves
-        # ``value`` as Python ``None``. Without a CAST, the DuckDB driver
-        # binds NULL as the default INT64 type and the schema renderer
-        # surfaces the column as ``INTEGER`` even though the script said
-        # ``DECLARE x STRING DEFAULT NULL``. Wrapping the placeholder in
-        # a ``CAST(... AS <declared_type>)`` makes the type travel
-        # through to the wire schema — matching BigQuery's "declared
-        # type is authoritative" contract. STRUCT-valued variables
-        # short-circuit out via the ``table`` branch above so the CAST
-        # here only fires for scalar variables.
-        if var_value is None and var_type and var_type.upper() != "ANY":
-            # Defensive: fall back to bare placeholder if the declared
-            # type string is not parseable by ``exp.DataType.build``.
-            with contextlib.suppress(Exception):
-                placeholder = exp.Cast(this=placeholder, to=exp.DataType.build(var_type))
-        # ADR 0023 §1.E — BigQuery infers a projection's column name from
-        # the source identifier when the SELECT has no explicit AS
-        # (``SELECT label`` → column name ``label``). Replacing the column
-        # with a bound parameter erases that signal, so DuckDB falls back
-        # to ``$1``. Wrap the placeholder in an alias whenever the column
-        # is a top-level SELECT projection — scoped narrowly to bare
-        # identifiers, matching BigQuery's "single identifier → use as
-        # name" rule.
-        if isinstance(col.parent, exp.Select) and col.arg_key == "expressions":
-            placeholder = exp.Alias(this=placeholder, alias=exp.to_identifier(name))
-        col.replace(placeholder)
-        replaced_any = True
-
+        if _rewrite_one_column(col, visible, params):
+            replaced_any = True
     if not replaced_any:
         return bq_sql, []
+    return tree.sql(dialect="bigquery"), params
 
-    rewritten = tree.sql(dialect="bigquery")
-    return rewritten, params
+
+def _rewrite_one_column(
+    col: exp.Column,
+    visible: dict[str, Any],
+    params: list[Any],
+) -> bool:
+    """Replace ``col`` with a parameter placeholder when it resolves to a script var.
+
+    Returns ``True`` when a substitution happened (and ``params`` was
+    extended). ``False`` means the column referred to a real SQL
+    column (not a script variable) and was left alone.
+    """
+    if col.table:
+        return _rewrite_struct_field_column(col, visible, params)
+    name = col.name
+    if name not in visible:
+        return False
+    var = visible[name]
+    placeholder = _build_scalar_placeholder(var.value, var.type_name, params)
+    if _is_top_level_projection(col):
+        placeholder = exp.Alias(this=placeholder, alias=exp.to_identifier(name))
+    col.replace(placeholder)
+    return True
+
+
+def _rewrite_struct_field_column(
+    col: exp.Column,
+    visible: dict[str, Any],
+    params: list[Any],
+) -> bool:
+    """Handle ``table.field`` references where ``table`` is a STRUCT variable.
+
+    STRUCT-valued variables — including the implicit ``FOR row IN
+    (...)`` row variable — resolve ``var.field`` directly to the
+    inner field value. Non-STRUCT or unknown lookups fall through to
+    the caller (no substitution).
+    """
+    table = col.table
+    if table not in visible:
+        return False
+    container = visible[table].value
+    if not isinstance(container, dict) or col.name not in container:
+        return False
+    params.append(container[col.name])
+    col.replace(exp.Placeholder(this=str(len(params))))
+    return True
+
+
+def _build_scalar_placeholder(
+    value: Any,
+    type_name: str | None,
+    params: list[Any],
+) -> exp.Expression:
+    """Append ``value`` to ``params`` and return its Placeholder expression.
+
+    Preserves the declared variable type when DEFAULT NULL leaves
+    ``value`` as Python ``None``. Without a CAST, the DuckDB driver
+    binds NULL as the default INT64 type and the schema renderer
+    surfaces the column as ``INTEGER`` even though the script said
+    ``DECLARE x STRING DEFAULT NULL``. Wrapping the placeholder in
+    a ``CAST(... AS <declared_type>)`` makes the type travel through
+    to the wire schema — matching BigQuery's "declared type is
+    authoritative" contract. STRUCT-valued variables short-circuit
+    out via :func:`_rewrite_struct_field_column` so the CAST here
+    only fires for scalar variables.
+    """
+    params.append(value)
+    placeholder: exp.Expression = exp.Placeholder(this=str(len(params)))
+    if value is None and type_name and type_name.upper() != "ANY":
+        # Defensive: fall back to bare placeholder if the declared
+        # type string is not parseable by ``exp.DataType.build``.
+        with contextlib.suppress(Exception):
+            placeholder = exp.Cast(this=placeholder, to=exp.DataType.build(type_name))
+    return placeholder
+
+
+def _is_top_level_projection(col: exp.Column) -> bool:
+    """True when ``col`` is a top-level SELECT projection expression.
+
+    ADR 0023 §1.E — BigQuery infers a projection's column name from
+    the source identifier when the SELECT has no explicit AS
+    (``SELECT label`` → column name ``label``). Replacing the column
+    with a bound parameter erases that signal, so DuckDB falls back
+    to ``$1``. Used by :func:`_rewrite_one_column` to wrap the
+    placeholder in an alias and preserve the projected name.
+    """
+    return isinstance(col.parent, exp.Select) and col.arg_key == "expressions"
 
 
 #: Matches ``BEGIN`` / ``BEGIN TRANSACTION`` / ``START TRANSACTION``,

--- a/src/bqemulator/scripting/lexer.py
+++ b/src/bqemulator/scripting/lexer.py
@@ -96,6 +96,11 @@ class Token:
     raw_value: str = ""  # original source slice for STRING/IDENT — used for round-tripping
 
 
+def _is_ident_start(ch: str) -> bool:
+    """True when ``ch`` may legally start a SQL identifier."""
+    return ch.isalpha() or ch == "_"
+
+
 class Lexer:
     """Greedy lexer for BigQuery scripts."""
 
@@ -120,24 +125,52 @@ class Lexer:
 
         start = self._pos
         ch = self._source[self._pos]
+        token = self._dispatch_first_char(ch, start)
+        if token is not None:
+            return token
+        return self._read_operator_or_punct(start)
 
+    def _dispatch_first_char(self, ch: str, start: int) -> Token | None:
+        """Route the next-token decision based on the leading character.
+
+        Returns ``None`` when ``ch`` doesn't match any literal /
+        identifier / numeric / at-sign opener — the caller falls
+        through to :meth:`_read_operator_or_punct`. Splitting the
+        cascade out keeps :meth:`_next_token` under the cyclomatic
+        ceiling without changing tokenisation order.
+        """
         if ch == "`":
             return self._read_backtick_ident(start)
         if ch in ("'", '"'):
             return self._read_string(start)
-        if ch.isalpha() or ch == "_":
-            # Check for raw-string prefix r'...' or R'...'
-            if ch.lower() == "r" and start + 1 < len(self._source):
-                nxt = self._source[start + 1]
-                if nxt in ("'", '"'):
-                    self._pos += 1
-                    return self._read_string(start, raw=True)
-            return self._read_identifier(start)
-        if ch.isdigit() or (ch == "." and self._peek_digit()):
+        if _is_ident_start(ch):
+            return self._read_ident_or_raw_string(ch, start)
+        if self._is_number_start(ch):
             return self._read_number(start)
         if ch == "@":
             return self._read_at(start)
-        return self._read_operator_or_punct(start)
+        return None
+
+    def _is_number_start(self, ch: str) -> bool:
+        """True for digits and for a ``.`` followed by a digit (``.5``)."""
+        if ch.isdigit():
+            return True
+        return ch == "." and self._peek_digit()
+
+    def _read_ident_or_raw_string(self, ch: str, start: int) -> Token:
+        """Read either an identifier or a raw-string literal.
+
+        BigQuery's raw-string prefix is ``r``/``R`` followed by ``'``
+        or ``"``. When the prefix matches, advance past the ``r`` and
+        delegate to :meth:`_read_string` with ``raw=True``. Otherwise
+        fall through to :meth:`_read_identifier`.
+        """
+        if ch.lower() == "r" and start + 1 < len(self._source):
+            nxt = self._source[start + 1]
+            if nxt in ("'", '"'):
+                self._pos += 1
+                return self._read_string(start, raw=True)
+        return self._read_identifier(start)
 
     # -- Whitespace + comments --------------------------------------------
 

--- a/src/bqemulator/scripting/parser.py
+++ b/src/bqemulator/scripting/parser.py
@@ -9,6 +9,7 @@ script variables bound as parameters — see
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, ClassVar
 
 from bqemulator.domain.errors import InvalidQueryError
@@ -37,6 +38,90 @@ from bqemulator.udf.types import parse_bq_type_string
 
 # Tuple length for the (name, type, mode) form used by procedure args.
 _PROCEDURE_ARG_TUPLE_LEN = 3
+
+
+@dataclass(slots=True)
+class _TypeReadState:
+    """Mutable state threaded through :meth:`Parser._step_type_name`.
+
+    Holds the live bracket depth and a ``consumed_any`` flag so the
+    type-annotation reader can tell whether at least one token has
+    been absorbed (used to drive the post-loop error path).
+    """
+
+    depth: int = 0
+    consumed_any: bool = False
+
+
+@dataclass(slots=True)
+class _ArgListState:
+    """Mutable state threaded through :meth:`Parser._step_arg_list`."""
+
+    depth: int
+    start: int
+
+
+def _is_type_open_bracket(tok: Token) -> bool:
+    """True for a ``<`` OP token (opens a parameterised type)."""
+    return tok.kind == "OP" and tok.value == "<"
+
+
+def _is_type_close_bracket(tok: Token) -> bool:
+    """True for ``>``/``>>``/``>>>`` OP tokens (closing brackets).
+
+    The lexer fuses two/three consecutive ``>`` into a single OP
+    token; the closing-bracket count is recovered from the literal
+    length.
+    """
+    return tok.kind == "OP" and bool(tok.value) and set(tok.value) == {">"}
+
+
+def _is_open_paren(tok: Token) -> bool:
+    return tok.kind == "PUNCT" and tok.value == "("
+
+
+def _is_close_paren(tok: Token) -> bool:
+    return tok.kind == "PUNCT" and tok.value == ")"
+
+
+def _is_arg_separator(tok: Token, depth: int) -> bool:
+    """True for a top-level ``,`` argument separator (``depth == 1``)."""
+    return tok.kind == "PUNCT" and tok.value == "," and depth == 1
+
+
+def _is_stop_token(
+    tok: Token,
+    stop_puncts: tuple[str, ...],
+    stop_keywords: tuple[str, ...],
+) -> bool:
+    """True when ``tok`` is a top-level capture terminator."""
+    return (tok.kind == "PUNCT" and tok.value in stop_puncts) or (
+        tok.kind == "KEYWORD" and tok.value in stop_keywords
+    )
+
+
+def _classify_capture_token(
+    tok: Token,
+    depth: int,
+    stop_puncts: tuple[str, ...],
+    stop_keywords: tuple[str, ...],
+) -> tuple[int, bool]:
+    """Return ``(depth_delta, terminate)`` for ``tok`` in capture state.
+
+    ``depth_delta`` is +1 for ``(``, -1 for a matched ``)``, otherwise
+    0. ``terminate`` is True when the token should stop the capture
+    (without being consumed by the caller).
+    """
+    if _is_open_paren(tok):
+        return 1, False
+    if _is_close_paren(tok):
+        if depth == 0:
+            return 0, True
+        return -1, False
+    if depth == 0 and _is_stop_token(tok, stop_puncts, stop_keywords):
+        return 0, True
+    return 0, False
+
 
 # Keywords that start a known scripting construct.
 _SCRIPTING_STARTERS: frozenset[str] = frozenset(
@@ -696,48 +781,56 @@ class Parser:
         bracket depth: ``>>`` decrements depth by 2 and ``>>>`` by 3.
         """
         start = self._cursor.pos
-        depth = 0
-        consumed_any = False
+        state = _TypeReadState()
         while not self._cursor.at_eof():
-            tok = self._cursor.current
-            # Opening bracket — always advances the bracket depth.
-            if tok.kind == "OP" and tok.value == "<":
-                depth += 1
-                consumed_any = True
-                self._cursor.advance()
-                continue
-            # Closing brackets — may be one, two, or three ``>`` chars
-            # fused into a single OP token.
-            if tok.kind == "OP" and tok.value and set(tok.value) == {">"}:
-                if depth == 0:
-                    break
-                close_count = self._close_bracket_count(tok.value)
-                if close_count > depth:
-                    raise InvalidQueryError(
-                        f"Type annotation has more closing brackets than openings: {tok.value!r}"
-                    )
-                depth -= close_count
-                consumed_any = True
-                self._cursor.advance()
-                continue
-            # Inside the bracket span — any token is part of the
-            # parameterised type body.
-            if depth > 0:
-                consumed_any = True
-                self._cursor.advance()
-                continue
-            # Bare type identifier at the head — capture, then consume
-            # an optional ``(precision, scale)`` paren block (e.g.
-            # ``DECIMAL(38, 9)``).
-            if tok.kind in ("IDENT", "KEYWORD") and not consumed_any:
-                consumed_any = True
-                self._cursor.advance()
-                self._consume_precision_parens()
-                continue
-            break
-        if not consumed_any:
+            if not self._step_type_name(self._cursor.current, state):
+                break
+        if not state.consumed_any:
             raise InvalidQueryError(f"Expected type name, got {self._cursor.current.kind}")
         return self._cursor.slice(start, self._cursor.pos).strip()
+
+    def _step_type_name(self, tok: Token, state: _TypeReadState) -> bool:
+        """Advance one token of a type annotation; return True to keep reading.
+
+        Returns False when the cursor lands on a token that doesn't
+        belong to the annotation (the outer loop breaks; the token is
+        left unconsumed for the caller).
+        """
+        if _is_type_open_bracket(tok):
+            state.depth += 1
+            state.consumed_any = True
+            self._cursor.advance()
+            return True
+        if _is_type_close_bracket(tok):
+            return self._handle_type_close(tok, state)
+        if state.depth > 0:
+            state.consumed_any = True
+            self._cursor.advance()
+            return True
+        if tok.kind in ("IDENT", "KEYWORD") and not state.consumed_any:
+            state.consumed_any = True
+            self._cursor.advance()
+            self._consume_precision_parens()
+            return True
+        return False
+
+    def _handle_type_close(self, tok: Token, state: _TypeReadState) -> bool:
+        """Apply a ``>``/``>>``/``>>>`` closing-bracket token to ``state``.
+
+        Returns False when the close hits depth 0 (the type annotation
+        is fully consumed) or True after decrementing the depth.
+        """
+        if state.depth == 0:
+            return False
+        close_count = self._close_bracket_count(tok.value)
+        if close_count > state.depth:
+            raise InvalidQueryError(
+                f"Type annotation has more closing brackets than openings: {tok.value!r}",
+            )
+        state.depth -= close_count
+        state.consumed_any = True
+        self._cursor.advance()
+        return True
 
     def _capture_expr_until(
         self,
@@ -753,20 +846,17 @@ class Parser:
         depth = 0
         while not self._cursor.at_eof():
             tok = self._cursor.current
-            if tok.kind == "PUNCT" and tok.value == "(":
-                depth += 1
-            elif tok.kind == "PUNCT" and tok.value == ")":
-                if depth == 0:
-                    break
-                depth -= 1
-            elif depth == 0 and (
-                (tok.kind == "PUNCT" and tok.value in stop_puncts)
-                or (tok.kind == "KEYWORD" and tok.value in stop_keywords)
-            ):
+            depth_delta, terminate = _classify_capture_token(
+                tok,
+                depth,
+                stop_puncts,
+                stop_keywords,
+            )
+            if terminate:
                 break
+            depth += depth_delta
             self._cursor.advance()
-        end = self._cursor.pos
-        return self._cursor.slice(start, end)
+        return self._cursor.slice(start, self._cursor.pos)
 
     def _capture_comma_list_until(
         self,
@@ -790,29 +880,55 @@ class Parser:
         return items
 
     def _capture_arg_list(self) -> list[str]:
-        """Capture a comma-separated argument list inside ``( ... )``."""
+        """Capture a comma-separated argument list inside ``( ... )``.
+
+        Assumes the caller already consumed the outer ``(``. Returns the
+        captured argument slices (whitespace-stripped). Raises when the
+        matching ``)`` never arrives.
+        """
         items: list[str] = []
-        depth = 1  # assume caller already consumed the outer "("
-        start = self._cursor.pos
+        state = _ArgListState(depth=1, start=self._cursor.pos)
         while not self._cursor.at_eof():
-            tok = self._cursor.current
-            if tok.kind == "PUNCT" and tok.value == "(":
-                depth += 1
-            elif tok.kind == "PUNCT" and tok.value == ")":
-                depth -= 1
-                if depth == 0:
-                    slice_text = self._cursor.slice(start, self._cursor.pos).strip()
-                    if slice_text:
-                        items.append(slice_text)
-                    return items
-            elif tok.kind == "PUNCT" and tok.value == "," and depth == 1:
-                slice_text = self._cursor.slice(start, self._cursor.pos).strip()
-                items.append(slice_text)
-                self._cursor.advance()
-                start = self._cursor.pos
-                continue
-            self._cursor.advance()
+            done = self._step_arg_list(self._cursor.current, items, state)
+            if done is not None:
+                return done
         raise InvalidQueryError("Unterminated argument list")
+
+    def _step_arg_list(
+        self,
+        tok: Token,
+        items: list[str],
+        state: _ArgListState,
+    ) -> list[str] | None:
+        """Advance through one token of the argument list.
+
+        Returns the completed items list when the outer ``)`` closes,
+        else ``None`` to signal the caller to keep walking.
+        """
+        if _is_open_paren(tok):
+            state.depth += 1
+            self._cursor.advance()
+            return None
+        if _is_close_paren(tok):
+            state.depth -= 1
+            if state.depth == 0:
+                return self._finalise_arg_list(items, state.start)
+            self._cursor.advance()
+            return None
+        if _is_arg_separator(tok, state.depth):
+            items.append(self._cursor.slice(state.start, self._cursor.pos).strip())
+            self._cursor.advance()
+            state.start = self._cursor.pos
+            return None
+        self._cursor.advance()
+        return None
+
+    def _finalise_arg_list(self, items: list[str], start: int) -> list[str]:
+        """Append the trailing argument slice (if non-empty) and return ``items``."""
+        slice_text = self._cursor.slice(start, self._cursor.pos).strip()
+        if slice_text:
+            items.append(slice_text)
+        return items
 
     def _consume_optional_semicolon(self) -> None:
         if self._cursor.current.kind == "PUNCT" and self._cursor.current.value == ";":
@@ -848,6 +964,72 @@ def _unquote_string(raw: str) -> str:
     return _decode_bq_string_escapes(inner)
 
 
+#: Single-char BigQuery escape sequences. Sourced from BigQuery's
+#: quoted-literal grammar.
+_BQ_SIMPLE_ESCAPES: dict[str, str] = {
+    "\\": "\\",
+    "'": "'",
+    '"': '"',
+    "n": "\n",
+    "t": "\t",
+    "r": "\r",
+    "b": "\b",
+    "f": "\f",
+    "v": "\v",
+    "0": "\0",
+    "a": "\a",
+    "/": "/",
+    "?": "?",
+}
+
+
+def _decode_unicode_escape(s: str, i: int, n: int) -> tuple[str, int] | None:
+    r"""Decode a ``\uXXXX`` 4-hex-digit Unicode escape at ``s[i]``.
+
+    Returns ``(decoded_char, next_index)`` on success, ``None`` when
+    the lookahead is too short or the hex parse fails (the caller
+    falls back to the verbatim-backslash pass-through).
+    """
+    if i + 5 >= n or not s[i + 2 : i + 6].isalnum():
+        return None
+    try:
+        return chr(int(s[i + 2 : i + 6], 16)), i + 6
+    except ValueError:
+        return None
+
+
+def _decode_hex_escape(s: str, i: int, n: int) -> tuple[str, int] | None:
+    r"""Decode a ``\xXX`` 2-hex-digit byte escape at ``s[i]``."""
+    if i + 3 >= n:
+        return None
+    try:
+        return chr(int(s[i + 2 : i + 4], 16)), i + 4
+    except ValueError:
+        return None
+
+
+def _consume_bq_escape(s: str, i: int, n: int) -> tuple[str, int]:
+    r"""Consume one BigQuery escape sequence at ``s[i]``.
+
+    Returns ``(decoded_text, next_index)``. Unknown escapes pass the
+    leading ``\`` through verbatim and advance by 1 — this matches
+    BigQuery's permissive behaviour.
+    """
+    nxt = s[i + 1]
+    simple = _BQ_SIMPLE_ESCAPES.get(nxt)
+    if simple is not None:
+        return simple, i + 2
+    if nxt == "u":
+        unicode_match = _decode_unicode_escape(s, i, n)
+        if unicode_match is not None:
+            return unicode_match
+    if nxt == "x":
+        hex_match = _decode_hex_escape(s, i, n)
+        if hex_match is not None:
+            return hex_match
+    return s[i], i + 1
+
+
 def _decode_bq_string_escapes(s: str) -> str:
     r"""Decode BigQuery string-literal escape sequences in ``s``.
 
@@ -866,47 +1048,8 @@ def _decode_bq_string_escapes(s: str) -> str:
             out.append(ch)
             i += 1
             continue
-        nxt = s[i + 1]
-        mapping = {
-            "\\": "\\",
-            "'": "'",
-            '"': '"',
-            "n": "\n",
-            "t": "\t",
-            "r": "\r",
-            "b": "\b",
-            "f": "\f",
-            "v": "\v",
-            "0": "\0",
-            "a": "\a",
-            "/": "/",
-            "?": "?",
-        }
-        if nxt in mapping:
-            out.append(mapping[nxt])
-            i += 2
-            continue
-        if nxt == "u":
-            if i + 5 < n and s[i + 2 : i + 6].isalnum():
-                try:
-                    out.append(chr(int(s[i + 2 : i + 6], 16)))
-                    i += 6
-                    continue
-                except ValueError:
-                    pass
-            out.append(ch)
-            i += 1
-            continue
-        if nxt == "x" and i + 3 < n:
-            try:
-                out.append(chr(int(s[i + 2 : i + 4], 16)))
-                i += 4
-                continue
-            except ValueError:
-                pass
-        # Unknown escape: pass through verbatim.
-        out.append(ch)
-        i += 1
+        decoded, i = _consume_bq_escape(s, i, n)
+        out.append(decoded)
     return "".join(out)
 
 


### PR DESCRIPTION
## Summary

PR-10 of the C→B cyclomatic-complexity refactor campaign (gates flip in PR-12). Decomposes the eight C-rank blocks in the scripting lexer / parser / interpreter into smaller, named helpers so they fit under the upcoming B ceiling. Pure structural refactor — no behaviour change.

## Refactors

| Symbol | Before | After |
| --- | --- | --- |
| ``Lexer._next_token`` | C(13) | A(3) |
| ``Parser._read_type_name`` | C(13) | A(4) |
| ``Parser._capture_expr_until`` | C(12) | A(3) |
| ``Parser._capture_arg_list`` | C(11) | A(4) |
| ``_decode_bq_string_escapes`` | C(12) | A(4) |
| ``ScriptInterpreter._exec_statement`` | C(18) | A(5) |
| ``ScriptInterpreter._exec_call`` | C(15) | A(3) |
| ``_rewrite_vars_to_params`` | C(15) | A(6) |

### Highlights

**``_exec_statement`` (interpreter.py)** — Replaced the 16-arm ``isinstance``/``elif`` cascade with a ``_STATEMENT_DISPATCH`` ClassVar pairing ``Statement`` subclasses with method *names*; the loop dispatches via ``getattr(self, method_name)``. Storing names (not bound functions) sidesteps SLF001 and the per-handler argument-type variance that would otherwise require per-entry casts. Three thin adapter methods (``_exec_break_stmt``, ``_exec_continue_stmt``, ``_exec_sql_stmt``) give Break / Continue / SqlStmt the uniform ``(self, stmt) -> None`` shape every dispatch entry shares.

**``_exec_call`` (interpreter.py)** — Decomposed into ``_resolve_call_routine`` (lookup + PROCEDURE assertion), ``_evaluate_call_arguments`` + ``_evaluate_one_argument`` (IN/OUT/INOUT mode dispatch), and ``_apply_callee_writebacks`` (post-call frame copy-back).

**``_rewrite_vars_to_params`` (interpreter.py)** — Per-column dispatch via ``_rewrite_one_column`` / ``_rewrite_struct_field_column``; ``_build_scalar_placeholder`` handles the typed-NULL CAST preservation; ``_is_top_level_projection`` factors out the ADR 0023 §1.E projection-alias rule.

**``_next_token`` (lexer.py)** — ``_dispatch_first_char`` routes by character class; ``_read_ident_or_raw_string`` handles the ``r"..."``/``R"..."`` raw-string prefix without inflating the main lexer step.

**Parser type / capture helpers** — Threaded ``_TypeReadState`` and ``_ArgListState`` dataclasses through extracted step functions (``_step_type_name``, ``_step_arg_list``); ``_classify_capture_token`` returns ``(depth_delta, terminate)`` so ``_capture_expr_until`` is a thin walk.

**``_decode_bq_string_escapes`` (parser.py)** — ``_BQ_SIMPLE_ESCAPES`` dispatch dict plus per-shape helpers (``_consume_bq_escape``, ``_decode_unicode_escape``, ``_decode_hex_escape``).

## Validation

- ``make verify`` clean — lint + complexity + unit + property + integration + coverage + matrices + docker-build + e2e × 5 clients (Python/Node/Go/Java/bq CLI) + conformance + docs ``mkdocs --strict``.
- 204 scripting tests pass (unit + integration).
- Remaining C-block count: **17 → 9** (PR-11 closes out the final bucket in ``jobs/``).

## Test plan

- [ ] CI green across the full matrix
- [ ] CodeRabbit clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined statement processing dispatch within the scripting interpreter.
  * Reorganized procedure call execution and argument evaluation handling.
  * Refactored script variable binding mechanisms in SQL expressions.
  * Enhanced token parsing and dispatch logic in the lexer and parser.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->