### PR TITLE
build(linkcheck): bump lychee max_redirects 10→15 for GCP docs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,6 +26,7 @@ on:
       - "pyproject.toml"
       - ".vulture_whitelist.py"
       - ".jscpd.json"
+      - ".lychee.toml"
       - "Makefile"
       # Run on every workflow / dependabot example change too, so the
       # ``Quality gates`` job emits a status on PRs that only touch

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -19,12 +19,20 @@
 # Default check timeout per URL.
 timeout = 20
 
-# Don't follow more than 10 redirects (catches infinite-loop CDNs).
-# Bumped from 5 to absorb Google Cloud docs' CDN/locale redirect
-# chain (``cloud.google.com → docs.cloud.google.com → locale-
-# prefixed → canonical``) which can land at 6+ hops from runner
-# egress regions.
-max_redirects = 10
+# Don't follow more than 15 redirects (catches infinite-loop CDNs).
+# Bumped from 5 → 10 → 15 to absorb Google Cloud docs' CDN/locale
+# redirect chain (``cloud.google.com → docs.cloud.google.com →
+# locale-prefixed → canonical``) which keeps growing with their
+# CDN topology. The 10-cap held through v1.1.x but PR #100
+# (2026-05-28) hit fresh ``[302] Rejected status code: ... Redirects
+# may have been limited by "max-redirects"`` failures on
+# ``cloud.google.com/bigquery/docs/reference/...`` URLs from
+# ``docs/reference/conformance-coverage-matrix.md``. Same URLs
+# resolve fine in a browser — the hop count from the runner egress
+# region is the variable. 15 absorbs the observed chain with
+# headroom; infinite-loop CDNs cap out much higher (40+) so we
+# still catch the pathological cases.
+max_redirects = 15
 
 # Retry failed URLs on transient errors. Calibrated against the
 # v1.0.2 release CI cycle (PR #43, 2026-05-23) where lychee hit


### PR DESCRIPTION
## Summary

CI-infrastructure hotfix. PR #100 (``refactor/cc-10-scripting``) is blocked on its required ``Verify links`` check because ``cloud.google.com/bigquery/docs/reference/...`` URLs in ``docs/reference/conformance-coverage-matrix.md`` are bouncing through more than the configured 10 redirects from the GitHub Actions runner egress region.

Same URLs resolve fine in a browser — Google's CDN chain has lengthened past 10 hops since the previous bump (``5 → 10``, v1.0.2). Bumping the cap to **15** absorbs the observed chain with headroom and keeps the upper bound well below the 40+ hops infinite-loop CDNs would hit.

The retry budget (``max_retries = 4``, ``retry_wait_time = 10``) is unchanged.

## Test plan

- [ ] ``Verify links`` passes on this PR
- [ ] Auto-merge fires
- [ ] PR #100 rebases on top and ``Verify links`` passes there too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the maximum redirect limit for the link-checker configuration.
  * Updated CI path filters so changes to the link-checker configuration trigger code-quality checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->