### PR TITLE
build(complexity): ratchet xenon --max-modules from C to B + ADR 0042

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,12 +2,17 @@ name: Code quality
 
 # Quality gates: cyclomatic complexity (xenon), DRY / duplication
 # (jscpd), dead code (vulture). Wired per ADR 0035; complexity
-# promoted to required + ratcheted to rank C in ADR 0036; ratcheted
-# from rank C to rank B in ADR 0041 after the PR-1…PR-11 sweep.
+# promoted to required + per-function ratcheted to rank C in
+# ADR 0036; per-function ratcheted from rank C to rank B in
+# ADR 0041 after the PR-1…PR-11 sweep; per-module-average ratcheted
+# from rank C to rank B in ADR 0042 (the per-function campaign drove
+# module averages down to ≤B as a side effect — no refactor required
+# for the module ratchet).
 #
 # Wiring status:
 #   - Complexity (xenon): REQUIRED. No ``continue-on-error``. A
-#     function above rank B (cyclomatic complexity > 10) fails the
+#     function above rank B (cyclomatic complexity > 10) OR a module
+#     whose average complexity exceeds rank B (CC avg > 10) fails the
 #     workflow. Branch protection lists this job in required-checks.
 #   - Duplication (jscpd) + dead code (vulture): still non-blocking
 #     (``continue-on-error: true``). Each gets its own ratchet PR
@@ -102,11 +107,15 @@ jobs:
       - name: Cyclomatic complexity (xenon)
         id: complexity
         # Required gate as of ADR 0036 — fails the workflow on any
-        # function ranked above B (ADR 0041 ratcheted the absolute
+        # function ranked above B OR any module whose average exceeds
+        # rank B. ADR 0041 ratcheted the per-function ``--max-absolute``
         # ceiling from C to B once the PR-1…PR-11 sweep closed every
-        # rank-C function). Drop ``continue-on-error`` (which the
-        # duplication / dead-code steps still keep) once those gates
-        # ratchet to required on their own follow-up PRs.
+        # rank-C function; ADR 0042 ratcheted the per-module-average
+        # ``--max-modules`` ceiling from C to B as a single-PR config
+        # flip (the per-function campaign drove module averages down
+        # to ≤B as a side effect). Drop ``continue-on-error`` (which
+        # the duplication / dead-code steps still keep) once those
+        # gates ratchet to required on their own follow-up PRs.
         run: make quality-complexity
 
       - name: Cross-file duplication (jscpd)
@@ -133,10 +142,10 @@ jobs:
             echo ""
             echo "| Gate | Outcome | Blocking |"
             echo "|---|---|---|"
-            echo "| Cyclomatic complexity (xenon) | ${{ steps.complexity.outcome }} | ✅ required (ADR 0036 + 0041) |"
+            echo "| Cyclomatic complexity (xenon) | ${{ steps.complexity.outcome }} | ✅ required (ADR 0036 + 0041 + 0042) |"
             echo "| Cross-file duplication (jscpd) | ${{ steps.duplication.outcome }} | ⏳ non-blocking |"
             echo "| Dead code (vulture) | ${{ steps.dead-code.outcome }} | ⏳ non-blocking |"
             echo ""
             echo "The non-blocking gates have follow-up ratchet PRs scheduled —"
-            echo "see ADR 0035 + ADR 0036 + ADR 0041 for the promotion pattern."
+            echo "see ADR 0035 + ADR 0036 + ADR 0041 + ADR 0042 for the promotion pattern."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -104,21 +104,29 @@ linkcheck: ## Run lychee with the workspace-aware self-link remap (CI parity)
 #
 #   - ``quality-complexity`` is REQUIRED (part of ``make verify``, no
 #     ``continue-on-error`` on its CI step). ADR 0036 promoted the
-#     gate from non-blocking to required and ratcheted the threshold
-#     from rank E to rank C; ADR 0041 ratcheted it further from rank
-#     C to rank B after the PR-1 through PR-11 sweep closed every
-#     remaining rank-C function (~60 of them across 26 files).
+#     gate from non-blocking to required and ratcheted the absolute
+#     threshold from rank E to rank C; ADR 0041 ratcheted it further
+#     from rank C to rank B after the PR-1 through PR-11 sweep closed
+#     every remaining rank-C function (~60 across 26 files); ADR 0042
+#     ratcheted the per-module-average threshold from rank C to rank B
+#     as a single-PR config flip (the per-function campaign drove
+#     module averages down to ≤B as a side effect — verified by
+#     ``xenon --max-modules B`` exit 0 pre-flip; zero refactor work
+#     required for the module ratchet).
 #   - ``quality-duplication`` and ``quality-dead-code`` are still
 #     non-blocking in CI; their own promote-to-required PRs come
 #     when the baselines settle.
 
 .PHONY: quality-complexity
-quality-complexity: ## Cyclomatic-complexity ceiling via xenon — REQUIRED gate (ratcheted to B in ADR 0041)
+quality-complexity: ## Cyclomatic-complexity ceiling via xenon — REQUIRED gate (per-function + per-module both at B in ADR 0041 + ADR 0042)
 	# Threshold: every function in src/bqemulator must rank B or
 	# better (cyclomatic complexity ≤ 10), every module average must
-	# stay ≤ rank C, and the project-wide average must stay ≤ rank A.
+	# stay ≤ rank B (CC avg ≤ 10), and the project-wide average must
+	# stay ≤ rank A (currently 3.06 against the 5.0 rank-A ceiling).
 	# ADR 0036 documents the original C-ratchet bucket-A/B refactor
-	# patterns; ADR 0041 documents the C→B campaign retrospective.
+	# patterns; ADR 0041 documents the per-function C→B campaign
+	# retrospective; ADR 0042 documents the per-module C→B audit
+	# (campaign side-effect, no extra refactor work).
 	# Any new function above rank B either gets a behavior-preserving
 	# refactor (dispatch table or helper extraction — see the existing
 	# ``_DUCKDB_TRANSLATORS`` / ``_ARROW_TO_BQ_RULES`` /
@@ -127,7 +135,7 @@ quality-complexity: ## Cyclomatic-complexity ceiling via xenon — REQUIRED gate
 	# ``--exclude`` carve-out (a new bucket-C irreducibility verdict —
 	# bar is genuine domain-shaped complexity, not accumulated cruft;
 	# the empirical bucket-C rate across PR-1…PR-11 was 0%).
-	xenon --max-absolute B --max-modules C --max-average A src/bqemulator
+	xenon --max-absolute B --max-modules B --max-average A src/bqemulator
 
 .PHONY: quality-duplication
 quality-duplication: ## Cross-file DRY check via jscpd (non-blocking)

--- a/docs/adr/0041-complexity-ratchet-to-b.md
+++ b/docs/adr/0041-complexity-ratchet-to-b.md
@@ -365,3 +365,36 @@ complexity is domain-shaped, not accumulated."
 * `AGENTS.md` "Pre-PR gate (mandatory)" — the contract this ADR
   extends; `make verify` runs `make quality-complexity` against
   the new ceiling.
+
+## Update (2026-05-28): follow-up `--max-modules` ratchet in ADR 0042
+
+This ADR's "Why we keep `--max-modules` at C" section held the
+per-module-average ratchet open as "the right ratchet for them is a
+separate audit + per-module PR sequence if/when justified, not a
+side-effect of the per-function ratchet."
+
+A focused audit immediately following this PR's merge tested that
+assumption empirically: **the per-function C→B campaign drove module
+averages down to ≤B as a side effect.** `xenon --max-modules B
+src/bqemulator` exited 0 against `main` at HEAD `247fb60` (this PR's
+own merge commit) with zero refactor work required. The audit found:
+
+* **0 modules** with CC average above rank B (CC > 10).
+* **14 modules** in the rank-B band (CC avg 6.01–10.00) — all
+  passing the rank-B threshold; would become the audit list for a
+  future B→A ratchet (out of scope).
+* **120+ modules** at rank A (CC avg ≤ 5.0).
+
+The mechanism: splitting branchy functions into dispatch tables +
+helpers redistributed complexity weight across more (smaller,
+lower-rank) functions, which lowered the per-module *average* even
+where function count grew. The campaign's per-function bucket-A/B
+patterns are also per-module-average favourable patterns.
+
+[ADR 0042](0042-module-ceiling-ratchet-to-b.md) is the single-PR
+config flip (`xenon --max-modules C → B`) that lands the
+already-met threshold as the standing rule. ADR 0041 is not
+superseded — it remains the per-function ratchet ADR; ADR 0042
+documents the per-module-average ratchet as a complementary axis.
+The "Why we keep `--max-modules` at C" section above is the
+historical record of the held question; ADR 0042 is the resolution.

--- a/docs/adr/0042-module-ceiling-ratchet-to-b.md
+++ b/docs/adr/0042-module-ceiling-ratchet-to-b.md
@@ -1,0 +1,231 @@
+# ADR 0042: Per-module-average ratchet to rank B (no-refactor follow-on)
+
+- **Status**: Accepted
+
+## Context
+
+The cyclomatic-complexity gate has three independent thresholds
+([ADR 0035](0035-code-quality-gates.md) §"Wiring"):
+
+| `xenon` flag | What it caps | Pre-this-ADR value |
+|---|---|---|
+| `--max-absolute` | The worst-ranked single function | **B** (per [ADR 0041](0041-complexity-ratchet-to-b.md)) |
+| `--max-modules` | The highest module-average CC | **C** |
+| `--max-average` | The project-wide CC average | **A** |
+
+[ADR 0036](0036-complexity-ratchet-to-c.md) and [ADR 0041](0041-complexity-ratchet-to-b.md)
+ratcheted `--max-absolute` from E → C → B through two campaigns. The
+per-function refactors were the load-bearing work; the gate flips
+were the recognition step.
+
+ADR 0041's "Why we keep `--max-modules` at C" section explicitly held
+the module-average ratchet open as the *next* question, with the
+proviso that "the right ratchet for them is a separate audit +
+per-module PR sequence if/when justified, not a side-effect of the
+per-function ratchet." It anticipated a fresh refactor campaign
+analogous to PR-1 through PR-11, scoped per-subsystem, before any
+flip of `--max-modules`.
+
+## Audit
+
+A focused audit against `main` HEAD `247fb60` (the ADR 0041 merge
+commit) tested ADR 0041's anticipation. The audit query was simple:
+**without any new refactor work, does `xenon --max-modules B
+src/bqemulator` exit 0?**
+
+The dry-run result:
+
+```
+$ xenon --max-absolute B --max-modules B --max-average A src/bqemulator
+$ echo $?
+0
+```
+
+The codebase already complies. The per-module distribution against
+the proposed threshold:
+
+| Avg CC band | Rank | Module count | Notes |
+|---|---|---|---|
+| > 10.00 | C+ | **0** | None — confirmed by xenon exit 0 |
+| 6.01 – 10.00 | B | **14** | All passing the rank-B threshold (B is inclusive of CC 10) |
+| ≤ 5.00 | A | **120+** | Vast majority |
+
+The 14 rank-B modules:
+
+| Avg CC | Worst | Blocks | Module |
+|---|---|---|---|
+| 10.00 | 10 | 1 | `sql/rewriter/sha512.py` |
+| 8.40 | 10 | 5 | `udf/types.py` |
+| 7.00 | 10 | 5 | `versioning/time_travel.py` |
+| 7.00 | 8 | 4 | `sql/rewriter/string_helpers.py` |
+| 6.75 | 9 | 4 | `sql/rewriter/unnest_struct.py` |
+| 6.67 | 10 | 3 | `jobs/orc_reader.py` |
+| 6.00 | 10 | 2 | `sql/rewriter/range_sessionize.py` |
+| 6.00 | 9 | 4 | `streaming/strategies/buffered.py` |
+| 5.75 | 10 | 4 | `sql/rewriter/create_table_schema_ctas.py` |
+| 5.67 | 10 | 9 | `storage/type_map.py` |
+| 5.67 | 9 | 3 | `sql/catalog_schema.py` |
+| 5.20 | 8 | 10 | `sql/rewriter/specialized_types.py` |
+| 5.20 | 8 | 5 | `sql/rewriter/timestamp_iso_helpers.py` |
+| 5.14 | 10 | 7 | `sql/translator.py` |
+
+These are the "future B→A audit list" — out of scope for this ADR.
+
+### Why no refactor work is needed
+
+The per-function ratchet campaigns (PR-1 through PR-11, closing
+~60 rank-C functions) drove module averages down to ≤B **as a side
+effect**. The mechanism:
+
+* Splitting a CC-15 dispatch function into a CC-3 dispatch loop +
+  N CC-2 handlers redistributes complexity weight across more
+  (smaller, lower-rank) functions.
+* The new helpers land at rank A almost universally (the C→B
+  campaign observed this empirically — ~150-200 new helpers added
+  across PR-1 through PR-11, overwhelmingly rank A).
+* The per-module *average* drops because the denominator (function
+  count) grows faster than the numerator (sum of complexities).
+
+ADR 0041's anticipation that the module ratchet would need its own
+campaign was correct *in theory* — module averages aren't the same
+metric as per-function ceilings, and a codebase could plausibly
+exist where per-function refactors didn't move the per-module
+average enough. In *this* codebase, the bucket-A/B refactor patterns
+that worked for the per-function ratchet happened to also work for
+the per-module-average ratchet.
+
+## Decision
+
+1. **Tighten `--max-modules` to rank B** in the Makefile gate:
+
+   ```
+   xenon --max-absolute B --max-modules B --max-average A src/bqemulator
+   ```
+
+   The project-wide `--max-average` stays at A (currently 3.06, well
+   below the 5.0 rank-A ceiling). All three xenon thresholds now sit
+   one ratchet step tighter than they did before the C→B work
+   started.
+
+2. **No refactor work.** The audit verified the codebase already
+   complies. This ADR's PR is a Makefile flip + workflow comment
+   updates + this ADR + an additive `Update` section on ADR 0041 +
+   an mkdocs nav entry. Total diff is ~10 lines of config + ~150
+   lines of docs.
+
+3. **Defer `--max-modules B → A` to a future audit.** The 14 rank-B
+   modules listed above would need refactoring before a `--modules A`
+   ratchet could land. Several look genuinely irreducible — notably
+   `sql/rewriter/sha512.py` is a single CC-10 function (SHA-512
+   software implementation; the unavoidable branch count is the
+   complexity), and `udf/types.py` is type-conversion dispatch
+   already at the natural floor. A B→A campaign would likely
+   produce the campaign's first bucket-C exclusions (the
+   "irreducible domain complexity" exit ADR 0036 anticipated but
+   neither ratchet has yet needed). That's a deliberate future
+   audit, not a side-effect ratchet.
+
+4. **ADR 0041 stays in effect.** Like ADR 0036 under ADR 0041,
+   ADR 0041 remains the authoritative ADR for the per-function
+   `--max-absolute` ceiling. ADR 0042 layers a tighter
+   `--max-modules` on top — different axis, complementary ratchet.
+
+## Consequences
+
+### Positive
+
+* The per-module-average gate now defends against drift the same
+  way the per-function gate does. A future PR that adds a
+  rank-C-average module fails CI loudly instead of merging silently.
+* The "campaign side-effect" pattern is documented as a real
+  phenomenon — future ratchet audits should check the side-effect
+  state of orthogonal thresholds before assuming a fresh campaign
+  is needed.
+* The three xenon thresholds are now visually consistent
+  (`B / B / A` is easier to read at a glance than `B / C / A`),
+  which makes drift more legible during code review.
+
+### Negative
+
+* The gate is now strict enough that adding *any* CC-10 function to
+  a single-block module risks tipping the module's average over the
+  B boundary (since the average is the only function's CC). This
+  matters for the 14 rank-B modules listed above whose averages
+  already sit at or near the boundary. Mitigation: the same
+  bucket-A/B refactor patterns that worked across the C→B campaign
+  work here — split a CC-10 function into a CC-3 dispatch + 3 CC-3
+  helpers and the module average drops to ~3.
+* A future contributor who lands a CC-10 helper in
+  `sql/rewriter/sha512.py` (which currently averages 10.00 with
+  exactly 1 block) would fail the gate even though the helper
+  itself is rank-B-clean. Mitigation: the small-single-purpose-file
+  pattern that `sha512.py` exemplifies is rare — most files in the
+  codebase carry multiple helpers and have headroom against the
+  module-average.
+
+### Neutral
+
+* No production runtime impact. Pure config + docs ratchet.
+* The `make verify` chain's complexity step continues to run xenon;
+  the only difference is `--max-modules B` vs `C`. Local + CI cost
+  is unchanged.
+* CHANGELOG entry deferred to release time per the project's
+  [release-time-authored CHANGELOG policy](https://github.com/jjviscomi/bqemulator/blob/main/CHANGELOG.md).
+  This ADR is the authoritative record of the ratchet until the next
+  release synthesises a CHANGELOG bullet from `git log`.
+
+## Alternatives considered
+
+1. **Run a per-module B→A refactor campaign first, then ratchet
+   `--max-modules` in one big step to A.** Rejected as scope-creep
+   — the data already supports the B-step landing today with zero
+   refactor work. Conflating "free ratchet that's already met" with
+   "campaign that requires real refactor work" loses both the
+   defensive value of the cheap ratchet (which would wait on the
+   slow campaign) and the audit clarity (the B→A campaign would
+   need its own retrospective ADR, which the B-step ratchet doesn't
+   need to block).
+
+2. **Skip `--max-modules` and ratchet `--max-average A → ??`
+   instead.** Not possible — xenon doesn't expose sub-rank
+   ceilings. The project-wide average is already at the tightest
+   rank xenon supports. Tightening "more" would require either
+   forking xenon or switching to a different tool (radon's `cc -a
+   --total-average` reports the number; xenon doesn't gate on
+   sub-rank numeric thresholds).
+
+3. **Fold this ratchet into a future release-related PR.** Rejected
+   — the audit signal is independent of release cadence, and the
+   defensive value of the new threshold compounds with every PR
+   merged in the meantime. Better to land the cheap defensive
+   ratchet immediately than wait for an unrelated trigger.
+
+4. **Run the same per-subsystem multi-PR pattern as ADR 0041's
+   campaign for the module-ceiling ratchet, even though the
+   per-PR diff is empty.** Rejected — the campaign pattern's
+   value was *review surface* (no PR exceeds N files / M LOC of
+   refactor work). With zero refactor work required, the pattern
+   produces a sequence of empty PRs each doing nothing. The
+   single-PR shape this ADR adopts matches the actual work shape.
+
+## References
+
+* [ADR 0035](0035-code-quality-gates.md) — the foundation ADR
+  documenting the three independent xenon thresholds this ADR
+  ratchets one of.
+* [ADR 0036](0036-complexity-ratchet-to-c.md) — the first
+  per-function ratchet (E → C). Established the bucket A/B/C
+  taxonomy.
+* [ADR 0041](0041-complexity-ratchet-to-b.md) — the second
+  per-function ratchet (C → B). Anticipated this ADR under
+  "Why we keep `--max-modules` at C"; see ADR 0041's dated
+  update at the bottom for the cross-reference.
+* [radon documentation](https://radon.readthedocs.io/en/latest/) —
+  rank-tier definitions (A: 1-5, B: 6-10, C: 11-20, D: 21-30,
+  E: 31-40, F: ≥41).
+* [xenon documentation](https://xenon.readthedocs.io/en/latest/) —
+  CLI threshold semantics (`--max-absolute`, `--max-modules`,
+  `--max-average`).
+* `AGENTS.md` "Pre-PR gate (mandatory)" — the contract this ADR
+  extends; `make verify` runs `make quality-complexity` against
+  the new ceiling.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -226,6 +226,7 @@ nav:
       - "0039 SLSA Build Provenance on GitHub Release assets": adr/0039-artifact-attestations.md
       - "0040 SESSION_USER coverage closure: aliases + Storage Read pre-pass": adr/0040-session-user-coverage-closure.md
       - "0041 Cyclomatic-complexity ratchet to rank B + campaign retrospective": adr/0041-complexity-ratchet-to-b.md
+      - "0042 Per-module-average ratchet to rank B (no-refactor follow-on)": adr/0042-module-ceiling-ratchet-to-b.md
   - RFCs: rfcs/README.md
   - Examples:
       - Overview: examples/README.md


### PR DESCRIPTION
## Summary

- Ratchet the xenon `--max-modules` threshold from C to B. The audit verified the codebase already complies: `xenon --max-modules B src/bqemulator` exits 0 against `main` at HEAD `247fb60` with zero refactor work required.
- The per-function C→B campaign (PR-1 through PR-11; gate flip in #103) drove per-module averages down to ≤B as a side effect. This PR is the single-line config flip that lands the already-met threshold as the standing rule.
- Adds **ADR 0042** documenting the audit, the no-refactor-required decision, the 14-module rank-B watch list (the future B→A audit candidates, out of scope), and the alternatives considered.
- Adds a dated `Update` section to ADR 0041 — the "Why we keep `--max-modules` at C" section becomes the historical record of the held question; ADR 0042 is the resolution.

## Audit data (verified pre-push)

| Avg CC band | Rank | Modules | Status |
|---|---|---|---|
| > 10.00 | C+ | **0** | Confirmed by `xenon --max-modules B` exit 0 |
| 6.01 – 10.00 | B | **14** | All passing the new B-gate; future B→A audit list (out of scope) |
| ≤ 5.00 | A | **120+** | Vast majority |

The 14 rank-B modules (avg / worst-CC / blocks / path):

```
10.00  10  1  sql/rewriter/sha512.py            (single CC-10 fn — likely irreducible)
 8.40  10  5  udf/types.py                       (type-conversion dispatch)
 7.00  10  5  versioning/time_travel.py
 7.00   8  4  sql/rewriter/string_helpers.py
 6.75   9  4  sql/rewriter/unnest_struct.py
 6.67  10  3  jobs/orc_reader.py
 6.00  10  2  sql/rewriter/range_sessionize.py
 6.00   9  4  streaming/strategies/buffered.py
 5.75  10  4  sql/rewriter/create_table_schema_ctas.py
 5.67  10  9  storage/type_map.py
 5.67   9  3  sql/catalog_schema.py
 5.20   8 10  sql/rewriter/specialized_types.py
 5.20   8  5  sql/rewriter/timestamp_iso_helpers.py
 5.14  10  7  sql/translator.py
```

## Changes

| File | Change |
|---|---|
| `Makefile` | Flip `xenon --max-modules C → B`; update target docstring + wiring-status comment header to reflect the per-module ratchet via ADR 0042 |
| `.github/workflows/code-quality.yml` | Update file-level description + per-step comment + workflow-summary table to reference ADR 0042; Quality-gate failure condition now reads `function above rank B OR module whose average exceeds rank B` |
| `docs/adr/0041-complexity-ratchet-to-b.md` | Append dated `Update (2026-05-28): follow-up --max-modules ratchet in ADR 0042` section |
| `docs/adr/0042-module-ceiling-ratchet-to-b.md` | **NEW.** Audit + decision + rationale (~150 LOC) |
| `mkdocs.yml` | Register ADR 0042 in the ADRs nav |

No code changes — pure config + docs ratchet.

## Why no refactor work needed

The mechanism: per-function bucket-A/B refactors (extracting helpers into smaller functions) redistribute complexity weight across more (smaller, lower-rank) functions. The per-module *average* drops because the function-count denominator grows faster than the complexity-sum numerator. The new helpers PR-1 through PR-11 introduced (~150-200 across the campaign) overwhelmingly landed at rank A, which is what dropped the module averages.

ADR 0041's "Why we keep `--max-modules` at C" section explicitly anticipated this question and held it open for a future audit. That audit is this PR's ADR 0042; the answer turned out to be "already met, no campaign needed."

## Validation

Full `make verify` gate clean (run locally pre-push):

- ✅ `lint` (ruff check + ruff format + typos)
- ✅ `quality-complexity` — **the new `--max-absolute B --max-modules B --max-average A` gate is GREEN**
- ✅ `test` (266 unit + integration tests, 1 skipped — avro-tools not on local PATH)
- ✅ `test-coverage` (99.4%, well above the 90% floor)
- ✅ `coverage-matrix-check` / `compat-matrix-check` / `function-mapping-check` / `api-coverage-check`
- ✅ `docker-build`
- ✅ `test-e2e` × 5 clients (Python / Node / Go / Java / bq-CLI — 43 passed, 2 skipped — bq-CLI doesn't expose Storage Read/Write gRPC per ADR 0032)
- ✅ `docs-build` (mkdocs strict — ADR 0042 indexed cleanly)

## Test plan

- [x] `make verify` clean locally
- [ ] CI runs the same gates on push
- [ ] **Quality gates** check — first CI run exercising the new `--max-modules B` threshold; must stay green (it does locally)
- [ ] Verify links — ADR 0042's internal cross-refs + GitHub URLs should resolve via the `--remap` config
- [ ] CodeRabbit ASSERTIVE review — address any nits via follow-up commits

## What this PR is NOT

- ❌ **Not** a refactor — pure config + docs change
- ❌ **Not** the `--max-modules B → A` ratchet — that's a future audit + likely-multi-PR campaign (the 14 rank-B modules are the audit list)
- ❌ **Not** a release — CHANGELOG remains release-time-authored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened code quality gates by enforcing stricter cyclomatic complexity limits at the module level.
  * Updated CI/CD workflows and documentation to reflect enhanced complexity requirements across per-function and per-module metrics.
  * Expanded architecture decision records to document updated module complexity governance standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjviscomi/bqemulator/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->