### PR TITLE
release: bump to v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ new release.
 See [`docs/architecture/contributing/documentation-style-guide.md`](docs/architecture/contributing/documentation-style-guide.md)
 for the full entry-form rules and worked examples.
 
+## [1.1.2] - 2026-05-31
+
+### Changed
+
+- Refactor about sixty internal functions across SQL / scripting / jobs / streaming / catalog / versioning modules below cyclomatic complexity rank C with no observable runtime behaviour change.
+- Tighten the cyclomatic-complexity gate's `--max-absolute` and `--max-modules` thresholds from rank C to rank B ([ADR 0041](docs/adr/0041-complexity-ratchet-to-b.md) + [ADR 0042](docs/adr/0042-module-ceiling-ratchet-to-b.md)).
+- Pin `starlette<1.0` to keep the `httpx`-backed `TestClient` working against the starlette 0.x line.
+- Bump GitHub Actions: `actions/checkout` 4.3.1 → 6.0.2, `actions/cache` 4.3.0 → 5.0.5, `docker/setup-buildx-action` 3.12.0 → 4.1.0, `docker/setup-qemu-action` 3.7.0 → 4.1.0, `crate-ci/typos` 1.46.3 → 1.47.0.
+
+### Fixed
+
+- Emit the un-padded year for `FORMAT_DATE('%Y', d)` on dates before year 1000, matching BigQuery's documented behaviour.
+
 ## [1.1.1] - 2026-05-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ DuckDB-backed, SQLGlot-powered, and tested against the real service. Point the o
 [![E2E](https://github.com/jjviscomi/bqemulator/actions/workflows/e2e.yml/badge.svg)](https://github.com/jjviscomi/bqemulator/actions/workflows/e2e.yml)
 [![Conformance](https://github.com/jjviscomi/bqemulator/actions/workflows/conformance.yml/badge.svg)](https://github.com/jjviscomi/bqemulator/actions/workflows/conformance.yml)
 [![Docs](https://github.com/jjviscomi/bqemulator/actions/workflows/docs.yml/badge.svg)](https://jjviscomi.github.io/bqemulator/)
-[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg?cacheSeconds=120&v=1.1.1)](https://pypi.org/project/bqemulator/)
-[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg?cacheSeconds=120&v=1.1.1)](https://pypi.org/project/bqemulator/)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jjviscomi/bqemulator/badge?v=1.1.1)](https://scorecard.dev/viewer/?uri=github.com/jjviscomi/bqemulator)
+[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg?cacheSeconds=120&v=1.1.2)](https://pypi.org/project/bqemulator/)
+[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg?cacheSeconds=120&v=1.1.2)](https://pypi.org/project/bqemulator/)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jjviscomi/bqemulator/badge?v=1.1.2)](https://scorecard.dev/viewer/?uri=github.com/jjviscomi/bqemulator)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
@@ -201,7 +201,7 @@ See the [`docker-compose/full-stack`](docs/examples/docker-compose/full-stack/) 
 
 ## What works today
 
-`bqemulator` is at **v1.1.1** — first minor on the production-stable
+`bqemulator` is at **v1.1.2** — first minor on the production-stable
 line. SemVer applies: breaking changes ship only in MAJOR,
 deprecations live ≥2 MINOR or 6 months. The [compatibility matrix](https://jjviscomi.github.io/bqemulator/latest/reference/compatibility-matrix/) is auto-generated from the conformance corpus on every CI run; the [conformance coverage matrix](https://jjviscomi.github.io/bqemulator/latest/reference/conformance-coverage-matrix/) breaks down support by surface item.
 
@@ -271,7 +271,7 @@ Every example under [`docs/examples/`](docs/examples/) is a complete, runnable p
 
 ## Project status
 
-`bqemulator` is at **v1.1.1** — first minor on the production-stable
+`bqemulator` is at **v1.1.2** — first minor on the production-stable
 line. SemVer applies: breaking changes ship only in MAJOR
 versions, preceded by ≥1 MINOR with deprecation warnings;
 deprecated APIs remain for ≥2 MINOR versions or 6 months.
@@ -286,8 +286,8 @@ Maturity signals:
 - ✅ Fuzz-tier (`Atheris`) harnesses on the SQL translator, dynamic-protobuf decoder, and Arrow bridge.
 - ✅ Differential-tier row-order perturbation of the entire conformance corpus passes.
 - ✅ Performance baselines committed for `darwin-arm64`, with regression gates (`pytest-benchmark` `--benchmark-compare-fail=median:10%`).
-- ✅ PyPI publish via Trusted Publishing (sigstore-attested wheels) — `pip install bqemulator==1.1.1` resolves from [PyPI](https://pypi.org/project/bqemulator/).
-- ✅ GHCR publish with keyless cosign signatures — `docker pull ghcr.io/jjviscomi/bqemulator:1.1.1` resolves and the image is cosign-verifiable.
+- ✅ PyPI publish via Trusted Publishing (sigstore-attested wheels) — `pip install bqemulator==1.1.2` resolves from [PyPI](https://pypi.org/project/bqemulator/).
+- ✅ GHCR publish with keyless cosign signatures — `docker pull ghcr.io/jjviscomi/bqemulator:1.1.2` resolves and the image is cosign-verifiable.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for the complete release-by-release inventory.
 

--- a/docs/examples/ci-recipes/github-actions/README.md
+++ b/docs/examples/ci-recipes/github-actions/README.md
@@ -38,5 +38,5 @@ make test
 Copy `workflow.yml` into your `.github/workflows/` directory and edit:
 
 - `BQEMU_IMAGE` env var — pin to the version you want (e.g.
-  `ghcr.io/jjviscomi/bqemulator:1.1.1`).
+  `ghcr.io/jjviscomi/bqemulator:1.1.2`).
 - The `test:` step — replace with your project's test command.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ Check the health endpoint:
 
 ```bash
 curl http://localhost:9050/healthz
-# {"status":"ok","version":"1.1.1"}
+# {"status":"ok","version":"1.1.2"}
 ```
 
 ## Point a client at it

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ A local emulator for Google BigQuery. Run it on your laptop or in CI and
 point the official Google Cloud client libraries at it.
 
 !!! note "Status"
-    **v1.1.1** — production-stable. SemVer applies: breaking changes
+    **v1.1.2** — production-stable. SemVer applies: breaking changes
     ship only in MAJOR, preceded by ≥1 MINOR with deprecation
     warnings; deprecated APIs remain for ≥2 MINOR or 6 months. See
     the [compatibility matrix](reference/compatibility-matrix.md) for

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -57,7 +57,7 @@ catalog. No row data is copied.
 ## `bqemulator version`
 
 ```
-bqemulator 1.1.1
+bqemulator 1.1.2
 ```
 
 ## Using Google's `bq` CLI against the emulator

--- a/src/bqemulator/__init__.py
+++ b/src/bqemulator/__init__.py
@@ -15,4 +15,4 @@ __all__ = ["__version__"]
 
 # Single source of truth for the version; hatchling reads this via
 # `[tool.hatch.version] path = "src/bqemulator/__init__.py"`.
-__version__ = "1.1.1"
+__version__ = "1.1.2"


### PR DESCRIPTION
## Summary

**v1.1.2 patch release.** This PR makes the version bump + CHANGELOG date stamp + manual doc sweep that the tag push triggers the publish workflows against.

The audit pass (PR #110) landed first. This PR is purely the release commit on top of audit-clean docs.

## What's in this release

**Changed:**
- Complete the cyclomatic-complexity C→B campaign — refactor ~60 internal functions across SQL / scripting / jobs / streaming / catalog / versioning modules below rank C (no behaviour change).
- Tighten the gate's `--max-absolute` and `--max-modules` thresholds from C to B ([ADR 0041](docs/adr/0041-complexity-ratchet-to-b.md) + [ADR 0042](docs/adr/0042-module-ceiling-ratchet-to-b.md)).
- Pin `starlette<1.0` to keep the `httpx`-backed `TestClient` working.

**Fixed:**
- Emit the un-padded year for `FORMAT_DATE('%Y', d)` on dates before year 1000, matching BigQuery's documented behaviour.

## Files changed (7)

| File | Change |
|---|---|
| `src/bqemulator/__init__.py` | `__version__ = "1.1.1"` → `"1.1.2"` |
| `CHANGELOG.md` | New `## [1.1.2] - 2026-05-30` section (3 Changed + 1 Fixed) |
| `README.md` | 3 badge cache-bust suffixes + 4 body refs (Project status × 2, pip install, docker pull) |
| `docs/index.md` | Status callout v1.1.1 → v1.1.2 |
| `docs/getting-started.md` | healthz example output v1.1.1 → v1.1.2 |
| `docs/reference/cli.md` | `bqemulator version` example v1.1.1 → v1.1.2 |
| `docs/examples/ci-recipes/github-actions/README.md` | example image pin v1.1.1 → v1.1.2 |

+24 / −12. Shape matches the v1.1.1 release commit ([c109b4e](https://github.com/jjviscomi/bqemulator/commit/c109b4e)).

## Validation

Full `make verify` gate clean locally on the bumped state:

- ✅ `lint` (ruff + typos)
- ✅ `quality-complexity` (both `--max-absolute B` + `--max-modules B`)
- ✅ `test` (266 unit + integration tests)
- ✅ `test-coverage` (99.4%)
- ✅ All four docs-drift gates (coverage / compat / function-mapping / api-coverage)
- ✅ `docker-build`
- ✅ `test-e2e` × 5 clients
- ✅ `docs-build` (mkdocs strict)

## Tag

The `v1.1.2` annotated tag is **created locally only** (SSH-signed, points at `9280bc3`). It will be re-pointed at this PR's squash-merge commit on `main` after merge, then pushed — the tag push is what triggers the publish workflows:

- `release.yml` — PyPI Trusted Publishing (sigstore-attested wheels)
- `docker.yml` — GHCR multi-arch image (`linux/amd64,linux/arm64`) + cosign keyless signing + SLSA Build Provenance
- `release.yml` — GitHub Release create with artifact attestations
- `docs.yml` — mike-versioned docs deploy (publishes `/v1.1.2/` + updates `/latest/`)

## Test plan

- [x] Full `make verify` clean locally on the bumped state
- [ ] CI runs the same gates on push
- [ ] **Quality gates** must stay green at the new B/B/A threshold
- [ ] All 5 e2e client suites pass
- [ ] CodeRabbit review — address nits via follow-up commits on `release/v1.1.2`
- [ ] After merge: retag onto main's squash commit, push tag, watch the publish workflows complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date year formatting for years before 1000

* **Chores**
  * Version bumped to 1.1.2

* **Documentation**
  * Updated README, docs, examples, and CLI output to reference version 1.1.2
<!-- end of auto-generated comment: release notes by coderabbit.ai -->