### PR TITLE
chore(conformance): scrub internal GCP project id from fixtures and recorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,8 +182,7 @@ for the full entry-form rules and worked examples.
   Coverage-matrix regenerated: corpus fixture count grows by 18
   (1141 → 1159); the INFORMATION_SCHEMA category lifts from
   **0 / 6 covered** to **6 / 6 covered** (all green, no XFAILs).
-  Recording cost: ~$0 against ``perigon-health-nonprod-svc`` (18
-  queries × 10 MiB minimum scan).
+  Recording cost: ~$0 (18 queries × 10 MiB minimum scan).
 
 ### Changed
 

--- a/scripts/record_conformance_fixtures.py
+++ b/scripts/record_conformance_fixtures.py
@@ -115,6 +115,12 @@ DEFAULT_BYTE_CAP = 1 * 1024 * 1024 * 1024  # 1 GiB
 # payload shape is purely additive.
 FIXTURE_VERSION = 2
 
+#: The recorded ``bigquery.project`` field is informational — the runner
+#: never compares it. Emit a neutral placeholder instead of the operator's
+#: real ``--project`` so a private project id can never leak into a
+#: committed fixture.
+FIXTURE_PROJECT_PLACEHOLDER = "your-bigquery-project"
+
 # Duration-class thresholds (informational; not used for comparison).
 DURATION_FAST_MS = 1_000
 DURATION_MEDIUM_MS = 10_000
@@ -421,7 +427,7 @@ def _record_one(  # noqa: PLR0915 — the recorder body is a linear pipeline
                 payload = _build_error_payload(
                     fixture=fixture,
                     exc=exc,
-                    project=project,
+                    project=FIXTURE_PROJECT_PLACEHOLDER,
                     location=client.location or "",
                     dataset_fqdn=dataset_fqdn,
                     wall_ms=wall_ms,
@@ -456,7 +462,7 @@ def _record_one(  # noqa: PLR0915 — the recorder body is a linear pipeline
                     payload: dict[str, Any] = {
                         "fixture_version": FIXTURE_VERSION,
                         "bigquery": {
-                            "project": project,
+                            "project": FIXTURE_PROJECT_PLACEHOLDER,
                             "job_id": job.job_id,
                             "location": job.location or client.location or "",
                             "total_bytes_processed": bytes_processed,

--- a/tests/conformance/sql_corpus/information_schema/is_columns_basic/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_columns_basic/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "0e38d6fa-1af0-424b-ae4c-f8730d3d86d8",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_columns_partitioning_column/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_columns_partitioning_column/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "3728e27a-1943-4299-a3b7-ffed0346a61a",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_columns_with_struct_field/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_columns_with_struct_field/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "2e3b8f09-513f-49d8-a2bc-32407308e53f",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_partitions_basic/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_partitions_basic/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "ad1deaa5-3ba7-4998-b9d5-28197a68fa4a",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_partitions_empty_table/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_partitions_empty_table/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "b46f2901-b33f-4bcf-aee9-916899aa8dba",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_partitions_ingestion_time/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_partitions_ingestion_time/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "28c0bf57-44e7-49f3-b1b9-72886a8fbd68",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_schemata_basic/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_schemata_basic/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "31236301-eda0-4500-9777-565777a87cd2",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_schemata_empty_project/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_schemata_empty_project/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "051e8ecc-3348-4b30-8357-962fdbe8e48c",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_schemata_with_filter/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_schemata_with_filter/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "1d68647e-c232-4de4-b1a4-4d5f7ce73bba",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_table_options_basic/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_table_options_basic/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "58e0785b-d245-4703-8c1f-066d38afaaeb",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_table_options_description/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_table_options_description/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "a6b5decb-127a-4a70-a19d-35886a150b02",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_table_options_partition_filter/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_table_options_partition_filter/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "b5d30106-67a3-4cdf-ad2a-6d4724d86d3d",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_tables_basic/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_tables_basic/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "29520ace-86af-43ed-bb4c-274fd81208d2",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_tables_filter_by_type/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_tables_filter_by_type/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "abf3989d-b0ad-4651-b39f-f22f17618dcf",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_tables_select_specific_columns/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_tables_select_specific_columns/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "b6a15106-08ab-4fdb-b929-5d6ef38025d1",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_views_basic/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_views_basic/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "95b56d03-a6c5-495f-9552-43340973de6c",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_views_empty_dataset/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_views_empty_dataset/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "b9a15d39-451e-4913-a9c0-602e8cf35759",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/information_schema/is_views_with_definition/expected.json
+++ b/tests/conformance/sql_corpus/information_schema/is_views_with_definition/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "7e71e9ca-927d-4c4d-87d3-05ffd81786ba",
     "location": "US",
     "total_bytes_processed": 10485760,

--- a/tests/conformance/sql_corpus/standard_functions/tpcds_q12/expected.json
+++ b/tests/conformance/sql_corpus/standard_functions/tpcds_q12/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "5c8b989c-13dd-4d83-8a2a-3d628f4c4336",
     "location": "US",
     "total_bytes_processed": 725,

--- a/tests/conformance/sql_corpus/standard_functions/tpcds_q20/expected.json
+++ b/tests/conformance/sql_corpus/standard_functions/tpcds_q20/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "95032cc5-5213-4668-a445-d1ecf3db3cbd",
     "location": "US",
     "total_bytes_processed": 725,

--- a/tests/conformance/sql_corpus/standard_functions/tpcds_q37/expected.json
+++ b/tests/conformance/sql_corpus/standard_functions/tpcds_q37/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "6eb3f167-642c-4e46-98a2-1c24a4816f97",
     "location": "US",
     "total_bytes_processed": 716,

--- a/tests/conformance/sql_corpus/standard_functions/tpcds_q45/expected.json
+++ b/tests/conformance/sql_corpus/standard_functions/tpcds_q45/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "1053f050-d53a-4d14-bc48-822be8951bca",
     "location": "US",
     "total_bytes_processed": 691,

--- a/tests/conformance/sql_corpus/standard_functions/tpcds_q57/expected.json
+++ b/tests/conformance/sql_corpus/standard_functions/tpcds_q57/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "52ffe7f2-a65a-4f04-9491-3e357ee53c08",
     "location": "US",
     "total_bytes_processed": 785,

--- a/tests/conformance/sql_corpus/standard_functions/tpcds_q65/expected.json
+++ b/tests/conformance/sql_corpus/standard_functions/tpcds_q65/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "bd744464-5acd-4a5b-9310-0858be12fa2c",
     "location": "US",
     "total_bytes_processed": 810,

--- a/tests/conformance/sql_corpus/standard_functions/tpcds_q79/expected.json
+++ b/tests/conformance/sql_corpus/standard_functions/tpcds_q79/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "581f4e2d-ab01-47ae-8487-ead5b2136f3d",
     "location": "US",
     "total_bytes_processed": 919,

--- a/tests/conformance/sql_corpus/standard_functions/tpcds_q81/expected.json
+++ b/tests/conformance/sql_corpus/standard_functions/tpcds_q81/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "6e9509b5-f50d-4182-8472-91584fe3135e",
     "location": "US",
     "total_bytes_processed": 727,

--- a/tests/conformance/sql_corpus/standard_functions/tpcds_q82/expected.json
+++ b/tests/conformance/sql_corpus/standard_functions/tpcds_q82/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "c01a3071-2a0e-41a6-b8b7-6f79af4e6bbc",
     "location": "US",
     "total_bytes_processed": 668,

--- a/tests/conformance/sql_corpus/standard_functions/tpcds_q93/expected.json
+++ b/tests/conformance/sql_corpus/standard_functions/tpcds_q93/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "68cbf43a-34a2-4f5a-89f7-d18665d16569",
     "location": "US",
     "total_bytes_processed": 393,

--- a/tests/conformance/sql_corpus/standard_functions/tpcds_q98/expected.json
+++ b/tests/conformance/sql_corpus/standard_functions/tpcds_q98/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_version": 2,
   "bigquery": {
-    "project": "perigon-health-nonprod-svc",
+    "project": "your-bigquery-project",
     "job_id": "6a7b8ed9-5c33-46ae-9085-890f17ee7b0d",
     "location": "US",
     "total_bytes_processed": 725,


### PR DESCRIPTION
## Summary

Scrub an internal GCP project id that had leaked into recorded conformance fixtures and one CHANGELOG line, and fix the recorder so it cannot recur.

## Motivation

The conformance recorder writes its `--project` value verbatim into every fixture's `expected.json` `bigquery.project` field. That field is informational — the conformance runner never compares it — but recording against a real project baked a private project id into committed fixtures and a CHANGELOG note. Private project/config identifiers must not live in a public repository.

## Changes

- Replace the leaked project id with the neutral `your-bigquery-project` placeholder across the 29 affected `expected.json` fixtures (`information_schema/` + `standard_functions/tpcds_*`) and the CHANGELOG line.
- **Root-cause fix:** `scripts/record_conformance_fixtures.py` now emits the `your-bigquery-project` placeholder for `bigquery.project` instead of the operator's real `--project`, so future recordings can't leak it. `_build_error_payload`'s contract is unchanged (sanitization happens at the call site), so its unit test needs no change.

## Testing

- [x] Unit tests pass — recorder unit tests unchanged and green (11/11)
- [ ] Property tests — N/A
- [x] Integration tests — affected conformance fixtures still pass (676 passed; `bigquery.project` is not compared)
- [ ] E2E — N/A (no runtime/protocol change)
- [x] `make lint test-unit` passes locally
- [x] Coverage — no `bqemulator` source lines changed (fixture data + dev-only script)

## Documentation

- [ ] User guide — N/A
- [x] Reference docs — none affected
- [ ] Architecture doc — N/A
- [ ] ADR — N/A (privacy hygiene, no architectural decision)
- [ ] Runnable example — N/A

## Release hygiene

- [ ] `CHANGELOG.md` entry under `Unreleased` — N/A (release-time authoring; this corrects a released entry by removing a private identifier)
- [ ] Catalog migration — N/A
- [x] No `TODO` / `FIXME` without a linked issue number
- [x] Conventional Commits used

## Related

- Sibling privacy-hygiene cleanup alongside #113.

## Scope

This scrubs the working tree and prevents recurrence. It intentionally does **not** rewrite git history; eradicating the identifier from prior history would require rewriting the protected default branch and is out of scope for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified CHANGELOG entry for version 1.0.1's recording cost information by removing service-specific references while maintaining cost and scan-size details.

* **Bug Fixes**
  * Improved security in conformance test fixture recording by utilizing placeholder values for BigQuery project identifiers, preventing sensitive project information from being exposed in committed test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->