### PR TITLE
fix(deps): cap grpcio-tools and grpcio-health-checking below 1.81

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,19 @@ dependencies = [
     "fastapi>=0.110,!=0.136.3",
     "uvicorn[standard]>=0.27",
     "grpcio>=1.60",
-    "grpcio-tools>=1.60",
-    "grpcio-health-checking>=1.60",
+    # ``grpcio-tools`` and ``grpcio-health-checking`` each declare
+    # ``Requires-Dist: grpcio>=<their own version>`` and ship generated stubs
+    # with a matching runtime guard. ``grpc_api/server.py`` imports
+    # ``grpc_health.v1`` at startup, so a ``grpcio-health-checking`` newer than
+    # the installed ``grpcio`` raises ``RuntimeError`` and the emulator won't
+    # start; a newer ``grpcio-tools`` is a pip-flagged incompatibility. The repo's
+    # example lock files (``docs/examples/python/*/requirements.txt``) pin
+    # ``grpcio==1.80.0`` and install bqemulator editable alongside them, so cap
+    # both to <1.81 to stay consistent with that ``grpcio``. ``grpcio`` itself is
+    # left uncapped so the core tracks the latest runtime. Lift once those
+    # example locks move ``grpcio`` to >=1.81.
+    "grpcio-tools>=1.60,<1.81",
+    "grpcio-health-checking>=1.60,<1.81",
     "protobuf>=4.25",
     "googleapis-common-protos>=1.62",
     # Storage Read/Write API servicer uses proto-plus types from this package.


### PR DESCRIPTION
## Summary

Cap `grpcio-tools` and `grpcio-health-checking` to `<1.81` so they can't float ahead of the `grpcio` version that data-stack frameworks pin — fixing the four example/integration CI jobs that currently fail because the emulator's gRPC health service won't import.

## Motivation

`grpcio-tools` and `grpcio-health-checking` embed a generated-code runtime guard requiring the installed `grpcio` to be **at least their own version**. The example jobs install bqemulator (`pip install -e ".[dev,all]"`) — whose `>=1.60` floor let those two resolve to `1.81.0` — then install the example lock files, which pin `grpcio==1.80.0` (via `grpcio-status`). The resulting `grpcio 1.80.0` + `grpcio-health-checking 1.81.0` mismatch makes `grpc_health.v1.health_pb2_grpc` raise `RuntimeError` on import, so the emulator never starts.

All four failing jobs — `dbt-local`, `airflow-dag-test`, `pyspark-bigquery`, `pytest-integration` — share this single cause. Core, conformance, and e2e jobs are unaffected (their envs resolve the trio consistently). This also protects any downstream user installing bqemulator alongside a framework that pins grpcio.

## Changes

- Cap `grpcio-tools` and `grpcio-health-checking` to `>=1.60,<1.81` in `pyproject.toml`, with a comment explaining the constraint and when to lift it. `grpcio` itself stays uncapped — its `>=1.80.0` guard is satisfied at 1.81.

## Testing

- [x] Reproduced the CI install order locally (bqemulator's capped grpc constraints, then the example's `grpcio==1.80.0` pin): the trio resolves to a consistent `1.80.0` and `grpc_health.v1.health_pb2_grpc` imports cleanly — no `RuntimeError`.
- [x] Confirmed the grpc trio's `1.80.x` line has only `1.80.0`, so `<1.81` resolves to exactly `1.80.0`, matching the framework pin.
- CI exercises all four example jobs end-to-end.
- Remaining checklist items N/A — dependency-constraint change only, no source or behaviour change.

## Related

- Unblocks the example/integration CI shared by open PRs (including #113); pre-existing failure surfaced when `grpcio` 1.81.0 was released, independent of those PRs' code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened version constraints for gRPC-related runtime dependencies to ensure compatibility and avoid runtime/import issues; added inline rationale for the chosen version bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->