### PR TITLE
fix(scripting): sync CREATE SCHEMA datasets in multi-statement scripts

### DIFF
--- a/docs/adr/0023-conformance-divergence-baseline.md
+++ b/docs/adr/0023-conformance-divergence-baseline.md
@@ -586,6 +586,35 @@ interpreter. `DROP MATERIALIZED VIEW` and `DROP SNAPSHOT TABLE`
 continue to route through the versioning DDL manager, which already
 reconciles the catalog.
 
+**Amendment (2026-06-01) — `CREATE SCHEMA` catalog sync wired into the
+script interpreter.** The 2026-05-27 amendment added
+`sync_created_schema` but wired it only into the single-statement
+executor path (`_run_query_body`); the script interpreter's `_exec_sql`
+hook called `sync_created_table` / `sync_created_view` (and later
+`sync_dropped_object`) but not `sync_created_schema`. As a result, a
+bare `CREATE SCHEMA` inside a multi-statement script created the DuckDB
+schema but left the dataset unregistered in the catalog, so it stayed
+invisible to `INFORMATION_SCHEMA.SCHEMATA` and `datasets.list` —
+diverging from real BigQuery and from the single-statement path, which
+already registered it. A single `CREATE SCHEMA ds;` routes to the
+executor fast path (`is_scripted` is false for a lone statement), so
+the gap surfaced only once a second statement tipped the job into the
+interpreter. `ScriptInterpreter._exec_sql` now calls
+`sync_created_schema` alongside the other sync helpers, so SQL-created
+datasets are catalog-visible regardless of whether the statement ran
+standalone or inside a script. Pinned by interpreter-wiring unit tests
+(`TestCreateSchemaSyncWiring` in `tests/unit/catalog/test_ddl_sync.py`)
+covering the executor fast path, the script path, and a
+SCHEMATA-visibility composition, plus end-to-end coverage across all
+five conformance clients in their `routines_scripting` suites. A
+recorded conformance fixture was evaluated and deliberately omitted: a
+multi-statement `CREATE SCHEMA` fixture either leaves a dataset in the
+shared session-scoped corpus emulator (perturbing the dataset-listing
+fixtures) or, if it self-cleans with a trailing `DROP SCHEMA`, records
+an empty BigQuery result — BigQuery returns the final statement's
+result, not the last row-producing statement's — so the script-path
+parity is pinned by the unit and e2e tiers instead.
+
 #### Bucket G — RANGE / INTERVAL wire format — Closed
 
 **Status.** Closed. The closure ships three coordinated

--- a/src/bqemulator/scripting/interpreter.py
+++ b/src/bqemulator/scripting/interpreter.py
@@ -28,6 +28,7 @@ import sqlglot
 from sqlglot import exp
 
 from bqemulator.catalog.ddl_sync import (
+    sync_created_schema,
     sync_created_table,
     sync_created_view,
     sync_dropped_object,
@@ -668,6 +669,13 @@ class ScriptInterpreter:
         table = await self._run_query(sql)
         if _is_row_producing(sql):
             self._final_table = table
+        # Register plain ``CREATE [OR REPLACE] SCHEMA`` (dataset) outputs
+        # so a dataset created inside a multi-statement script is
+        # catalog-visible (INFORMATION_SCHEMA.SCHEMATA, datasets.list),
+        # matching real BigQuery and the single-statement executor path.
+        # Synced before the table sync so a later ``CREATE TABLE`` in the
+        # same script finds its dataset already registered.
+        sync_created_schema(sql, self._project_id, self._ctx)
         # ADR 0023 §1.F — register plain ``CREATE [OR REPLACE] TABLE``
         # outputs in the catalog so a follow-on snapshot / clone / MV
         # finds the source via ``catalog.get_table``.

--- a/tests/e2e/bq_cli_client/test_routines_scripting.py
+++ b/tests/e2e/bq_cli_client/test_routines_scripting.py
@@ -121,3 +121,31 @@ def test_javascript_udf(bq_runner: BqRunner) -> None:
         assert out == [{"r": "42"}]
     finally:
         _rm_dataset(bq_runner, ds_id)
+
+
+def test_scripted_create_schema_is_listed(bq_runner: BqRunner) -> None:
+    """A ``CREATE SCHEMA`` inside a multi-statement script registers the dataset.
+
+    A single-statement ``CREATE SCHEMA`` takes the executor fast path; the
+    trailing ``SELECT`` tips this job into the scripting interpreter, whose
+    DDL-sync hook must register the dataset so it surfaces via ``bq ls``.
+    """
+    ds_id = "bq_cli_scripted_created_schema"
+    try:
+        # Guard against a stale dataset left by an interrupted run.
+        _rm_dataset(bq_runner, ds_id)
+
+        created = bq_runner.run(
+            "query",
+            "--use_legacy_sql=false",
+            f"CREATE SCHEMA `{ds_id}`;\nSELECT 1 AS n;",
+        )
+        assert created.succeeded(), created.stderr
+
+        # Project-level listing surfaces the script-created dataset.
+        listed = bq_runner.run("ls", "--format=json")
+        assert listed.succeeded(), listed.stderr
+        dataset_ids = {row["datasetReference"]["datasetId"] for row in listed.json()}
+        assert ds_id in dataset_ids
+    finally:
+        _rm_dataset(bq_runner, ds_id)

--- a/tests/e2e/go_client/routines_scripting_test.go
+++ b/tests/e2e/go_client/routines_scripting_test.go
@@ -113,3 +113,53 @@ END IF;
 		t.Fatalf("expected answer=18, got %v", row[0])
 	}
 }
+
+// TestScriptedCreateSchemaIsListed checks that a CREATE SCHEMA inside a
+// multi-statement script registers the dataset in the catalog so it
+// surfaces via datasets.list and datasets.get. A single-statement
+// CREATE SCHEMA takes the executor fast path; the trailing SELECT tips
+// this job into the scripting interpreter, whose DDL-sync hook must run.
+func TestScriptedCreateSchemaIsListed(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	client := routines_scriptingClient(ctx, t)
+	defer client.Close()
+
+	dsID := "scripted_created_schema_go_ds"
+	ds := client.Dataset(dsID)
+	// Guard against a stale dataset left by an interrupted run.
+	_ = ds.DeleteWithContents(ctx)
+	defer func() {
+		if err := ds.DeleteWithContents(ctx); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	}()
+
+	script := fmt.Sprintf("CREATE SCHEMA `%s`;\nSELECT 1 AS n;", dsID)
+	if _, err := client.Query(script).Read(ctx); err != nil {
+		t.Fatalf("script query: %v", err)
+	}
+
+	found := false
+	it := client.Datasets(ctx)
+	for {
+		d, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Fatalf("list datasets: %v", err)
+		}
+		if d.DatasetID == dsID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("dataset %q absent from datasets.list after scripted CREATE SCHEMA", dsID)
+	}
+
+	if _, err := ds.Metadata(ctx); err != nil {
+		t.Fatalf("datasets.get %q: %v", dsID, err)
+	}
+}

--- a/tests/e2e/java_client/src/test/java/com/example/RoutinesScriptingTest.java
+++ b/tests/e2e/java_client/src/test/java/com/example/RoutinesScriptingTest.java
@@ -3,6 +3,7 @@ package com.example;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.FieldValueList;
@@ -20,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * E2E: Phase 6 routines + scripting via the google-cloud-bigquery Java client.
@@ -107,6 +110,45 @@ END IF;
                 QueryJobConfiguration.newBuilder(script).setUseLegacySql(false).build());
         FieldValueList row = result.iterateAll().iterator().next();
         assertEquals(18L, row.get("answer").getLongValue());
+    }
+
+    @Test
+    void testScriptedCreateSchemaIsListed() throws Exception {
+        // A single-statement CREATE SCHEMA takes the executor fast path; the
+        // trailing SELECT tips this job into the scripting interpreter, whose
+        // DDL-sync hook must register the dataset so it surfaces via
+        // datasets.list and datasets.get.
+        String scriptedDs = "scripted_created_schema_java_ds";
+        try {
+            client.delete(DatasetId.of(PROJECT, scriptedDs),
+                    BigQuery.DatasetDeleteOption.deleteContents());
+        } catch (Exception ignore) {
+            // absent is fine
+        }
+        try {
+            String script = "CREATE SCHEMA `" + scriptedDs + "`;\nSELECT 1 AS n;";
+            client.query(QueryJobConfiguration.newBuilder(script).setUseLegacySql(false).build());
+
+            boolean found = false;
+            for (Dataset ds : client.listDatasets(PROJECT).iterateAll()) {
+                if (scriptedDs.equals(ds.getDatasetId().getDataset())) {
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue(found,
+                    "dataset " + scriptedDs + " absent from datasets.list after scripted CREATE SCHEMA");
+
+            assertNotNull(client.getDataset(DatasetId.of(PROJECT, scriptedDs)),
+                    "datasets.get returned null for " + scriptedDs);
+        } finally {
+            try {
+                client.delete(DatasetId.of(PROJECT, scriptedDs),
+                        BigQuery.DatasetDeleteOption.deleteContents());
+            } catch (Exception ignore) {
+                // fine
+            }
+        }
     }
 
     private void createRoutine(

--- a/tests/e2e/nodejs_client/test/routines_scripting.test.js
+++ b/tests/e2e/nodejs_client/test/routines_scripting.test.js
@@ -111,4 +111,35 @@ END IF;
     const names = rows.map((r) => r.routine_name);
     assert.deepEqual(names, ["js_double", "one_to_n", "sql_inc"]);
   });
+
+  it("registers a CREATE SCHEMA created inside a multi-statement script", async () => {
+    // A single-statement CREATE SCHEMA takes the executor fast path; the
+    // trailing SELECT tips this job into the scripting interpreter, whose
+    // DDL-sync hook must register the dataset so it surfaces via
+    // datasets.list and datasets.get.
+    const scriptedDs = "scripted_created_schema_node_ds";
+    // Guard against a stale dataset left by an interrupted run.
+    await client
+      .dataset(scriptedDs)
+      .delete({ force: true })
+      .catch(() => {});
+    try {
+      await client.query(`CREATE SCHEMA \`${scriptedDs}\`;\nSELECT 1 AS n;`);
+
+      const [datasets] = await client.getDatasets();
+      const ids = datasets.map((d) => d.id);
+      assert.ok(
+        ids.includes(scriptedDs),
+        `dataset ${scriptedDs} absent from datasets.list after scripted CREATE SCHEMA`,
+      );
+
+      const [exists] = await client.dataset(scriptedDs).exists();
+      assert.ok(exists, `datasets.get failed for ${scriptedDs}`);
+    } finally {
+      await client
+        .dataset(scriptedDs)
+        .delete({ force: true })
+        .catch(() => {});
+    }
+  });
 });

--- a/tests/e2e/python_client/test_routines_scripting.py
+++ b/tests/e2e/python_client/test_routines_scripting.py
@@ -220,3 +220,26 @@ def test_routines_scripting_dml_flow(bq_client: bigquery.Client) -> None:
             delete_contents=True,
             not_found_ok=True,
         )
+
+
+def test_scripted_create_schema_is_listed(bq_client: bigquery.Client) -> None:
+    """A ``CREATE SCHEMA`` inside a multi-statement script registers the dataset.
+
+    A single-statement ``CREATE SCHEMA`` takes the executor fast path;
+    the trailing ``SELECT`` tips this job into the scripting interpreter,
+    whose DDL-sync hook must register the dataset so it surfaces via
+    ``datasets.list`` and ``datasets.get``, matching real BigQuery.
+    """
+    ds_id = "scripted_created_schema_ds"
+    fqdn = f"{bq_client.project}.{ds_id}"
+    try:
+        # Guard against a stale dataset left by an earlier interrupted run.
+        bq_client.delete_dataset(fqdn, delete_contents=True, not_found_ok=True)
+
+        bq_client.query(f"CREATE SCHEMA `{ds_id}`;\nSELECT 1 AS n;").result()
+
+        listed = {ds.dataset_id for ds in bq_client.list_datasets()}
+        assert ds_id in listed
+        assert bq_client.get_dataset(fqdn).dataset_id == ds_id
+    finally:
+        bq_client.delete_dataset(fqdn, delete_contents=True, not_found_ok=True)

--- a/tests/unit/catalog/test_ddl_sync.py
+++ b/tests/unit/catalog/test_ddl_sync.py
@@ -740,3 +740,56 @@ class TestDropSyncWiring:
         script = "CREATE TABLE `p.ds.scripted` (id INT64);\nDROP TABLE `p.ds.scripted`;"
         await execute_query_job("p", "job-script", script, None, ctx)
         assert ctx.catalog.get_table("p", "ds", "scripted") is None
+
+
+class TestCreateSchemaSyncWiring:
+    """CREATE SCHEMA through ``execute_query_job`` registers the dataset end-to-end."""
+
+    async def test_single_statement_create_schema_registers_dataset(
+        self,
+        ctx: AppContext,
+    ) -> None:
+        """A single ``CREATE SCHEMA`` job registers the dataset via the executor path."""
+        assert ctx.catalog.get_dataset("p", "solo_ds") is None
+        await execute_query_job("p", "job-create-schema", "CREATE SCHEMA solo_ds", None, ctx)
+        assert ctx.catalog.get_dataset("p", "solo_ds") is not None
+
+    async def test_scripted_create_schema_registers_dataset(self, ctx: AppContext) -> None:
+        """A multi-statement script routes ``CREATE SCHEMA`` through the interpreter hook.
+
+        A single-statement ``CREATE SCHEMA`` takes the executor fast path
+        (already synced); a script with two or more statements runs
+        through :class:`ScriptInterpreter`, whose ``_exec_sql`` hook must
+        call ``sync_created_schema`` so a dataset created purely inside
+        the script is catalog-visible (``datasets.list`` /
+        INFORMATION_SCHEMA.SCHEMATA), matching real BigQuery. The trailing
+        ``SELECT`` is what tips the job past the single-statement fast
+        path into the interpreter.
+        """
+        assert ctx.catalog.get_dataset("p", "scripted_ds") is None
+        script = "CREATE SCHEMA scripted_ds;\nSELECT 1 AS n;"
+        await execute_query_job("p", "job-script-schema", script, None, ctx)
+        assert ctx.catalog.get_dataset("p", "scripted_ds") is not None
+
+    async def test_scripted_create_schema_visible_in_information_schema(
+        self,
+        ctx: AppContext,
+    ) -> None:
+        """A schema created in a script is visible to a later SCHEMATA query.
+
+        The interpreter registers the ``CREATE SCHEMA`` dataset, and the
+        same script's INFORMATION_SCHEMA.SCHEMATA query — expanded from
+        the catalog — then surfaces it. The ``SELECT`` is the script's
+        last statement, so its single row is the script result (matching
+        BigQuery).
+        """
+        from bqemulator.scripting.interpreter import run_script
+
+        script = (
+            "CREATE SCHEMA scripted_visible_ds;\n"
+            "SELECT schema_name FROM `region-us.INFORMATION_SCHEMA.SCHEMATA` "
+            "WHERE schema_name = 'scripted_visible_ds' ORDER BY schema_name"
+        )
+        result = await run_script(ctx, "p", script)
+        assert result.final_table is not None
+        assert result.final_table.to_pylist() == [{"schema_name": "scripted_visible_ds"}]


### PR DESCRIPTION
## Summary

Fixes a catalog-sync gap in the BigQuery scripting interpreter: a `CREATE SCHEMA` run inside a multi-statement script created the DuckDB schema but did not register the dataset in the catalog, so it stayed invisible to `INFORMATION_SCHEMA.SCHEMATA` and `datasets.list` — diverging from real BigQuery and from the single-statement `jobs.query` path.

A lone `CREATE SCHEMA ds;` routes to the executor fast path (which has called `sync_created_schema` since the 2026-05-27 ADR 0023 amendment) and was already correct; the gap only appeared once a second statement tipped the job into the `ScriptInterpreter`, whose `_exec_sql` hook synced tables, views, and drops but not schemas.

## Change

- Wire `sync_created_schema` into `ScriptInterpreter._exec_sql`, before the table sync (mirroring the executor's ordering so a later `CREATE TABLE` in the same script finds its dataset registered).

## Testing

- **Unit** (`TestCreateSchemaSyncWiring`): single-statement executor path, multi-statement script path (verified to fail without the fix via `git stash`), and a SCHEMATA-visibility composition through `run_script`.
- **E2E**: scripted `CREATE SCHEMA` → dataset-visible scenario added to all five conformance clients (Python, Go, Node.js, Java, `bq` CLI).
- Local gates green: lint, unit (2679), `test-coverage` (≥90% line+branch) + `test-patch-coverage` (≥70%), full conformance corpus, quality/complexity, the coverage/compat/function-mapping/api drift checks, `docker-build`, `test-e2e` ×5, and `docs-build`.

## Notes

- ADR 0023 gains a follow-up amendment documenting the interpreter parity and why a recorded conformance fixture was deliberately omitted: a multi-statement `CREATE SCHEMA` fixture either leaves a dataset in the shared session-scoped corpus emulator (perturbing dataset-listing fixtures) or, when self-cleaning with a trailing `DROP SCHEMA`, records an empty BigQuery result.
- No CHANGELOG entry — this project authors the changelog at release time only.
- Recording the self-cleaning variant surfaced a separate, pre-existing divergence (the interpreter returns the last *row-producing* statement's result; BigQuery returns the last *statement's* result, empty for a script ending in DDL/DML). It is out of scope here and tracked as a separate follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schema creation within multi-statement scripts now properly registers datasets in the catalog, making them discoverable in dataset listings.

* **Tests**
  * Added comprehensive test coverage across multiple client libraries to verify schema registration in scripting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->