### PR TITLE
test(scripting): restore "without"/"outside" mangled by a non-word-bounded rename

### DIFF
--- a/tests/unit/scripting/test_interpreter.py
+++ b/tests/unit/scripting/test_interpreter.py
@@ -1,7 +1,7 @@
 """Unit tests for the scripting interpreter.
 
 These tests use an in-memory DuckDB engine + MemoryCatalogRepository
-so they exercise the full SQL pipeline withresult_val spinning up the REST
+so they exercise the full SQL pipeline without spinning up the REST
 server.
 """
 
@@ -82,7 +82,7 @@ class TestDeclareSet:
         assert result.final_table is not None
         assert result.final_table.column(0).to_pylist() == [42]
 
-    async def test_declare_withresult_val_default(self, ctx: AppContext) -> None:
+    async def test_declare_without_default(self, ctx: AppContext) -> None:
         result = await run_script(ctx, "p", "DECLARE x INT64; SELECT x;")
         assert result.final_table is not None
 
@@ -271,13 +271,13 @@ SELECT result_val;
         assert result.final_table.column(0).to_pylist() == ["caught"]
 
     async def test_raise_bare_propagates(self, ctx: AppContext) -> None:
-        # Withresult_val a handler, RAISE should escape the script.
+        # Without a handler, RAISE should escape the script.
         with pytest.raises(InvalidQueryError):
             await run_script(ctx, "p", "RAISE;")
 
 
 class TestReturnInProcedure:
-    """RETURN result_valside a procedure becomes a script-level early exit."""
+    """RETURN outside a procedure becomes a script-level early exit."""
 
     async def test_return_halts_script(self, ctx: AppContext) -> None:
         script = """


### PR DESCRIPTION
## Summary

Restores four words that a historical non-word-bounded find-replace corrupted in `tests/unit/scripting/test_interpreter.py`. A variable rename (`out` → `result_val`) was applied without word boundaries, splicing `result_val` into unrelated words that happened to contain the substring `out`.

## Motivation

The corruptions are valid Python identifiers / comment text, so the suite kept passing and they went unnoticed — but the test name and prose are wrong (`test_declare_withresult_val_default` is a DECLARE *without* a default; a docstring claims the pipeline runs "withresult_val spinning up the REST server"). Cosmetic/quality cleanup; no behavior change.

## Changes

All in `tests/unit/scripting/test_interpreter.py`:

| Location | Before | After |
|---|---|---|
| module docstring | `…pipeline withresult_val spinning up…` | `…pipeline without spinning up…` |
| test method (L85) | `test_declare_withresult_val_default` | `test_declare_without_default` |
| comment (L274) | `# Withresult_val a handler, RAISE…` | `# Without a handler, RAISE…` |
| class docstring (L280) | `RETURN result_valside a procedure…` | `RETURN outside a procedure…` |

The legitimate `result_val` scripting variables in the same file (`DECLARE` / `SET` / `SELECT` / `INTO result_val`, 25 occurrences) are intentionally left untouched.

## Blast radius

A repo-wide scan across **all tracked files and every extension** confirms these four were the only spliced occurrences:
- `git grep -nE "[A-Za-z]result_val|result_val[A-Za-z]"` (excluding the legit `result_value`/`result_values`) → only these 4 lines.
- Token census `git grep -hoE "[A-Za-z_]*result_val[A-Za-z_]*" | sort | uniq -c` → after fix: only `result_val` (×25, all legit variables); zero spliced tokens.
- Checked corrupted forms of other `out`-words (`output`→`result_valput`, `about`→`abresult_val`, `timeout`→`timeresult_val`, `routine`→`rresult_valine`, `outer`/`outcome`/`layout`/`throughout`, digit-adjacent) → none present.
- Verified every standalone `result_val` is a genuine SQL variable, not a standalone English "out" mangled into a word-bounded `result_val`.

## Testing

- [x] Renamed test collects and passes (`TestDeclareSet::test_declare_without_default`), as do its neighbors (`test_raise_bare_propagates`, `TestReturnInProcedure`).
- [x] `make lint` passes — including `typos`, the gate that would now flag such corruption (`without`/`outside` are clean dictionary words; `withresult_val` was not).
- [x] `make test-unit` — 2725 passed (unchanged count; no test lost in the rename).
- [x] `make test-coverage` — 91.44% (≥90%); `test-patch-coverage` reports no coverable lines in the diff (comments/docstrings/rename only).
- n/a docker-build / e2e ×5 / conformance / docs-build — this is a comment/rename in a unit-test file that no other module imports; it cannot affect those surfaces. CI re-runs the full chain regardless.

## Documentation

- n/a — test-internal naming and comments only; no user-facing docs, ADR, or CHANGELOG entry (CHANGELOG is authored at release time).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected test method naming and clarified test documentation for improved accuracy.

* **Documentation**
  * Enhanced clarity in test comments and module headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->