### PR TITLE
fix(deps): raise pyjwt floor to >=2.13.0 to close PYSEC-2025-183

### DIFF
--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -79,16 +79,6 @@ CVE-2026-45409
 # sweep that bumps idna / requests.
 PYSEC-2026-89
 
-# pyjwt 2.12.1 — PYSEC-2025-183. PyJWT is a direct dep (floor-pinned
-# at 2.12.0 to close the older CVE-2026-32597 JWT validation bypass)
-# but the emulator does NOT use the JWT codepath at runtime — the
-# import lands in the dep graph via ``google-auth`` / ``firebase_admin``
-# and friends. The advisory rolled into the pip-audit DB after the
-# P3.d follow-up (2026-05-20) baseline was checked clean. No upstream
-# fix version is available; tracked for the same dependency-refresh
-# sweep that bumps idna / requests / markdown.
-PYSEC-2025-183
-
 # starlette 0.52.1 — PYSEC-2026-161 (fix in 1.0.1). The starlette
 # version is gated by fastapi's compatibility range; the next
 # fastapi minor (>0.118) will pull starlette 1.0.1 transitively.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,13 +113,14 @@ dependencies = [
     # pip-audit on 2026-05-17. cryptography 46.0.5 → 46.0.7 closes
     # CVE-2026-34073 + CVE-2026-39892 (X.509 / PKCS-7 parsing). pyasn1
     # 0.6.2 → 0.6.3 closes CVE-2026-30922 (BER-encoding edge case).
-    # PyJWT 2.11.0 → 2.12.0 closes CVE-2026-32597 (JWT validation
-    # bypass). Each is transitive via ``google-cloud-bigquery-storage``
-    # → ``google-auth``; floor-pinning here makes the fix mandatory
-    # for any bqemulator install.
+    # PyJWT closes CVE-2026-32597 (JWT validation bypass) at 2.12.0
+    # and PYSEC-2025-183 at 2.13.0, so the floor pins 2.13.0. Each is
+    # transitive via ``google-cloud-bigquery-storage`` → ``google-auth``;
+    # floor-pinning here makes the fix mandatory for any bqemulator
+    # install.
     "cryptography>=46.0.7",
     "pyasn1>=0.6.3",
-    "pyjwt>=2.12.0",
+    "pyjwt>=2.13.0",
     # Floor pin to dodge CVE-2026-25645 in requests 2.32.5
     # (credential-leak on redirect). 2.33.0 is the fixed version.
     # ``requests`` is a transitive of ``google-cloud-bigquery`` and


### PR DESCRIPTION
## Summary

Raise the `pyjwt` floor pin from `>=2.12.0` to `>=2.13.0` to close
**PYSEC-2025-183**, and retire the now-stale suppression for that
advisory in `.pip-audit-ignore`.

## Motivation

PYSEC-2025-183 affects the PyJWT `2.12.x` line. When it landed in the
pip-audit DB there was no upstream fix version available, so it was
suppressed in `.pip-audit-ignore` (with the rationale that the emulator
does not exercise the JWT codepath at runtime — PyJWT arrives only as a
`google-auth` transitive). PyJWT `2.13.0` now ships the fix, so the
honest move is to make the fix mandatory for every `bqemulator` install
via the floor pin and drop the suppression rather than carry a stale
"ignored" entry.

## Changes

- `pyproject.toml`: `pyjwt>=2.12.0` → `pyjwt>=2.13.0`; the floor-pin
  comment now records both advisories the pin covers — CVE-2026-32597
  (closed at 2.12.0) and PYSEC-2025-183 (closed at 2.13.0).
- `.pip-audit-ignore`: remove the `PYSEC-2025-183` entry + its rationale
  block (no longer suppressed — it is fixed, not ignored).

## Testing

- [ ] Unit tests added / updated — **N/A**: dependency-constraint-only
  change, no code paths added or modified.
- [ ] Property tests added / updated — **N/A** (no code change).
- [ ] Integration tests added / updated — **N/A** (no code change).
- [ ] E2E tests added / updated for all four client languages —
  **N/A**: no runtime/behavior change. The full e2e ×5 matrix
  (Python / Node / Go / Java / `bq` CLI) runs in CI; local docker-build +
  e2e were intentionally deferred to CI for this metadata-only bump.
- [x] `make lint test-unit` passes locally — `make lint` (incl.
  **pip-audit**) is green with the shortened ignore list
  (*"No known vulnerabilities found, 18 ignored"*); `make test-coverage`
  (supersets unit) passed at **91.56%** (3414 passed).
- [x] Coverage on changed files is ≥90% — **N/A in practice**: the two
  changed files carry no Python lines, so `make test-patch-coverage`
  reports *"No lines with coverage information in this diff."* Project
  coverage is unchanged at 91.56%.

Additional local gates run green: `quality-complexity`,
`coverage-matrix-check`, `compat-matrix-check`, `function-mapping-check`,
`api-coverage-check`, `docs-build`.

## Documentation

- [ ] User guide — **N/A** (no user-facing feature).
- [ ] Reference docs — **N/A** (no surface/compat/function-mapping change).
- [ ] Architecture doc — **N/A**.
- [ ] ADR added — **N/A**: a dependency security floor pin is not an
  architectural decision; the rationale lives in the `pyproject.toml`
  comment, consistent with the existing floor pins.
- [ ] Runnable example — **N/A**.

## Release hygiene

- [ ] `CHANGELOG.md` entry under `Unreleased` — **intentionally omitted**:
  per the project convention (AGENTS.md), the CHANGELOG is authored at
  release time only, not per-PR.
- [ ] Catalog migration — **N/A** (no schema change).
- [x] No `TODO` / `FIXME` without a linked issue number.
- [x] Conventional Commits used (`fix(deps): …`).

## Related

- Retires the `PYSEC-2025-183` suppression in `.pip-audit-ignore`.
- Sibling to the existing transitive floor pins (`cryptography`,
  `pyasn1`, `requests`, `urllib3`, `python-dotenv`) in `pyproject.toml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PyJWT dependency with an increased minimum version requirement to address and resolve security vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->