### PR TITLE
chore(ci): ignore starlette major Dependabot bumps; cover dependabot.yml in Quality-gates paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,15 +38,16 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "apache-airflow-providers-google"
         update-types: ["version-update:semver-major"]
-      # Starlette 1.0 switched ``starlette.testclient`` from ``httpx``
-      # to ``httpx2`` (``import httpx2 as httpx``), which FastAPI's
-      # ``TestClient`` re-exports — so adopting 1.x breaks the entire
-      # unit + property test tier until ``httpx2`` ships and FastAPI is
-      # on a 1.x-compatible line. The deliberate ``starlette<1.0``
-      # ceiling in pyproject.toml holds the line; the related
-      # PYSEC-2026-161 advisory is tracked in .pip-audit-ignore for a
-      # coordinated FastAPI + Starlette + httpx2 refresh. Suppress the
-      # major bump until that lands.
+      # Starlette 1.x's ``starlette.testclient`` imports ``httpx2``
+      # (``import httpx2 as httpx``), which this project does not depend
+      # on, so FastAPI's ``TestClient`` (which re-exports it) fails to
+      # import with ``ModuleNotFoundError: No module named 'httpx2'`` —
+      # taking down the whole unit + property test tier. The deliberate
+      # ``starlette<1.0`` ceiling in pyproject.toml holds the line until
+      # the project adds an ``httpx2`` dependency and FastAPI is on a
+      # 1.x-compatible line; the related PYSEC-2026-161 advisory is
+      # tracked in .pip-audit-ignore for that coordinated refresh.
+      # Suppress the major bump until then.
       - dependency-name: "starlette"
         update-types: ["version-update:semver-major"]
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,17 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "apache-airflow-providers-google"
         update-types: ["version-update:semver-major"]
+      # Starlette 1.0 switched ``starlette.testclient`` from ``httpx``
+      # to ``httpx2`` (``import httpx2 as httpx``), which FastAPI's
+      # ``TestClient`` re-exports — so adopting 1.x breaks the entire
+      # unit + property test tier until ``httpx2`` ships and FastAPI is
+      # on a 1.x-compatible line. The deliberate ``starlette<1.0``
+      # ceiling in pyproject.toml holds the line; the related
+      # PYSEC-2026-161 advisory is tracked in .pip-audit-ignore for a
+      # coordinated FastAPI + Starlette + httpx2 refresh. Suppress the
+      # major bump until that lands.
+      - dependency-name: "starlette"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "chore(deps)"
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -36,7 +36,8 @@ on:
       - "Makefile"
       # Run on every workflow / dependabot example change too, so the
       # ``Quality gates`` job emits a status on PRs that only touch
-      # ``.github/workflows/*`` or ``docs/examples/**``. Without these
+      # ``.github/workflows/*``, ``.github/dependabot.yml``, or
+      # ``docs/**``. Without these
       # patterns the required-check is "missing" rather than green for
       # those PRs and even ``gh pr merge --admin`` can't bypass it
       # (GitHub treats a never-reported required-check as unresolvable).
@@ -44,6 +45,7 @@ on:
       # workflow- or dependabot-only PR — cheap relative to the
       # never-merge blocker the prior filter caused.
       - ".github/workflows/**"
+      - ".github/dependabot.yml"
       - "docs/**"
       - "CHANGELOG.md"
       - "README.md"
@@ -59,7 +61,8 @@ on:
       - "Makefile"
       # Run on every workflow / dependabot example change too, so the
       # ``Quality gates`` job emits a status on PRs that only touch
-      # ``.github/workflows/*`` or ``docs/examples/**``. Without these
+      # ``.github/workflows/*``, ``.github/dependabot.yml``, or
+      # ``docs/**``. Without these
       # patterns the required-check is "missing" rather than green for
       # those PRs and even ``gh pr merge --admin`` can't bypass it
       # (GitHub treats a never-reported required-check as unresolvable).
@@ -67,6 +70,7 @@ on:
       # workflow- or dependabot-only PR — cheap relative to the
       # never-merge blocker the prior filter caused.
       - ".github/workflows/**"
+      - ".github/dependabot.yml"
       - "docs/**"
       - "CHANGELOG.md"
       - "README.md"


### PR DESCRIPTION
## Summary

Add a Dependabot `version-update:semver-major` ignore for `starlette` so
it stops repeatedly proposing the 1.x constraint widen until the
coordinated httpx2 refresh lands.

## Motivation

Dependabot keeps trying to relax the deliberate `starlette<1.0` ceiling
(most recently #112, which widened it to `<2.0`). Starlette 1.0 switched
`starlette.testclient` from `httpx` to `httpx2`, and FastAPI's
`TestClient` re-exports it — so 1.x breaks the **entire unit + property
test tier** with `ModuleNotFoundError: No module named 'httpx2'`
(confirmed on #112's CI: all 9 unit/property jobs red, e2e/integration
green). The `<1.0` ceiling is intentional, and the underlying security
advisory **PYSEC-2026-161** is already tracked + suppressed in
`.pip-audit-ignore` for a coordinated FastAPI + Starlette + httpx2 bump.
This ignore stops the recurring red-PR churn until that sweep happens.

## Changes

- `.github/dependabot.yml`: add a `starlette` →
  `version-update:semver-major` ignore under the pip ecosystem,
  mirroring the existing `apache-airflow` rule, with an explanatory
  comment.

## Testing

- [x] `make lint` passes locally (incl. `typos` over the new comment).
- [x] `dependabot.yml` validated — parses as YAML and the `starlette`
  ignore is well-formed (`version-update:semver-major`). GitHub also
  validates the config server-side.
- [ ] Unit / property / integration / e2e — **N/A**: CI-config-only
  change, no code paths touched.

## Documentation

- [ ] **N/A** — config change; rationale lives in the file comment and
  the commit message.

## Release hygiene

- [ ] `CHANGELOG.md` — **intentionally omitted** (authored at release
  time only, per AGENTS.md).
- [x] Conventional Commits used (`chore(ci): …`, matching the
  `apache-airflow` ignore precedent).

## Related

- Stops the recurring Dependabot starlette-1.x churn; **#112 is being
  closed** in favor of this rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted dependency update rules to ignore major-version upgrades of a core web framework component, avoiding automatic major bumps.
  * Updated CI configuration so code quality checks also run when dependency update configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->