### PR TITLE
docs: pre-v1.1.3 accuracy sweep — conformance counts, capability claims, authoring guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Three use cases, one binary:
 - 🧠 **Features `goccy/bigquery-emulator` doesn't have** — JavaScript UDFs (embedded V8 via `mini-racer`), procedural scripting (`DECLARE` / `BEGIN…END` / `IF` / `LOOP` / `EXCEPTION` / `BEGIN TRANSACTION`), time travel (`FOR SYSTEM_TIME AS OF`), table snapshots, table clones, materialized views with refresh dispatch, GEOGRAPHY (planar via DuckDB-spatial + S2 helpers), RANGE, INTERVAL, authorized views, row-access policies, `INFORMATION_SCHEMA`.
 - 🔌 **Five-client e2e matrix** — every release is exercised against the official Python, Node.js, Go, and Java BigQuery client libraries plus Google's `bq` CLI in a live Docker container.
 - 🧪 **7-tier test pyramid** — unit + property + integration + conformance + e2e + perf + chaos, plus mutation / fuzz / differential siblings. Combined coverage is gated at ≥90% line + branch.
-- 📐 **Conformance corpus** — 1,244 fixtures recorded against real BigQuery. Drift between the emulator and the real service surfaces as a failing test; documented divergences are pinned with ADR references.
+- 📐 **Conformance corpus** — 1,276 fixtures recorded against real BigQuery. Drift between the emulator and the real service surfaces as a failing test; documented divergences are pinned with ADR references.
 - 🐍 **Native pytest plugin** — `pip install bqemulator` registers a pytest plugin; the `bqemu_server` fixture starts an ephemeral in-process emulator on random free ports and sets `BIGQUERY_EMULATOR_HOST`. No `conftest.py` wiring required.
 - 🐳 **Multi-arch container** — `ghcr.io/jjviscomi/bqemulator` builds for `linux/amd64` + `linux/arm64`, with cosign keyless signatures via GitHub OIDC.
 - 🔭 **Production-grade observability** — `structlog` JSON logs, OpenTelemetry tracing (configurable OTLP exporter), Prometheus metrics endpoint.
@@ -227,13 +227,13 @@ deprecations live ≥2 MINOR or 6 months. The [compatibility matrix](https://jjv
 
 | Status | Surface items | % of deterministic surface |
 |---|---|---|
-| 🟢🟢 Deep (≥6 fixtures) | 98 | 24.3% |
-| 🟢 Covered (3–5 fixtures) | 69 | 17.1% |
-| 🟡 Sampled (1–2 fixtures) | 235 | 58.3% |
+| 🟢🟢 Deep (≥6 fixtures) | 101 | 24.8% |
+| 🟢 Covered (3–5 fixtures) | 68 | 16.7% |
+| 🟡 Sampled (1–2 fixtures) | 238 | 58.3% |
 | 🔴 Uncovered (0 fixtures) | 1 | 0.2% |
-| **Total** | **403** | 100.0% |
+| **Total** | **408** | 100.0% |
 
-Plus **10 non-deterministic items** (`RAND`, `CURRENT_*`, `SESSION_USER`, `GENERATE_UUID`, `TABLESAMPLE`, `FOR SYSTEM_TIME AS OF <expression>`) that are excluded from the conformance corpus by [ADR 0022](docs/adr/0022-conformance-corpus-design.md) and exercised in unit / property / integration tiers instead — bringing the full inventory to **413 surface items across 20 categories**, backed by a **1,244-fixture conformance corpus** (1,170 SQL + 48 HTTP + 26 gRPC) under `tests/conformance/`.
+Plus **10 non-deterministic items** (`RAND`, `CURRENT_*`, `SESSION_USER`, `GENERATE_UUID`, `TABLESAMPLE`, `FOR SYSTEM_TIME AS OF <expression>`) that are excluded from the conformance corpus by [ADR 0022](docs/adr/0022-conformance-corpus-design.md) and exercised in unit / property / integration tiers instead — bringing the full inventory to **418 surface items across 20 categories**, backed by a **1,276-fixture conformance corpus** (1,202 SQL + 48 HTTP + 26 gRPC) under `tests/conformance/`.
 
 We follow a **no-deferral principle**: features either ship complete or are excluded with documented rationale. There is no "TODO for v1.1." Scope boundaries are catalogued in [`docs/reference/out-of-scope.md`](docs/reference/out-of-scope.md).
 

--- a/docs/architecture/conformance-tier.md
+++ b/docs/architecture/conformance-tier.md
@@ -24,9 +24,8 @@ For every query in `tests/conformance/sql_corpus/`:
    `workflow_dispatch` invocation against a specific branch (typical
    use case: verifying a recording-session PR before opening it).
 
-The corpus currently ships **1141 active SQL fixtures + 48 HTTP +
-26 gRPC = 1215 active fixtures** (plus 18 INFORMATION_SCHEMA
-stubs awaiting operator-side recording). 13 fixtures are pinned
+The corpus currently ships **1202 active SQL fixtures + 48 HTTP +
+26 gRPC = 1276 active fixtures**. 12 fixtures are pinned
 XFAIL in `tests/conformance/divergences.py` as permanent
 design-decision divergences. The pass-rate gate is **100%
 non-divergent** — every fixture must either pass or be in the
@@ -129,9 +128,9 @@ field's presence:
   exact match; ``message`` regex-matched against
   ``message_pattern`` via ``re.search`` with DOTALL).
 
-The 644 pre-existing v1 fixtures stay backward-compatible because
-they lack an ``error`` field. Only newly-recorded fixtures get
-``fixture_version`` 2.
+Version-1 (success / row) fixtures stay backward-compatible because
+they lack an ``error`` field; error fixtures carry ``fixture_version``
+2.
 
 The `bigquery.*` block is metadata only — the runner reads it solely
 for diagnostic messages. The comparison is driven by `schema` and

--- a/docs/architecture/contributing/adding-conformance-cases.md
+++ b/docs/architecture/contributing/adding-conformance-cases.md
@@ -1,47 +1,96 @@
 # Adding conformance cases
 
-Conformance tests live at `tests/conformance/sql_corpus/`. Each case is
-one `.sql` file plus a JSON snapshot of the expected result.
+Conformance tests live under `tests/conformance/sql_corpus/`. Each case
+is a **directory** holding the query, optional setup, and a recorded
+snapshot of the result from real BigQuery. The
+[conformance-tier reference](../conformance-tier.md) is the canonical
+description of the harness; this guide is the practical "how to add one"
+path.
 
 ## Structure
 
 ```
 tests/conformance/sql_corpus/
-  safe_divide.sql
-  safe_divide.snapshot.json
+  <surface>/                 # surface area, e.g. rest_crud, routines_scripting
+    <fixture>/               # descriptive snake_case name, e.g. safe_divide_zero_divisor
+      query.sql              # the query under test (required)
+      setup.sql              # DDL/DML to stage data (optional)
+      expected.json          # recorded BigQuery result (required; generated)
 ```
 
-The `.sql` file contains the query with a header comment:
+Group the fixture under the `<surface>` directory that already holds
+related cases.
+
+## `query.sql`
+
+The single query under test — no header comment. Reference the per-test
+dataset through the `${DATASET}` placeholder, which the harness
+substitutes at run time (`_corpus.py`):
 
 ```sql
--- Fixture: none | tpch_sf0_01 | custom_<name>
--- Description: SAFE_DIVIDE returns NULL for zero divisor.
 SELECT SAFE_DIVIDE(10.0, 0) AS zero_case,
-       SAFE_DIVIDE(10.0, 4) AS normal_case;
+       SAFE_DIVIDE(10.0, 4) AS normal_case
 ```
 
-The `.snapshot.json` is produced by running the query against real
-BigQuery; commit only the JSON once verified:
+A fixture that needs tables references them under `${DATASET}`:
+
+```sql
+SELECT id, val FROM `${DATASET}.t` ORDER BY id
+```
+
+## `setup.sql` (optional)
+
+If the query needs tables or routines, stage them in `setup.sql`. The
+runner creates a fresh per-test dataset, runs `setup.sql`, runs
+`query.sql`, then drops the dataset. Literal-only fixtures omit
+`setup.sql` and skip dataset creation.
+
+```sql
+CREATE TABLE `${DATASET}.t` (id INT64, val STRING);
+INSERT INTO `${DATASET}.t` VALUES (1, 'a'), (2, 'b');
+```
+
+## `expected.json`
+
+The recorded baseline — the query result plus the BigQuery job's schema
+and metadata. It is **generated, not hand-written**: record it against a
+real BigQuery project, then commit the JSON.
 
 ```bash
-scripts/record_conformance_fixtures.py safe_divide \
-    --bq-project my-test-project
+python scripts/record_conformance_fixtures.py \
+    --project <your-bigquery-project> \
+    --filter <surface>/<fixture>
 ```
 
-The script writes `safe_divide.snapshot.json` containing the query
-result and the BigQuery job schema.
+`--project` (required) bills the recording jobs; `--filter` is a
+substring match that limits recording to the matching
+`<surface>/<fixture>` ids; `--force` overwrites an existing
+`expected.json`. The recorder enforces a byte-scan cap and refuses to
+overwrite without `--force`. The file shape (`fixture_version`,
+`bigquery`, `schema`, `rows`, `row_count`, `duration_class`, with a
+separate version-2 shape for error fixtures) is documented in the
+[conformance-tier reference](../conformance-tier.md).
 
 ## Runner
 
-`tests/conformance/runner.py` iterates over every `.sql` file,
-executes it against the emulator, and diffs the result against the
-snapshot row-for-row with type-aware tolerance (floats within 1e-9,
-timestamps within ±1 µs).
+`tests/conformance/test_corpus.py` discovers every fixture directory at
+import time and parametrises one pytest test per fixture. It runs
+`query.sql` against the emulator and diffs the result against
+`expected.json` with the type-aware tolerance in `_comparison.py`
+(ADR 0022 §3): `FLOAT64` via `math.isclose(rel_tol=1e-12, abs_tol=1e-15)`
+and `TIMESTAMP` / `DATETIME` / `TIME` within ±1 µs. The full tolerance
+table is in the [conformance-tier reference](../conformance-tier.md).
+
+Replay the tier locally with:
+
+```bash
+make test-conformance
+```
 
 ## Expectations
 
-- **One query per file.** Keeps diff failures scoped.
-- **Deterministic fixture data.** Use TPC-H SF0.01 or a custom fixture
-  loaded via `scripts/load_fixture_<name>.py`.
+- **One query per fixture.** Keeps diff failures scoped to one surface.
+- **Deterministic data.** Stage rows in `setup.sql`; avoid time- or
+  environment-dependent values.
 - **No absolute timestamps** unless the query pins them via literals
   (`TIMESTAMP '2024-04-15 00:00:00 UTC'`).

--- a/docs/architecture/contributing/tpcds-expansion-plan.md
+++ b/docs/architecture/contributing/tpcds-expansion-plan.md
@@ -1,12 +1,12 @@
-# TPC-DS expansion plan — closing the 40-query gap
+# TPC-DS expansion plan — closing the 29-query gap
 
-The conformance corpus today carries **59 of 99** TPC-DS queries (and
+The conformance corpus today carries **70 of 99** TPC-DS queries (and
 22/22 TPC-H). This document tracks the planned expansion to **99/99**
 and lives in the repo so the work survives session boundaries.
 
 ## What's missing
 
-40 queries, enumerated below in numerical order with a one-line
+29 queries, enumerated below in numerical order with a one-line
 **complexity hint** (table count + key SQL feature). "Easier" rows are
 roughly 2-4 tables and a single GROUP BY or window function; "harder"
 rows are 5+ tables, multi-CTE chains, or ROLLUP/GROUPING SETS.
@@ -15,46 +15,35 @@ rows are 5+ tables, multi-CTE chains, or ROLLUP/GROUPING SETS.
 |---|---|---|---|
 | 1 | q10 | 8 tables: customer, c_address, c_demo, h_demo, store_sales, web_sales, catalog_sales, date_dim. EXISTS to 3 fact tables. | hard |
 | 2 | q11 | 6 tables: customer, c_address, store_sales, web_sales, date_dim. Multi-CTE: year1 / year2 ratio. | medium |
-| 3 | q12 | 3 tables: web_sales, item, date_dim. Window SUM OVER PARTITION BY i_class. | easier |
-| 4 | q13 | 4 tables: store_sales, store, customer_demographics, household_demographics + date_dim. Three OR'd customer-segment filters + DECIMAL aggregates. | medium |
-| 5 | q19 | 5 tables: date_dim, store_sales, item, customer, customer_address, store. Manager-rank by brand-category-state. ORDER BY i_brand_id, item, store; LIMIT 100. | medium |
-| 6 | q20 | 3 tables: catalog_sales, item, date_dim. Item revenue ratio over class. Window SUM OVER. | easier |
-| 7 | q25 | 5 tables: store_sales, store_returns, catalog_sales, store, item, date_dim ×3 (sold + returned + reseller). Customer return ratio. | hard |
-| 8 | q26 | 4 tables: catalog_sales, customer_demographics, date_dim, item, promotion. Gender + marital + ed-status filter; promotion ID predicates. | medium |
-| 9 | q30 | 6 tables: web_returns, date_dim, customer_address, customer + customer-state ranking. Top-100 customers per state via CTE. | hard |
-| 10 | q32 | 3 tables: catalog_sales, item, date_dim. SUM(cs_ext_discount_amt) > 1.3 × AVG(...) correlated subquery. | medium |
-| 11 | q33 | 8 tables (3 channels × 3 dimension tables): store/web/catalog_sales × item × date_dim × customer_address. UNION ALL across 3 channels with GMT-zone filter. | hard |
-| 12 | q37 | 3 tables: item, inventory, date_dim, catalog_sales. Item-on-promotion + min-inventory filter. | easier |
-| 13 | q40 | 3 tables: catalog_sales, catalog_returns, date_dim, item, warehouse. Returns net-sales by warehouse + item, date-range PIVOT. | medium |
-| 14 | q45 | 4 tables: web_sales, customer, customer_address, date_dim, item. Zip-prefix filter + city aggregation. | easier |
-| 15 | q46 | 6 tables: store_sales, customer_demographics, household_demographics, customer, customer_address, store, date_dim. Multi-segment customer filter. | medium |
-| 16 | q54 | 8 tables: catalog_sales + web_sales + customer + c_address + store + item + date_dim. Customer-ROI per item class. Multi-CTE. | hard |
-| 17 | q57 | 3 tables: call_center, item, date_dim, catalog_sales. Avg-sales window over call-center / month. | easier |
-| 18 | q58 | 3 tables: store_sales / web_sales / catalog_sales × item × date_dim. Item-rank by week sales across 3 channels. UNION ALL + window. | medium |
-| 19 | q59 | 3 tables: store_sales, date_dim, store. Week-over-week sales ratio. Self-join on week_seq. | medium |
-| 20 | q60 | 8 tables: store/web/catalog_sales × item × date_dim × customer_address. Sales channel UNION ALL + GROUPING SETS-like ROLLUP-by-item. | hard |
-| 21 | q61 | 8 tables: store_sales + promotion + date_dim + customer + customer_address + item + store. Promotion-driven sales ratio (with-promotion / no-promotion). | medium |
-| 22 | q62 | 5 tables: web_sales, warehouse, ship_mode, web_site, date_dim. Shipping-mode aggregates with NULLs for un-shipped. | medium |
-| 23 | q65 | 4 tables: store, item, store_sales, date_dim. DENSE_RANK over store-item revenue. | easier |
-| 24 | q68 | 6 tables: store_sales, date_dim, store, household_demographics, customer_address, customer. Customer-store visit counts. | medium |
-| 25 | q69 | 5 tables: customer, customer_address, customer_demographics, store_sales/web_sales/catalog_sales (EXISTS to one, NOT EXISTS to other two). | hard |
-| 26 | q71 | 6 tables: web_sales / catalog_sales / store_sales × item × time_dim × date_dim × promotion. By-hour sales rank across 3 channels. | medium |
-| 27 | q74 | 6 tables: customer, store_sales, web_sales, date_dim. Year-over-year ratio. Multi-CTE (year1 / year2 per channel). | medium |
-| 28 | q76 | 3 tables (one of: store/web/catalog_sales) × item × date_dim. NULL with missing-value statistics by channel. UNION ALL. | medium |
-| 29 | q78 | 3 tables: store_sales/web_sales/catalog_sales paired with returns. Sales-vs-returns ratio per customer per year. | medium |
-| 30 | q79 | 4 tables: store_sales, date_dim, store, household_demographics. Aggregates by date + customer (clean rendering for the day's grand-total). | easier |
-| 31 | q80 | 8 tables: store_sales / web_sales / catalog_sales each + their returns + date_dim + item + promotion. Returns ratio UNION ALL across 3 channels with ROLLUP. | hard |
-| 32 | q81 | 4 tables: store_returns, customer, customer_address, date_dim. Top-100 customers by return-amt with address fragments. | easier |
-| 33 | q82 | 5 tables: item, inventory, date_dim, store_sales. Item dependency on store sales over date-range. | easier |
-| 34 | q89 | 4 tables: item, store_sales, date_dim, store. Year-over-year monthly trend with AVG window. | medium |
-| 35 | q91 | 5 tables: call_center, catalog_returns, date_dim, customer, customer_address, customer_demographics, household_demographics. Call-center returns by manager. | hard |
-| 36 | q92 | 4 tables: web_sales, item, date_dim. SUM(ws_ext_discount_amt) > 1.3 × AVG correlated subquery. | medium |
-| 37 | q93 | 3 tables: store_sales, store_returns, reason. UPDATE-style net-amount per customer with reason filter. | easier |
-| 38 | q94 | 4 tables: web_sales, web_returns, date_dim, customer_address, web_site. State-filtered returns ratio. | medium |
-| 39 | q95 | 5 tables: web_sales, web_returns, date_dim, customer_address, web_site. Adds late-shipped filter on top of q94's shape. | medium |
-| 40 | q98 | 3 tables: store_sales, item, date_dim. ROLLUP over item-class with retail-price ratio. | easier |
+| 3 | q13 | 4 tables: store_sales, store, customer_demographics, household_demographics + date_dim. Three OR'd customer-segment filters + DECIMAL aggregates. | medium |
+| 4 | q19 | 5 tables: date_dim, store_sales, item, customer, customer_address, store. Manager-rank by brand-category-state. ORDER BY i_brand_id, item, store; LIMIT 100. | medium |
+| 5 | q25 | 5 tables: store_sales, store_returns, catalog_sales, store, item, date_dim ×3 (sold + returned + reseller). Customer return ratio. | hard |
+| 6 | q26 | 4 tables: catalog_sales, customer_demographics, date_dim, item, promotion. Gender + marital + ed-status filter; promotion ID predicates. | medium |
+| 7 | q30 | 6 tables: web_returns, date_dim, customer_address, customer + customer-state ranking. Top-100 customers per state via CTE. | hard |
+| 8 | q32 | 3 tables: catalog_sales, item, date_dim. SUM(cs_ext_discount_amt) > 1.3 × AVG(...) correlated subquery. | medium |
+| 9 | q33 | 8 tables (3 channels × 3 dimension tables): store/web/catalog_sales × item × date_dim × customer_address. UNION ALL across 3 channels with GMT-zone filter. | hard |
+| 10 | q40 | 3 tables: catalog_sales, catalog_returns, date_dim, item, warehouse. Returns net-sales by warehouse + item, date-range PIVOT. | medium |
+| 11 | q46 | 6 tables: store_sales, customer_demographics, household_demographics, customer, customer_address, store, date_dim. Multi-segment customer filter. | medium |
+| 12 | q54 | 8 tables: catalog_sales + web_sales + customer + c_address + store + item + date_dim. Customer-ROI per item class. Multi-CTE. | hard |
+| 13 | q58 | 3 tables: store_sales / web_sales / catalog_sales × item × date_dim. Item-rank by week sales across 3 channels. UNION ALL + window. | medium |
+| 14 | q59 | 3 tables: store_sales, date_dim, store. Week-over-week sales ratio. Self-join on week_seq. | medium |
+| 15 | q60 | 8 tables: store/web/catalog_sales × item × date_dim × customer_address. Sales channel UNION ALL + GROUPING SETS-like ROLLUP-by-item. | hard |
+| 16 | q61 | 8 tables: store_sales + promotion + date_dim + customer + customer_address + item + store. Promotion-driven sales ratio (with-promotion / no-promotion). | medium |
+| 17 | q62 | 5 tables: web_sales, warehouse, ship_mode, web_site, date_dim. Shipping-mode aggregates with NULLs for un-shipped. | medium |
+| 18 | q68 | 6 tables: store_sales, date_dim, store, household_demographics, customer_address, customer. Customer-store visit counts. | medium |
+| 19 | q69 | 5 tables: customer, customer_address, customer_demographics, store_sales/web_sales/catalog_sales (EXISTS to one, NOT EXISTS to other two). | hard |
+| 20 | q71 | 6 tables: web_sales / catalog_sales / store_sales × item × time_dim × date_dim × promotion. By-hour sales rank across 3 channels. | medium |
+| 21 | q74 | 6 tables: customer, store_sales, web_sales, date_dim. Year-over-year ratio. Multi-CTE (year1 / year2 per channel). | medium |
+| 22 | q76 | 3 tables (one of: store/web/catalog_sales) × item × date_dim. NULL with missing-value statistics by channel. UNION ALL. | medium |
+| 23 | q78 | 3 tables: store_sales/web_sales/catalog_sales paired with returns. Sales-vs-returns ratio per customer per year. | medium |
+| 24 | q80 | 8 tables: store_sales / web_sales / catalog_sales each + their returns + date_dim + item + promotion. Returns ratio UNION ALL across 3 channels with ROLLUP. | hard |
+| 25 | q89 | 4 tables: item, store_sales, date_dim, store. Year-over-year monthly trend with AVG window. | medium |
+| 26 | q91 | 5 tables: call_center, catalog_returns, date_dim, customer, customer_address, customer_demographics, household_demographics. Call-center returns by manager. | hard |
+| 27 | q92 | 4 tables: web_sales, item, date_dim. SUM(ws_ext_discount_amt) > 1.3 × AVG correlated subquery. | medium |
+| 28 | q94 | 4 tables: web_sales, web_returns, date_dim, customer_address, web_site. State-filtered returns ratio. | medium |
+| 29 | q95 | 5 tables: web_sales, web_returns, date_dim, customer_address, web_site. Adds late-shipped filter on top of q94's shape. | medium |
 
-Counts: 11 easier, 20 medium, 9 hard.
+Counts: 20 medium, 9 hard.
 
 **Recommended execution order:** ascending complexity within family,
 so the easiest fixtures land first, prove the toolchain, and the hard
@@ -107,7 +96,7 @@ adaptations:
 | ``COUNT_BIG(*)``, ``DECODE()`` | Avoid — use ``COUNT(*)``, ``CASE WHEN`` instead. |
 | ``ROWNUM``, ``CONNECT BY`` | Out of scope; never appears in TPC-DS but worth flagging. |
 
-The 59 existing fixtures collectively exercise every adaptation
+The 70 existing fixtures collectively exercise every adaptation
 pattern. When in doubt, grep the existing corpus for the same
 function / construct.
 
@@ -119,7 +108,7 @@ emulator's corpus deliberately uses **minimal seeded data** (a few
 rows per dimension; a few rows per fact) so:
 
 * Each recording job scans < 1 MiB (well under the cap).
-* The total cost of recording all 40 fixtures is ~$0.001 (TPC-DS SF=1
+* The total cost of recording all 29 fixtures is ~$0.001 (TPC-DS SF=1
   scan cost would be ~$5).
 * The recorded result rows fit in a hand-readable ``expected.json``
   (typically 5-30 rows).
@@ -152,7 +141,7 @@ filters something).
 |---|---|---|
 | Per-fixture byte-scan cap | 1 GiB (configurable via the ``--byte-cap`` flag) | ``scripts/record_conformance_fixtures.py`` — the ``DEFAULT_BYTE_CAP`` constant + the ``--byte-cap`` CLI flag |
 | Project billing | ``$BQEMU_CONFORMANCE_PROJECT`` (operator-supplied) | ``Makefile`` ``record-conformance`` target |
-| Expected total scan for all 40 fixtures | < 40 MiB | seeded-data sizing rule |
+| Expected total scan for all 29 fixtures | < 29 MiB | seeded-data sizing rule |
 | Expected total cost (US multi-region, on-demand) | < $0.01 | $5 / TiB scanned |
 
 The cap is a safety net: any well-formed TPC-DS fixture with
@@ -201,9 +190,9 @@ make test-conformance -- -k tpcds_q12
 
 ## Open questions (resolve before starting bulk recording)
 
-1. **Should any of the 40 queries be excluded from the corpus?**
-   The existing 59 are unanimously inclusion-worthy; the 40 missing
-   are similarly mainstream. **Recommendation**: include all 40.
+1. **Should any of the 29 queries be excluded from the corpus?**
+   The existing 70 are unanimously inclusion-worthy; the 29 missing
+   are similarly mainstream. **Recommendation**: include all 29.
 
 2. **Cost approval.** The total recording cost is ~$0.01 against
    the supplied GCP project's billing account. No approval needed

--- a/docs/architecture/testing-strategy.md
+++ b/docs/architecture/testing-strategy.md
@@ -66,15 +66,13 @@ Scenario coverage enumerated in the
 ## Tier 5 — Conformance (`tests/conformance/`)
 
 Replays recorded baselines against the emulator with row-for-row,
-type-aware tolerance. The corpus ships **1215 active fixtures** —
-**1141 SQL + 48 HTTP + 26 gRPC** (plus 18 INFORMATION_SCHEMA
-fixture stubs currently unrecorded; the same surfaces are
-exercised by Tier 3 integration tests). 13 documented XFAILs are
+type-aware tolerance. The corpus ships **1276 active fixtures** —
+**1202 SQL + 48 HTTP + 26 gRPC**. 12 documented XFAILs are
 pinned as permanent design-decision divergences in
 [`tests/conformance/divergences.py`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/divergences.py).
 
-The corpus includes full TPC-H (22/22 queries) and a 59-of-99
-TPC-DS subset. The remaining 40 TPC-DS queries are tracked in
+The corpus includes full TPC-H (22/22 queries) and a 70-of-99
+TPC-DS subset. The remaining 29 TPC-DS queries are tracked in
 [tpcds-expansion-plan.md](contributing/tpcds-expansion-plan.md),
 which lists the missing queries (numerical order, with complexity
 hints), the per-query authoring recipe, BigQuery adaptation
@@ -152,7 +150,7 @@ on permuted data (e.g., a ``LIMIT N`` shortcut that picks the
 first row in DuckDB's storage order, which happens to match
 BigQuery's storage order on the recorded dataset).
 
-The tier exercises ~77 of the ~1141 SQL fixtures; the remaining
+The tier exercises ~77 of the ~1202 SQL fixtures; the remaining
 fixtures are skipped because their queries use BigQuery-documented
 order-sensitive contracts (``ORDER BY``, ``LIMIT``, ``ARRAY_AGG``
 / ``STRING_AGG`` / window functions without explicit OVER ORDER

--- a/docs/reference/api-configuration-coverage-matrix.md
+++ b/docs/reference/api-configuration-coverage-matrix.md
@@ -213,9 +213,9 @@ payload.
 | Job `statistics.totalBytesBilled` | ❌ No | 🟡 | Same |
 | Job `statistics.cacheHit` | ❌ No | 🟡 | Real-BQ `false` (default) vs `true` (cache hit); emulator always `false` |
 | Job `statistics.totalSlotMs` | ❌ No | 🟢 | Real-BQ value; emulator should be 0 |
-| Job `statistics.query.statementType` | ❌ No | 🔴 | SELECT / INSERT / UPDATE / DELETE / MERGE / CREATE_TABLE /... — clients dispatch on this |
-| Job `statistics.query.numDmlAffectedRows` | ❌ No | 🔴 | UPDATE / DELETE / MERGE return count; critical for client correctness |
-| Job `statistics.query.ddlOperationPerformed` | ❌ No | 🔴 | CREATE / DROP / ALTER / TRUNCATE — clients dispatch on this |
+| Job `statistics.query.statementType` | ✅ Yes | n/a | Diffed key-by-key via the recorded `job_metadata` block (`ddl_result_*`, `routine_ddl_*` fixtures); clients dispatch on this |
+| Job `statistics.query.numDmlAffectedRows` | ✅ Yes | n/a | Diffed via the recorded `job_metadata` block (TRUNCATE / DML `ddl_result_*` fixtures); critical for client correctness |
+| Job `statistics.query.ddlOperationPerformed` | ✅ Yes | n/a | Diffed via the recorded `job_metadata` block (`ddl_result_*` fixtures); CREATE / DROP / ALTER — clients dispatch on this |
 | Job `statistics.query.referencedTables` | ❌ No | 🟡 | Lineage |
 | Job `statistics.query.schema` | ❌ No (the result schema only is diffed) | 🟡 | Pre-execution schema (dry-run uses this) |
 | Job `statistics.query.queryPlan` | ❌ No | 🟢 | Per-stage timing |

--- a/docs/reference/api-configuration-coverage-matrix.md
+++ b/docs/reference/api-configuration-coverage-matrix.md
@@ -213,9 +213,9 @@ payload.
 | Job `statistics.totalBytesBilled` | ❌ No | 🟡 | Same |
 | Job `statistics.cacheHit` | ❌ No | 🟡 | Real-BQ `false` (default) vs `true` (cache hit); emulator always `false` |
 | Job `statistics.totalSlotMs` | ❌ No | 🟢 | Real-BQ value; emulator should be 0 |
-| Job `statistics.query.statementType` | ✅ Yes | n/a | Diffed key-by-key via the recorded `job_metadata` block (`ddl_result_*`, `routine_ddl_*` fixtures); clients dispatch on this |
-| Job `statistics.query.numDmlAffectedRows` | ✅ Yes | n/a | Diffed via the recorded `job_metadata` block (TRUNCATE / DML `ddl_result_*` fixtures); critical for client correctness |
-| Job `statistics.query.ddlOperationPerformed` | ✅ Yes | n/a | Diffed via the recorded `job_metadata` block (`ddl_result_*` fixtures); CREATE / DROP / ALTER — clients dispatch on this |
+| Job `statistics.query.statementType` | ✅ Yes | n/a | Diffed key-by-key via the recorded `job_metadata` block; clients dispatch on this |
+| Job `statistics.query.numDmlAffectedRows` | ✅ Yes | n/a | Diffed via the recorded `job_metadata` block (DML / TRUNCATE fixtures); critical for client correctness |
+| Job `statistics.query.ddlOperationPerformed` | ✅ Yes | n/a | Diffed via the recorded `job_metadata` block (DDL fixtures); CREATE / DROP / ALTER — clients dispatch on this |
 | Job `statistics.query.referencedTables` | ❌ No | 🟡 | Lineage |
 | Job `statistics.query.schema` | ❌ No (the result schema only is diffed) | 🟡 | Pre-execution schema (dry-run uses this) |
 | Job `statistics.query.queryPlan` | ❌ No | 🟢 | Per-stage timing |

--- a/docs/reference/gap-analysis.md
+++ b/docs/reference/gap-analysis.md
@@ -113,8 +113,6 @@ table is maintained here (it has no authoritative generator).
 
 | Surface | Where it's tested today | Why not in conformance |
 |---|---|---|
-| **JS UDFs** (`CREATE TEMP FUNCTION... LANGUAGE js`) | Unit, integration (`tests/integration/test_udf*.py`) | Gated on `[udf-js]` extra (`mini-racer`); deterministic enough to record but no fixtures yet authored. |
-| **TVFs** (table-valued functions) | Unit, integration | No fixtures authored yet. |
 | **Storage Read API** (gRPC `BigQueryRead`) | Integration, E2E (`test_storage_read_*`) | Non-SQL surface; conformance is the SQL tier. |
 | **Storage Write API** (gRPC `BigQueryWrite`, 4 stream types) | Integration, E2E (`test_storage_write_*`) | Non-SQL surface. |
 | **Load jobs** (CSV/NDJSON/Parquet → table) | Integration, E2E | Non-SQL surface; not deterministic across CSV/JSON parser variations. |
@@ -127,7 +125,6 @@ table is maintained here (it has no authoritative generator).
 | **MV refresh** | Integration, chaos | Multi-step + time-dependent. |
 | **BEGIN/COMMIT/ROLLBACK transactions** | Integration | Few fixtures authored; multi-statement edge cases. |
 | **Session variables (`SET...`)** | Integration | Session state — non-replayable. |
-| **`CREATE PROCEDURE`** | Integration | Larger scripting surface; underrepresented in corpus. |
 | **`dryRun` validation** | Integration | `statistics.query.totalBytesProcessed` always returns `"0"` (a "validation passed" marker, not a cost estimate — the emulator has no byte-billing model; see [out-of-scope.md#slot-and-byte-billing-simulation](out-of-scope.md#slot-and-byte-billing-simulation)). |
 | **Job lifecycle** (cancel, list, get) | Integration, E2E | Non-SQL HTTP endpoints. |
 | **Query result pagination** | Integration, E2E | Non-SQL HTTP endpoint. |


### PR DESCRIPTION
## Summary

Pre-v1.1.3 documentation-accuracy sweep: correct stale conformance/corpus
counts, now-false capability claims, and the conformance-case authoring
guide across the **hand-maintained** docs. (The auto-generated reference
matrices were already current via the drift gates.)

## Motivation

Ahead of cutting v1.1.3, several hand-maintained docs had drifted from the
live corpus/inventory and from behaviours landed in #116–#122. Outdated or
inaccurate docs degrade confidence; this realigns them to the authoritative
numbers (the drift-gated matrices) and the real harness. Mirrors the
#110 → #111 pre-release pattern.

## Changes

- **`adding-conformance-cases.md`** — rewritten to match the real harness:
  directory-per-fixture layout (`query.sql` / optional `setup.sql` /
  `expected.json`), runner `test_corpus.py` (not `runner.py`), recorder
  `scripts/record_conformance_fixtures.py --project … --filter …`, FLOAT64
  tolerance `math.isclose(rel_tol=1e-12, abs_tol=1e-15)` (was `1e-9`).
- **Counts** (`README.md`, `conformance-tier.md`, `testing-strategy.md`):
  **1,276** fixtures (1,202 SQL + 48 HTTP + 26 gRPC), **12** XFAIL, **418**
  surface items (408 deterministic), TPC-DS **70-of-99**. Dropped the
  resolved "18 INFORMATION_SCHEMA stubs awaiting recording" clause (all
  fixtures are now recorded) and the stale "644 pre-existing v1 fixtures".
- **`api-configuration-coverage-matrix.md`**: `statementType` /
  `numDmlAffectedRows` / `ddlOperationPerformed` flipped from "not compared"
  to compared — they are diffed via the recorded `job_metadata` block
  (`tests/conformance/_comparison.py`).
- **`gap-analysis.md`**: removed JS UDFs, TVFs, and `CREATE PROCEDURE` from
  the "works but not in conformance" table — all three now have recorded
  fixtures (12 / 7 / 9).
- **`tpcds-expansion-plan.md`**: reconciled to the **29** remaining TPC-DS
  queries (70 of 99 recorded); the 11 now-recorded "easier" queries were
  removed from the enumerated list and the complexity tally.

## Testing

- [x] `mkdocs build --strict` passes.
- [x] `typos` clean.
- [x] Drift gates pass (`coverage-matrix-check`, `compat-matrix-check`,
  `function-mapping-check`, `api-coverage-check`).
- [ ] Unit / property / integration / e2e — **N/A** (docs-only; no code paths).
- All numbers cross-checked against the drift-gated matrices and the live
  `tests/conformance/` tree.

## Documentation

- [x] This PR **is** the documentation update.
- ADR 0028's v1.0-era "~1141" count is intentionally left unchanged — ADRs
  are immutable history; that figure is correct for v1.0.

## Release hygiene

- [ ] `CHANGELOG.md` — **intentionally omitted** (authored at release time only).
- [x] Conventional Commits used.

## Related

- Pre-release accuracy gate ahead of the **v1.1.3** release PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated conformance counts in README and testing strategy (1,276 fixtures; adjusted coverage and XFAIL totals).
  * Revised conformance-corpus inventory and fixture-versioning notes.
  * Described new fixture layout and updated recording/runner workflow and comparison tolerances.
  * Increased TPC-DS coverage from 59 to 70 fixtures and adjusted expansion plan.
  * Expanded gap-analysis and refreshed API response verification matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->