### PR TITLE
release: bump to v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,22 @@ new release.
 See [`docs/architecture/contributing/documentation-style-guide.md`](docs/architecture/contributing/documentation-style-guide.md)
 for the full entry-form rules and worked examples.
 
+## [1.1.3] - 2026-06-03
+
+### Fixed
+
+- Return BigQuery's per-type result shape for single-statement DDL submitted via `jobs.query` — the analyzed schema with zero rows for `CREATE TABLE` / CTAS / `CREATE VIEW`, an empty result for `ALTER` / `CREATE SCHEMA` / `DROP`, DML-style counts for `TRUNCATE` — instead of DuckDB's status column.
+- Report the correct `statementType` (`CREATE_FUNCTION` / `CREATE_TABLE_FUNCTION`) for single `CREATE FUNCTION` / `CREATE TABLE FUNCTION` statements instead of `SCRIPT`, and execute `DROP FUNCTION` / `DROP PROCEDURE` / `DROP TABLE FUNCTION` submitted via `jobs.query`.
+- Reject `DROP SCHEMA` on a non-empty dataset with a `resourceInUse` error, matching BigQuery; only `DROP SCHEMA ... CASCADE` removes the dataset's contents.
+- Return the final statement's result from a multi-statement script, rather than the last row-producing statement's.
+- Register datasets created by `CREATE SCHEMA` inside multi-statement scripts in the catalog so later statements and `INFORMATION_SCHEMA` resolve them.
+- Remove dropped tables, views, and datasets from the catalog when dropped via `jobs.query`.
+- Cap `grpcio-tools` and `grpcio-health-checking` below 1.81 to keep the generated gRPC stubs building against the example-pinned `grpcio` 1.80.0.
+
+### Security
+
+- Raise the PyJWT floor to `>=2.13.0` to close PYSEC-2025-183 (transitive via `google-auth`; the emulator does not exercise the JWT codepath at runtime).
+
 ## [1.1.2] - 2026-05-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ DuckDB-backed, SQLGlot-powered, and tested against the real service. Point the o
 [![E2E](https://github.com/jjviscomi/bqemulator/actions/workflows/e2e.yml/badge.svg)](https://github.com/jjviscomi/bqemulator/actions/workflows/e2e.yml)
 [![Conformance](https://github.com/jjviscomi/bqemulator/actions/workflows/conformance.yml/badge.svg)](https://github.com/jjviscomi/bqemulator/actions/workflows/conformance.yml)
 [![Docs](https://github.com/jjviscomi/bqemulator/actions/workflows/docs.yml/badge.svg)](https://jjviscomi.github.io/bqemulator/)
-[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg?cacheSeconds=120&v=1.1.2)](https://pypi.org/project/bqemulator/)
-[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg?cacheSeconds=120&v=1.1.2)](https://pypi.org/project/bqemulator/)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jjviscomi/bqemulator/badge?v=1.1.2)](https://scorecard.dev/viewer/?uri=github.com/jjviscomi/bqemulator)
+[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg?cacheSeconds=120&v=1.1.3)](https://pypi.org/project/bqemulator/)
+[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg?cacheSeconds=120&v=1.1.3)](https://pypi.org/project/bqemulator/)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jjviscomi/bqemulator/badge?v=1.1.3)](https://scorecard.dev/viewer/?uri=github.com/jjviscomi/bqemulator)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
@@ -201,7 +201,7 @@ See the [`docker-compose/full-stack`](docs/examples/docker-compose/full-stack/) 
 
 ## What works today
 
-`bqemulator` is at **v1.1.2** — first minor on the production-stable
+`bqemulator` is at **v1.1.3** — first minor on the production-stable
 line. SemVer applies: breaking changes ship only in MAJOR,
 deprecations live ≥2 MINOR or 6 months. The [compatibility matrix](https://jjviscomi.github.io/bqemulator/latest/reference/compatibility-matrix/) is auto-generated from the conformance corpus on every CI run; the [conformance coverage matrix](https://jjviscomi.github.io/bqemulator/latest/reference/conformance-coverage-matrix/) breaks down support by surface item.
 
@@ -271,7 +271,7 @@ Every example under [`docs/examples/`](docs/examples/) is a complete, runnable p
 
 ## Project status
 
-`bqemulator` is at **v1.1.2** — first minor on the production-stable
+`bqemulator` is at **v1.1.3** — first minor on the production-stable
 line. SemVer applies: breaking changes ship only in MAJOR
 versions, preceded by ≥1 MINOR with deprecation warnings;
 deprecated APIs remain for ≥2 MINOR versions or 6 months.
@@ -286,8 +286,8 @@ Maturity signals:
 - ✅ Fuzz-tier (`Atheris`) harnesses on the SQL translator, dynamic-protobuf decoder, and Arrow bridge.
 - ✅ Differential-tier row-order perturbation of the entire conformance corpus passes.
 - ✅ Performance baselines committed for `darwin-arm64`, with regression gates (`pytest-benchmark` `--benchmark-compare-fail=median:10%`).
-- ✅ PyPI publish via Trusted Publishing (sigstore-attested wheels) — `pip install bqemulator==1.1.2` resolves from [PyPI](https://pypi.org/project/bqemulator/).
-- ✅ GHCR publish with keyless cosign signatures — `docker pull ghcr.io/jjviscomi/bqemulator:1.1.2` resolves and the image is cosign-verifiable.
+- ✅ PyPI publish via Trusted Publishing (sigstore-attested wheels) — `pip install bqemulator==1.1.3` resolves from [PyPI](https://pypi.org/project/bqemulator/).
+- ✅ GHCR publish with keyless cosign signatures — `docker pull ghcr.io/jjviscomi/bqemulator:1.1.3` resolves and the image is cosign-verifiable.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for the complete release-by-release inventory.
 

--- a/docs/examples/ci-recipes/github-actions/README.md
+++ b/docs/examples/ci-recipes/github-actions/README.md
@@ -38,5 +38,5 @@ make test
 Copy `workflow.yml` into your `.github/workflows/` directory and edit:
 
 - `BQEMU_IMAGE` env var — pin to the version you want (e.g.
-  `ghcr.io/jjviscomi/bqemulator:1.1.2`).
+  `ghcr.io/jjviscomi/bqemulator:1.1.3`).
 - The `test:` step — replace with your project's test command.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ Check the health endpoint:
 
 ```bash
 curl http://localhost:9050/healthz
-# {"status":"ok","version":"1.1.2"}
+# {"status":"ok","version":"1.1.3"}
 ```
 
 ## Point a client at it

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ A local emulator for Google BigQuery. Run it on your laptop or in CI and
 point the official Google Cloud client libraries at it.
 
 !!! note "Status"
-    **v1.1.2** — production-stable. SemVer applies: breaking changes
+    **v1.1.3** — production-stable. SemVer applies: breaking changes
     ship only in MAJOR, preceded by ≥1 MINOR with deprecation
     warnings; deprecated APIs remain for ≥2 MINOR or 6 months. See
     the [compatibility matrix](reference/compatibility-matrix.md) for

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -57,7 +57,7 @@ catalog. No row data is copied.
 ## `bqemulator version`
 
 ```
-bqemulator 1.1.2
+bqemulator 1.1.3
 ```
 
 ## Using Google's `bq` CLI against the emulator

--- a/src/bqemulator/__init__.py
+++ b/src/bqemulator/__init__.py
@@ -15,4 +15,4 @@ __all__ = ["__version__"]
 
 # Single source of truth for the version; hatchling reads this via
 # `[tool.hatch.version] path = "src/bqemulator/__init__.py"`.
-__version__ = "1.1.2"
+__version__ = "1.1.3"


### PR DESCRIPTION
## Summary

Patch release **v1.1.2 → v1.1.3** — ships the conformance-parity fixes (#116–#121), the catalog-DROP fix, and the dependency/security fixes (#115 grpcio cap, #122 PyJWT / PYSEC-2025-183), with the version bump and the CHANGELOG `[1.1.3]` section.

## Motivation

Cut the accumulated patch fixes since v1.1.2. The docs-accuracy sweep (#130) already merged; the 6 open Dependabot PRs were triaged **out** of this release — the CI-action bumps don't affect the shipped artifact, and the grpcio cap-widens (#128/#129) were closed because they reverse #115 and would re-break the examples.

## Changes

- `src/bqemulator/__init__.py`: `__version__` `1.1.2` → `1.1.3` (hatch version source).
- `README.md`: shields cache-bust badges, prose, and `pip install` / `docker pull` pins → `1.1.3`.
- Doc version strings: `docs/index.md` Status callout, `docs/getting-started.md` `/healthz` sample, `docs/reference/cli.md` `version` output, the github-actions example image tag.
- `CHANGELOG.md`: new `## [1.1.3] - 2026-06-03` section (Fixed + Security).

## Testing

- [x] `ruff` / `ruff format` / `mypy --strict` / `bandit` / `typos` / `mkdocs build --strict` pass locally.
- [x] CHANGELOG `[1.1.3]` validates via the project's own `scripts/changelog.py` parser.
- [x] No test hard-codes the version (`test_cli.py` reads `__version__` dynamically; the `0.1.0` strings in `test_bump_version`/`test_release` are isolated fixtures).
- CI runs the full `verify` matrix: clean-env lint, unit+property ×9, integration, conformance corpus, e2e ×5, docs-build.
- **Note:** local `pip-audit` flags only **env-only** artifacts — `coderelay` (a local dev tool, not on PyPI) and 2 newer aiohttp CVEs (aiohttp is `Required-by` pubnub/twilio only, not a bqemulator dep). Neither is in the shipped wheel or CI's clean env.

## Documentation

- [x] `CHANGELOG.md` `[1.1.3]` authored (release-time).
- [x] Version strings + Status callouts bumped to 1.1.3.

## Release hygiene

- [x] `release: bump to vX.Y.Z` commit subject (matches the #111 pattern).
- After squash-merge, a **signed `v1.1.3` tag** is pushed to the merge commit → `release.yml` + `docker.yml` publish to PyPI + GHCR. **That tag push is the irreversible step and is held for explicit go-ahead.**

## Related

- Ships #115–#122 + the catalog-DROP fix + the internal-project-id fixture scrub; follows the docs-accuracy sweep #130.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected DDL result formatting to match BigQuery behavior.
  * Fixed statement type reporting and DROP statement handling.
  * Improved schema operations and multi-statement script execution.
  * Enhanced catalog management for dropped objects.

* **Security**
  * Updated PyJWT and gRPC tooling dependencies to meet security requirements.

* **Chores**
  * Version bumped to 1.1.3 across all documentation and package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->