### PR TITLE
build(deps): cap sqlglot below 30.9 (PARSE_TIME + TPC-DS Q47 regressions)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,16 @@ classifiers = [
 
 dependencies = [
     "duckdb>=1.0",
-    "sqlglot>=23.0",
+    # Cap below sqlglot 30.9.0: it changed PARSE_TIME translation to emit a
+    # ``TIMESTAMP WITH TIME ZONE -> TIME`` cast DuckDB rejects (breaks the
+    # unit ``test_datetime_semantics::TestParseTime`` + conformance
+    # ``standard_functions/parse_time_format``), and it fixed the TPC-DS Q47
+    # CTE-inlining so the strict-xfail divergence pin
+    # (``standard_functions/tpcds_q47``) now XPASSes and trips the gate. The
+    # pin was previously unbounded, so a fresh resolve pulled 30.9.0 and went
+    # red. Lift once the PARSE_TIME rule is updated and the Q47 divergence is
+    # re-evaluated for >=30.9.
+    "sqlglot>=23.0,<30.9",
     "pyarrow>=14.0",
     # Exclude fastapi 0.136.3: MAL-2026-4750 — Amazon Inspector flagged
     # the release as tampered (adds an undocumented ``fastar>=0.9.0``


### PR DESCRIPTION
## Summary

sqlglot 30.9.0 (the latest) breaks two unrelated areas of the suite on a fresh
dependency resolve, because `sqlglot>=23.0` had no upper bound:

- **PARSE_TIME** now translates to a `TIMESTAMP WITH TIME ZONE -> TIME` cast DuckDB
  rejects — fails `tests/unit/sql/rules/test_datetime_semantics.py::TestParseTime`
  and conformance `standard_functions/parse_time_format`.
- **TPC-DS Q47** CTE-inlining is fixed upstream, so the strict-xfail divergence pin
  `standard_functions/tpcds_q47` now `XPASS`es and trips the conformance gate.

Caps `sqlglot>=23.0,<30.9` so a fresh install resolves a known-good 30.8.x, matching
the repo's existing commented dep caps (fastapi, grpcio). Low-risk fix that greens
`main` and every open PR (e.g. #135), neither of whose failures it introduced.

## Follow-up (separate)
Adopt sqlglot >= 30.9 properly: update the PARSE_TIME translation rule for the new
cast, and re-evaluate / unpin the now-passing TPC-DS Q47 divergence.

## Checklist
- [x] No code change beyond the dependency constraint
- [x] No migration
- [ ] CHANGELOG — authored at release time per repo policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->