### PR TITLE
build(deps): adopt sqlglot >=30.9 and lift the <30.9 cap

### DIFF
--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -139,7 +139,7 @@ surfaces).
 
 > **Auto-generated.** Edit fixtures under [`tests/conformance/`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance) or update the XFAIL registry in [`tests/conformance/divergences.py`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/divergences.py), then run `make compat-matrix` to regenerate this block. The CI gate (`--check`) refuses to merge a PR whose committed snapshot has drifted from the corpus.
 
-- **Corpus totals**: 1288 fixtures (1213 SQL + 49 HTTP + 26 gRPC); **1276 PASS / 12 XFAIL**
+- **Corpus totals**: 1288 fixtures (1213 SQL + 49 HTTP + 26 gRPC); **1277 PASS / 11 XFAIL**
 - **XFAIL contract**: every pin in `KNOWN_DIVERGENCES` references an ADR or `out-of-scope.md` section — invented divergences are forbidden (see [ADR 0023](https://github.com/jjviscomi/bqemulator/blob/main/docs/adr/0023-conformance-divergence-baseline.md)).
 
 ### Per-phase fixture coverage
@@ -156,16 +156,16 @@ Each row aggregates fixtures by corpus (SQL / HTTP / gRPC) and the on-disk phase
 | SQL | `routines_scripting` | 70 | 70 | 0 | ✅ |
 | SQL | `row_access` | 23 | 22 | 1 | ⚠ |
 | SQL | `specialized_types` | 150 | 143 | 7 | ⚠ |
-| SQL | `standard_functions` | 662 | 658 | 4 | ⚠ |
+| SQL | `standard_functions` | 662 | 659 | 3 | ⚠ |
 | SQL | `versioning` | 24 | 24 | 0 | ✅ |
 | HTTP | `jobs` | 49 | 49 | 0 | ✅ |
 | gRPC | `storage_read` | 16 | 16 | 0 | ✅ |
 | gRPC | `storage_write` | 10 | 10 | 0 | ✅ |
-| **Total** | | **1288** | **1276** | **12** | ⚠ |
+| **Total** | | **1288** | **1277** | **11** | ⚠ |
 
 ### XFAIL pin registry
 
-All 12 entries in [`tests/conformance/divergences.py`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/divergences.py) — each rationale references an ADR or [`out-of-scope.md`](https://github.com/jjviscomi/bqemulator/blob/main/docs/reference/out-of-scope.md) section so closure paths stay traceable.
+All 11 entries in [`tests/conformance/divergences.py`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/divergences.py) — each rationale references an ADR or [`out-of-scope.md`](https://github.com/jjviscomi/bqemulator/blob/main/docs/reference/out-of-scope.md) section so closure paths stay traceable.
 
 | Fixture id | Rationale (short) |
 |---|---|
@@ -180,6 +180,5 @@ All 12 entries in [`tests/conformance/divergences.py`](https://github.com/jjvisc
 | [`standard_functions/agg_hll_count_init_basic`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/agg_hll_count_init_basic) | HLL sketch BYTES format differs — see docs/reference/out-of-scope.md#hll-sketch-binary-format-hll_countinit-m… |
 | [`standard_functions/agg_hll_count_merge_partial_basic`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/agg_hll_count_merge_partial_basic) | HLL sketch BYTES format differs — see docs/reference/out-of-scope.md#hll-sketch-binary-format-hll_countinit-m… |
 | [`standard_functions/bound_bignumeric_max`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/bound_bignumeric_max) | BIGNUMERIC literal with 39 integer digits exceeds DuckDB's DECIMAL(38, 0) cap; literals with ≤ 38 integer dig… |
-| [`standard_functions/tpcds_q47`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/tpcds_q47) | TPC-DS Q47-style multi-CTE pattern: a CTE that carries a window aggregate (AVG OVER PARTITION BY ... |
 
 <!-- END AUTO-GENERATED CONFORMANCE SNAPSHOT -->

--- a/docs/reference/gap-analysis.md
+++ b/docs/reference/gap-analysis.md
@@ -76,9 +76,6 @@ documented in [out-of-scope.md](out-of-scope.md), including:
   BigQuery gates the view on `bigquery.rowAccessPolicies.list`; the
   emulator does not enforce IAM. See
   [out-of-scope.md#iam-enforcement](out-of-scope.md#iam-enforcement).
-* **CTE self-join with window aggregate (TPC-DS Q47)** — a SQLGlot
-  CTE-inlining shape DuckDB's binder rejects. See
-  [out-of-scope.md#cte-self-join-with-window-aggregate-tpc-ds-q47](out-of-scope.md#cte-self-join-with-window-aggregate-tpc-ds-q47).
 
 Each pin's rationale string in `divergences.py` links to its
 out-of-scope.md section.

--- a/docs/reference/out-of-scope.md
+++ b/docs/reference/out-of-scope.md
@@ -477,61 +477,6 @@ standard pipeline. A full legacy-SQL parser remains out of scope.
 standard SQL (the canonical migration path BigQuery itself
 recommends) and submit it with `useLegacySql=false` (the default).
 
-### CTE self-join with window aggregate (TPC-DS Q47)
-
-TPC-DS Q47 uses a multi-CTE pattern where a CTE (`v1`) is
-defined with two window aggregates — `AVG(SUM(...)) OVER (PARTITION
-BY...)` for monthly-average sales plus `RANK() OVER (PARTITION
-BY... ORDER BY d_year, d_moy)` for a chronological row-number —
-and then **self-joined three times** in a subsequent CTE (`v2`):
-
-```sql
-WITH v1 AS (
-  SELECT ...,
-    AVG(SUM(ss_sales_price)) OVER (PARTITION BY ...) AS avg_monthly_sales,
-    RANK() OVER (PARTITION BY ... ORDER BY d_year, d_moy) AS rn
-  FROM item, store_sales, date_dim, store
-  WHERE ...
-  GROUP BY ...
-),
-v2 AS (
-  SELECT v1.*, v1_lag.sum_sales AS psum, v1_lead.sum_sales AS nsum
-  FROM v1, v1 v1_lag, v1 v1_lead
-  WHERE v1.rn = v1_lag.rn + 1
-    AND v1.rn = v1_lead.rn - 1
-)
-```
-
-When SQLGlot translates this to DuckDB it inlines `v1` three
-times into `v2`. DuckDB's planner raises `Binder Error: UNNEST
-requires a single list as input` on the resulting plan — the
-exact internal step that mis-fires is not yet diagnosed.
-
-Closing this divergence cleanly requires either:
-
-1. Investigating SQLGlot's inlining strategy for CTEs whose
-   bodies carry window aggregates and emitting an alternative
-   plan (materialise the CTE first via `CREATE TEMP TABLE AS
-   SELECT FROM v1` before the self-join). DuckDB does honour
-   `CREATE TEMP TABLE`, so a pre-translator that materialises
-   any multi-times-referenced CTE with a window aggregate would
-   work — but the criteria for "materialise vs inline" need a
-   cost model.
-2. A DuckDB upstream fix to the planner's UNNEST-related binder
-   for the specific shape SQLGlot emits — out of scope here.
-
-The conformance fixture
-[`standard_functions/tpcds_q47`](https://github.com/jjviscomi/bqemulator/blob/main/tests/conformance/sql_corpus/standard_functions/tpcds_q47)
-is pinned XFAIL against this divergence. Q47 is the only one of
-the 29 TPC-DS fixtures in the corpus that surfaces this issue; the
-other 28 picks PASS without code changes.
-
-*Workaround*: clients that need the same shape should
-materialise the CTE manually (`CREATE TEMP TABLE v1_materialised
-AS SELECT... FROM v1`) before the self-join, or refactor to
-use `LAG`/`LEAD` window functions on the original CTE without
-self-joining.
-
 ### ORC extract
 
 **Status**: Excluded permanently.

--- a/docs/reference/sql-function-mapping.md
+++ b/docs/reference/sql-function-mapping.md
@@ -50,7 +50,7 @@ table below maps each BigQuery view to its rewriter function.
 
 > **Auto-generated.** Edit translation rules under [`src/bqemulator/sql/rules/`](https://github.com/jjviscomi/bqemulator/blob/main/src/bqemulator/sql/rules/) or rewriters under [`src/bqemulator/sql/rewriter/`](https://github.com/jjviscomi/bqemulator/blob/main/src/bqemulator/sql/rewriter/), then run `make function-mapping` to regenerate this block. The CI gate (`--check`) refuses to merge a PR whose committed registry has drifted from the live source. Per-rule docstring summaries are extracted as the cell text — if a cell reads wrong, edit the rule's docstring.
 
-- **Registered rules**: 93 (13 rule modules)
+- **Registered rules**: 92 (13 rule modules)
 - **Rewriter functions**: 24 (24 rewriter modules; the INFORMATION_SCHEMA rewriter has its own hand-maintained per-view table below)
 
 ### Translation rules (post-transpile AST passes)
@@ -76,7 +76,6 @@ table below maps each BigQuery view to its rewriter function.
 | Date / time / timestamp | `FORMAT_TIME(fmt, t)` | `STRFTIME(DATE '1970-01-01' + t, fmt)` | `FORMAT_TIME` |
 | Date / time / timestamp | `JSON_TYPE(x)` | `LOWER(JSON_TYPE(x))` | `JSON_TYPE_LOWER` |
 | Date / time / timestamp | `PARSE_DATETIME(fmt, value)` | `strptime(value, fmt)` | `PARSE_DATETIME` |
-| Date / time / timestamp | `PARSE_TIME(value, fmt)` | `CAST(strptime(value, fmt) AS TIME)` | `PARSE_TIME` |
 | Date / time / timestamp | `STRPTIME(value, fmt)` | `timezone('UTC', STRPTIME(value, fmt))` | `PARSE_TIMESTAMP_UTC` |
 | Date / time / timestamp | `DATE_TRUNC('WEEK', ts AT TIME ZONE 'X')` | Sunday-start truncation | `TIMESTAMP_TRUNC_WEEK_ZONE_SUNDAY` |
 | Date / time / timestamp | `TIME(timestamp)` | `CAST(timezone('UTC', timestamp) AS TIME)` | `TIME_FROM_TIMESTAMPTZ` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,16 +42,14 @@ classifiers = [
 
 dependencies = [
     "duckdb>=1.0",
-    # Cap below sqlglot 30.9.0: it changed PARSE_TIME translation to emit a
-    # ``TIMESTAMP WITH TIME ZONE -> TIME`` cast DuckDB rejects (breaks the
-    # unit ``test_datetime_semantics::TestParseTime`` + conformance
-    # ``standard_functions/parse_time_format``), and it fixed the TPC-DS Q47
-    # CTE-inlining so the strict-xfail divergence pin
-    # (``standard_functions/tpcds_q47``) now XPASSes and trips the gate. The
-    # pin was previously unbounded, so a fresh resolve pulled 30.9.0 and went
-    # red. Lift once the PARSE_TIME rule is updated and the Q47 divergence is
-    # re-evaluated for >=30.9.
-    "sqlglot>=23.0,<30.9",
+    # Floor at 30.9: 30.9.0 transpiles BigQuery PARSE_TIME natively to
+    # ``CAST(STRPTIME(...) AS TIME)`` (handled by the ParseTimestampUtcRule
+    # Cast-to-TIME guard in ``sql/rules/datetime_semantics.py``) and fixed the
+    # TPC-DS Q47 CTE-inlining, so ``standard_functions/tpcds_q47`` now matches
+    # BigQuery and its KNOWN_DIVERGENCES pin was removed. Both behaviours are
+    # 30.9-specific, so the floor must be >=30.9 (a resolve to <30.9 would
+    # re-break PARSE_TIME and surface Q47 as an unexpected conformance fail).
+    "sqlglot>=30.9",
     "pyarrow>=14.0",
     # Exclude fastapi 0.136.3: MAL-2026-4750 — Amazon Inspector flagged
     # the release as tampered (adds an undocumented ``fastar>=0.9.0``

--- a/src/bqemulator/sql/rules/datetime_semantics.py
+++ b/src/bqemulator/sql/rules/datetime_semantics.py
@@ -25,9 +25,11 @@ post-translate stage:
   reaches ``STRFTIME`` as a ``TIMESTAMP``, and translates BigQuery's
   ``%E#S`` fractional-second extension to DuckDB's ``%S.%g`` /
   ``%S.%f``.
-* BigQuery's ``PARSE_TIME(fmt, value)`` returns ``TIME``; DuckDB has
-  no ``parse_time`` function. :class:`ParseTimeRule` emits
-  ``CAST(strptime(value, fmt) AS TIME)``.
+* BigQuery's ``PARSE_TIME(fmt, value)`` returns ``TIME``. SQLGlot
+  (>= 30.9) transpiles it natively to ``CAST(strptime(value, fmt) AS
+  TIME)``; the only bqemulator concern is keeping that ``strptime``
+  *naive* — :class:`ParseTimestampUtcRule` skips its UTC wrap when the
+  ``strptime`` is the operand of a ``CAST(... AS TIME)`` (or ``DATE``).
 * BigQuery's ``PARSE_DATETIME(fmt, value)`` returns ``DATETIME``;
   DuckDB has no ``parse_datetime`` function. :class:`ParseDatetimeRule`
   emits ``strptime(value, fmt)`` whose naive-TIMESTAMP return lands on
@@ -328,37 +330,6 @@ class FormatPrintfRule(TranslationRule):
 
 
 @register
-class ParseTimeRule(TranslationRule):
-    """``PARSE_TIME(value, fmt)`` → ``CAST(strptime(value, fmt) AS TIME)``.
-
-    DuckDB does not implement ``parse_time``; ``strptime`` returns a
-    ``TIMESTAMP`` which the explicit cast narrows to ``TIME``. The
-    BigQuery arg order is ``(format, value)`` but SQLGlot swaps to the
-    DuckDB-native ``(value, format)`` during the transpile — the
-    ``ParseTime`` AST node at this point already carries
-    ``this=value``, ``format=format``.
-    """
-
-    name = "PARSE_TIME"
-
-    def applies_to(self, node: exp.Expression) -> bool:
-        """Match the typed ``ParseTime`` AST node."""
-        return isinstance(node, exp.ParseTime)
-
-    def rewrite(self, node: exp.Expression) -> exp.Expression:
-        """Emit ``CAST(strptime(value, fmt) AS TIME)``."""
-        value = node.this
-        fmt = node.args.get("format")
-        if value is None or fmt is None:
-            return node
-        strptime_call = exp.Anonymous(
-            this="strptime",
-            expressions=[value.copy(), fmt.copy()],
-        )
-        return exp.Cast(this=strptime_call, to=exp.DataType.build("TIME"))
-
-
-@register
 class JsonTypeLowerRule(TranslationRule):
     """``JSON_TYPE(x)`` → ``LOWER(JSON_TYPE(x))``.
 
@@ -402,10 +373,28 @@ class ParseTimestampUtcRule(TranslationRule):
         """Match SQLGlot's ``StrToTime`` node (DuckDB ``strptime``)."""
         if not isinstance(node, exp.StrToTime):
             return False
+        parent = node.parent
         # Don't double-wrap when an outer ``timezone(...)`` already
         # settles the tz.
-        parent = node.parent
-        return not (isinstance(parent, exp.Anonymous) and str(parent.this).upper() == "TIMEZONE")
+        if isinstance(parent, exp.Anonymous) and str(parent.this).upper() == "TIMEZONE":
+            return False
+        # Don't wrap a ``strptime`` that is the operand of a CAST to a
+        # tz-less type (``TIME`` / ``DATE``). SQLGlot >= 30.9 transpiles
+        # BigQuery ``PARSE_TIME`` natively to ``CAST(STRPTIME(...) AS
+        # TIME)``; UTC-stamping that ``strptime`` would yield ``CAST(
+        # TIMESTAMP WITH TIME ZONE AS TIME)``, which DuckDB rejects (and
+        # is semantically wrong — ``TIME``/``DATE`` carry no zone). The
+        # naive ``CAST(STRPTIME(...) AS TIME)`` is already correct for
+        # ``PARSE_TIME``; ``PARSE_TIMESTAMP`` reaches this rule as a bare
+        # ``strptime`` (no CAST) and is still wrapped.
+        if isinstance(parent, exp.Cast):
+            to_type = parent.to
+            if isinstance(to_type, exp.DataType) and to_type.this in (
+                exp.DataType.Type.TIME,
+                exp.DataType.Type.DATE,
+            ):
+                return False
+        return True
 
     def rewrite(self, node: exp.Expression) -> exp.Expression:
         """Wrap the ``strptime`` call in ``timezone('UTC', …)``."""
@@ -923,7 +912,6 @@ __all__ = [
     "FormatTimeRule",
     "JsonTypeLowerRule",
     "ParseDatetimeRule",
-    "ParseTimeRule",
     "ParseTimestampUtcRule",
     "TimeFromTimestamptzRule",
     "TimeTruncRule",

--- a/tests/conformance/divergences.py
+++ b/tests/conformance/divergences.py
@@ -63,17 +63,6 @@ _BIGNUMERIC_CAP = (
     "fractional truncation (Path C of numeric_literals.py) — see "
     "docs/reference/out-of-scope.md#bignumeric-literals-with-39-integer-digits"
 )
-_CTE_SELF_JOIN_WINDOW_UNNEST = (
-    "TPC-DS Q47-style multi-CTE pattern: a CTE that carries a window "
-    "aggregate (AVG OVER PARTITION BY ... and RANK OVER ...) is self-"
-    "joined to itself three times (v1, v1 v1_lag, v1 v1_lead) with "
-    "row-number equality joins. SQLGlot inlines the CTE three times; "
-    "DuckDB raises ``Binder Error: UNNEST requires a single list as "
-    "input`` on the resulting plan. Closure needs an investigation "
-    "into how SQLGlot's CTE-inlining transforms window aggregates over "
-    "ROW_NUMBER joins — see "
-    "docs/reference/out-of-scope.md#cte-self-join-with-window-aggregate-tpc-ds-q47"
-)
 _HLL_SKETCH_BINARY = (
     "HLL sketch BYTES format differs — see "
     "docs/reference/out-of-scope.md#hll-sketch-binary-format-hll_countinit-merge_partial"
@@ -105,8 +94,6 @@ KNOWN_DIVERGENCES: dict[str, str] = {
     "standard_functions/agg_hll_count_merge_partial_basic": _HLL_SKETCH_BINARY,
     # docs/reference/out-of-scope.md#bignumeric-literals-with-39-integer-digits
     "standard_functions/bound_bignumeric_max": _BIGNUMERIC_CAP,
-    # docs/reference/out-of-scope.md#cte-self-join-with-window-aggregate-tpc-ds-q47
-    "standard_functions/tpcds_q47": _CTE_SELF_JOIN_WINDOW_UNNEST,
     # docs/reference/out-of-scope.md#iam-enforcement
     "row_access/caller_information_schema_visibility": _INFO_SCHEMA_IAM,
 }

--- a/tests/unit/sql/rules/test_datetime_semantics.py
+++ b/tests/unit/sql/rules/test_datetime_semantics.py
@@ -190,6 +190,36 @@ class TestParseTime:
         assert str(desc[0][1]).upper() == "TIME"
         assert cursor.fetchone() == (_dt.time(12, 34, 56),)
 
+    def test_strptime_not_utc_wrapped(self, t: SQLTranslator) -> None:
+        """Regression: the ``strptime`` under ``CAST(... AS TIME)`` stays naive.
+
+        SQLGlot >= 30.9 transpiles ``PARSE_TIME`` natively to
+        ``CAST(STRPTIME(...) AS TIME)``. ``ParseTimestampUtcRule`` must
+        NOT wrap that ``strptime`` in ``timezone('UTC', …)`` — doing so
+        yields ``CAST(TIMESTAMP WITH TIME ZONE AS TIME)``, which DuckDB
+        rejects (the bug that motivated the sqlglot 30.9 cap).
+        """
+        result = t.translate("SELECT PARSE_TIME('%H:%M:%S', '12:34:56') AS t")
+        assert isinstance(result, Ok)
+        upper = result.value.upper()
+        assert "TIMEZONE" not in upper
+        assert "AS TIME)" in upper
+
+
+class TestParseDate:
+    """``PARSE_DATE(fmt, value)`` → ``CAST(strptime(value, fmt) AS DATE)``."""
+
+    def test_basic_format(self, t: SQLTranslator, con: duckdb.DuckDBPyConnection) -> None:
+        result = t.translate("SELECT PARSE_DATE('%Y-%m-%d', '2024-01-15') AS d")
+        assert isinstance(result, Ok)
+        # The ``strptime`` must stay naive: UTC-wrapping it would tz-shift
+        # the value (``CAST(TIMESTAMP WITH TIME ZONE AS DATE)``) and read
+        # back off-by-one in a non-UTC session timezone.
+        assert "TIMEZONE" not in result.value.upper()
+        cursor = con.execute(result.value)
+        assert str(cursor.description[0][1]).upper() == "DATE"
+        assert cursor.fetchone() == (_dt.date(2024, 1, 15),)
+
 
 class TestParseTimestampUtc:
     """``PARSE_TIMESTAMP`` → wrapped in ``timezone('UTC', strptime(...))``."""
@@ -205,6 +235,20 @@ class TestParseTimestampUtc:
         row = cursor.fetchone()
         assert row is not None
         assert row[0].tzinfo is not None
+
+    def test_cast_to_timestamp_still_wrapped(self, t: SQLTranslator) -> None:
+        """A ``strptime`` cast to ``TIMESTAMP`` keeps its UTC wrap.
+
+        The Cast-to-TIME/DATE guard suppresses the UTC wrap only for
+        tz-less target types; a ``TIMESTAMP`` (instant) target must still
+        be UTC-stamped so the wire renderer emits a UTC datetime.
+        """
+        result = t.translate(
+            "SELECT CAST(PARSE_TIMESTAMP('%Y-%m-%d %H:%M:%S', "
+            "'2024-01-15 12:34:56') AS TIMESTAMP) AS ts",
+        )
+        assert isinstance(result, Ok)
+        assert "TIMEZONE" in result.value.upper()
 
 
 class TestFormatTime:


### PR DESCRIPTION
## Summary

Closes the follow-up from PR #136 (which capped `sqlglot<30.9`). Adopts sqlglot 30.9 properly and lifts the cap.

### PARSE_TIME / PARSE_DATE
sqlglot 30.9 transpiles BigQuery `PARSE_TIME` natively to `CAST(STRPTIME(...) AS TIME)` (and `PARSE_DATE` → `CAST(STRPTIME(...) AS DATE)`), and now parses DuckDB `strptime` as `exp.StrToTime`. That made `ParseTimestampUtcRule` grab the inner `strptime` and wrap it in `timezone('UTC', …)` → `CAST(TIMESTAMP WITH TIME ZONE AS TIME)`, which DuckDB **rejects** for `PARSE_TIME` and silently **tz-shifts** for `PARSE_DATE`.

**Fix:** `ParseTimestampUtcRule` skips the UTC wrap when the `strptime` is the operand of a `CAST` to a tz-less type (`TIME`/`DATE`). `PARSE_TIMESTAMP` still wraps (bare `strptime` / `CAST AS TIMESTAMP`). The now-redundant `ParseTimeRule` (matched `exp.ParseTime`, unreachable under the duckdb reparse on ≥30.9) is removed. +3 unit regression tests.

### TPC-DS Q47
30.9's CTE-inlining fix closes the divergence — `standard_functions/tpcds_q47` now matches BigQuery. Removed the `KNOWN_DIVERGENCES` pin, its rationale constant, the `out-of-scope.md` section, and the `gap-analysis.md` bullet.

### Regenerated docs
compatibility-matrix (12→11 XFAILs), conformance-coverage-matrix, sql-function-mapping (93→92 rules).

## Verification (on sqlglot 30.9.0)
- Full conformance: **1202 passed / 11 xfailed / 0 unexpected**
- SQL unit 930 · datetime unit 60 (+3) · property 54 · full unit suite green
- `make lint` (ruff/mypy/bandit/pip-audit/interrogate/typos) · `make quality-complexity` (xenon) · `mkdocs --strict` · `lychee` · all matrix/function-mapping drift checks — all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated compatibility matrix reflecting improved test status (1277 PASS / 11 XFAIL).
  * Updated gap analysis and removed documentation for a resolved CTE window aggregate issue.

* **Chores**
  * Upgraded sqlglot dependency to version 30.9 or later.

* **Improvements**
  * Enhanced datetime parsing behavior for PARSE_TIME, PARSE_DATE, and PARSE_TIMESTAMP functions.

* **Tests**
  * Added regression and end-to-end test coverage for datetime parsing semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->