### PR TITLE
ci(release): dispatch OpenSSF Scorecard re-score after publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,3 +113,34 @@ jobs:
           generate_release_notes: true
           files: |
             dist/*
+
+  rescore:
+    name: Re-score OpenSSF Scorecard
+    runs-on: ubuntu-latest
+    needs: github-release
+    # Re-run Scorecard now that the signed release artefacts exist, so
+    # the ``Signed-Releases`` check credits the freshly-published
+    # release. This closes a timing + recursion gap that otherwise
+    # leaves the public score one release behind until the weekly cron:
+    #
+    #  - The release-bump commit's ``push: main`` re-scores Scorecard
+    #    BEFORE this workflow attaches the wheel + provenance, so that
+    #    scan never sees the new release assets.
+    #  - ``scorecard.yml``'s ``release: published`` trigger can't cover
+    #    the gap: the GitHub Release above is created with the default
+    #    ``GITHUB_TOKEN``, and events triggered by ``GITHUB_TOKEN`` do
+    #    NOT start other workflow runs (GitHub's recursion guard).
+    #
+    # ``workflow_dispatch`` (with ``repository_dispatch``) is the one
+    # event type exempt from that recursion guard, so dispatching
+    # Scorecard explicitly here is the supported way to chain the
+    # re-score off a token-created release.
+    permissions:
+      # ``gh workflow run`` (the workflow-dispatch REST call) is the
+      # only API this job touches; no other write scope is needed.
+      actions: write
+    steps:
+      - name: Dispatch Scorecard re-score
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run scorecard.yml --ref main -R "${{ github.repository }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,15 +15,25 @@
 #  - First-class signalling for OSSF tooling (e.g. ``deps.dev``,
 #    Open Source Insights, ``allstar``) downstream of the database.
 #
-# Three triggers feed the database:
+# Four triggers feed the database:
 #  - ``push: main``      — every change on the default branch
 #                          re-scores immediately (catches regressions).
-#  - ``release: published`` — re-score on tag-driven releases so the
-#                          badge reflects the freshly-published
-#                          artefacts (signed wheel + signed image).
+#  - ``release: published`` — re-score when a release is published
+#                          *manually* (e.g. through the GitHub UI).
+#                          The automated ``release.yml`` creates its
+#                          release with the default ``GITHUB_TOKEN``,
+#                          and token-created events do NOT start other
+#                          workflow runs — so for tag-driven releases
+#                          this trigger is inert and ``release.yml``
+#                          dispatches the re-score explicitly via
+#                          ``workflow_dispatch`` (below) once the
+#                          signed artefacts are attached.
 #  - ``schedule``        — weekly cron for low-frequency signals
 #                          (deps that drifted, vuln database updates).
-#  - ``workflow_dispatch`` — manual re-run from the Actions UI.
+#  - ``workflow_dispatch`` — manual re-run from the Actions UI, and
+#                          the programmatic re-score that
+#                          ``release.yml`` fires after a release
+#                          publishes its signed artefacts.
 #
 # Third-party action pinning follows the project-wide
 # OpenSSF-alignment rule (see AGENTS.md): full commit SHA + trailing


### PR DESCRIPTION
## Problem

The public OpenSSF Scorecard score lagged one release behind. After v1.2.0 shipped, the `Signed-Releases` check listed v1.1.3 → v1.0.2 but **not** v1.2.0, even though v1.2.0 has its signed provenance (`bqemulator-1.2.0.intoto.jsonl`) attached.

Two compounding causes:

1. **Timing.** The release-bump commit's `push: main` re-scores Scorecard *before* `release.yml` builds and attaches the signed wheel + provenance. At scan time the new release has no assets, so the scan never credits it. (For v1.2.0: push-scan at `18:24:56Z`, artifacts published `18:38Z`.)
2. **Dead trigger.** `scorecard.yml`'s `release: published` trigger was meant to cover that gap, but it **never fires** — the GitHub Release is created by `release.yml` with the default `GITHUB_TOKEN`, and events triggered by `GITHUB_TOKEN` don't start other workflow runs (GitHub's recursion guard). Across the last 40 Scorecard runs: 37 `push`, 2 `schedule`, 1 `workflow_dispatch`, **0 `release`**.

So the score only corrected on the weekly Monday cron — up to ~7 days stale per release.

## Fix

- Add a `rescore` job to `release.yml` that runs after `github-release` and dispatches `scorecard.yml` via `gh workflow run` (least-privilege `actions: write` only). `workflow_dispatch`/`repository_dispatch` are the one event type **exempt** from the `GITHUB_TOKEN` recursion guard, so this is the supported way to chain a re-score off a token-created release — it runs once the signed artefacts are live.
- Correct `scorecard.yml`'s trigger comment to document that `release: published` is inert for automated (token-created) releases and is now driven explicitly from `release.yml`.

The current v1.2.0 gap was already corrected out-of-band by a manual `workflow_dispatch` (Signed-Releases now 10, overall 6.5 → 6.6); this PR prevents recurrence on future releases.

## Verification

- `actionlint` (Docker `rhysd/actionlint`) clean on both workflows (exit 0).
- YAML parses; no `src/`, test, or docs changes — workflow-only.

## Checklist

- [x] Tests — n/a (CI workflow-only change)
- [x] Docs — inline workflow comments updated; no user-facing docs affected
- [x] Changelog — n/a (authored at release time; no `[Unreleased]` section per CHANGELOG policy)
- [x] ADR — n/a (CI plumbing bugfix, not an architectural decision; rationale captured inline)
- [x] Migration — n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to automatically re-evaluate security scorecards after signed release artifacts are published, ensuring security metrics reflect the finalized release state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->