### PR TITLE
ci(quality): trigger Quality gates on root Dockerfile / compose changes

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -38,16 +38,20 @@ on:
       # Run on every workflow / dependabot example change too, so the
       # ``Quality gates`` job emits a status on PRs that only touch
       # ``.github/workflows/*``, ``.github/dependabot.yml``,
-      # ``docs/**``, or ``.pip-audit-ignore``. Without these
-      # patterns the required-check is "missing" rather than green for
-      # those PRs and even ``gh pr merge --admin`` can't bypass it
-      # (GitHub treats a never-reported required-check as unresolvable).
-      # Worst case: ~1 min of unnecessary quality-complexity run on a
-      # workflow- or dependabot-only PR — cheap relative to the
+      # ``docs/**``, the root ``Dockerfile`` / ``docker-compose.yml``,
+      # or ``.pip-audit-ignore``. Without these patterns the
+      # required-check is "missing" rather than green for those PRs
+      # and even ``gh pr merge --admin`` can't bypass it (GitHub
+      # treats a never-reported required-check as unresolvable) — this
+      # is exactly what stranded the Dependabot docker digest-bump
+      # PRs. Worst case: ~1 min of unnecessary quality-complexity run
+      # on a workflow- or dependabot-only PR — cheap relative to the
       # never-merge blocker the prior filter caused.
       - ".github/workflows/**"
       - ".github/dependabot.yml"
       - "docs/**"
+      - "Dockerfile"
+      - "docker-compose.yml"
       - "CHANGELOG.md"
       - "README.md"
       - "mkdocs.yml"
@@ -64,16 +68,20 @@ on:
       # Run on every workflow / dependabot example change too, so the
       # ``Quality gates`` job emits a status on PRs that only touch
       # ``.github/workflows/*``, ``.github/dependabot.yml``,
-      # ``docs/**``, or ``.pip-audit-ignore``. Without these
-      # patterns the required-check is "missing" rather than green for
-      # those PRs and even ``gh pr merge --admin`` can't bypass it
-      # (GitHub treats a never-reported required-check as unresolvable).
-      # Worst case: ~1 min of unnecessary quality-complexity run on a
-      # workflow- or dependabot-only PR — cheap relative to the
+      # ``docs/**``, the root ``Dockerfile`` / ``docker-compose.yml``,
+      # or ``.pip-audit-ignore``. Without these patterns the
+      # required-check is "missing" rather than green for those PRs
+      # and even ``gh pr merge --admin`` can't bypass it (GitHub
+      # treats a never-reported required-check as unresolvable) — this
+      # is exactly what stranded the Dependabot docker digest-bump
+      # PRs. Worst case: ~1 min of unnecessary quality-complexity run
+      # on a workflow- or dependabot-only PR — cheap relative to the
       # never-merge blocker the prior filter caused.
       - ".github/workflows/**"
       - ".github/dependabot.yml"
       - "docs/**"
+      - "Dockerfile"
+      - "docker-compose.yml"
       - "CHANGELOG.md"
       - "README.md"
       - "mkdocs.yml"


### PR DESCRIPTION
## Problem

The required **Quality gates** check (`code-quality.yml`) uses a `paths:` filter. An earlier sweep extended it to cover `.github/workflows/**`, `.github/dependabot.yml`, and `docs/**` so workflow-/docs-only PRs still emit the status — but it **omitted the root `Dockerfile` and `docker-compose.yml`**.

The Dependabot `docker` ecosystem watches `/` (both files), so a Docker-only digest-bump PR never triggers `code-quality.yml` → the required `Quality gates` check is reported as **missing**, not green → the PR is permanently unmergeable. GitHub treats a never-reported required check as unresolvable, so even `gh pr merge --admin` can't bypass it.

This is the same dead-lock class previously fixed for `.pip-audit-ignore` (#137). It currently strands **#142** (`Bump python from a9bee15 to a705190`).

## Fix

Add `Dockerfile` and `docker-compose.yml` to both the `pull_request` and `push` `paths:` blocks, and update the explanatory comment. After this merges, `@dependabot rebase` on #142 will pull in the updated filter and `Quality gates` will run.

## Verification

- `actionlint` clean (exit 0).
- Workflow-only change; no `src/`, test, or docs impact.

## Checklist

- [x] Tests — n/a (CI workflow-only change)
- [x] Docs — inline workflow comment updated
- [x] Changelog — n/a (authored at release time; no `[Unreleased]` section)
- [x] ADR — n/a (CI plumbing fix; rationale captured inline + in commit)
- [x] Migration — n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the code quality workflow to run quality gates when repository-root Docker configuration files (`Dockerfile` and `docker-compose.yml`) change, improving coverage and helping catch issues earlier during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->