### PR TITLE
test(conformance): make class-scoped module-loader fixtures static (pytest 9.1)

### DIFF
--- a/tests/unit/conformance/test_corpus_framework.py
+++ b/tests/unit/conformance/test_corpus_framework.py
@@ -286,7 +286,8 @@ class TestTrackDatasetCreation:
     """Both runner and recorder must spot ``POST /datasets`` for teardown."""
 
     @pytest.fixture(scope="class")
-    def runner_module(self):
+    @staticmethod
+    def runner_module():
         """Load the conformance runner's REST helpers as a module."""
         import importlib.util
         from pathlib import Path
@@ -299,7 +300,8 @@ class TestTrackDatasetCreation:
         return module
 
     @pytest.fixture(scope="class")
-    def recorder_module(self):
+    @staticmethod
+    def recorder_module():
         """Load the recorder's REST helpers as a module."""
         import importlib.util
         from pathlib import Path
@@ -729,7 +731,8 @@ class TestRunnerBuildJobConfig:
     """The runner's ``_build_job_config`` produces a ``QueryJobConfig`` or ``None``."""
 
     @pytest.fixture(scope="class")
-    def runner_module(self):
+    @staticmethod
+    def runner_module():
         """Load the conformance runner module so its private helpers are testable."""
         import importlib.util
 
@@ -812,7 +815,8 @@ class TestRecorderBuildJobConfig:
     """The recorder's ``_build_job_config`` mirrors the runner's contract."""
 
     @pytest.fixture(scope="class")
-    def recorder_module(self):
+    @staticmethod
+    def recorder_module():
         import importlib.util
 
         path = Path(__file__).resolve().parents[3] / "scripts" / "record_conformance_fixtures.py"
@@ -866,7 +870,8 @@ class TestRecorderReferencesGcsBucket:
     """The recorder's ``${GCS_BUCKET}`` needs-bucket guard predicate (RFC 0001)."""
 
     @pytest.fixture(scope="class")
-    def recorder_module(self):
+    @staticmethod
+    def recorder_module():
         import importlib.util
 
         path = Path(__file__).resolve().parents[3] / "scripts" / "record_conformance_fixtures.py"


### PR DESCRIPTION
## Problem

CI's **Unit + property tests** job started failing on **all 9 matrix shards** (every OS × py3.11/3.12/3.13) on PRs opened after 2026-06-10, while `main`'s own last run (fe23dfd) was green. The failure is unrelated to the PR contents — it reproduces on `main` itself.

Root cause: **pytest 9.1.0** (released since `main`'s last green run; the dev deps don't pin it) escalates `PytestRemovedIn10Warning` for *class-scoped fixtures defined as instance methods*:

> Class-scoped fixture defined as instance method is deprecated. Instance attributes set in this fixture will NOT be visible to test methods… Use `@classmethod`/`@staticmethod` instead.

The suite runs warnings-as-errors (`filterwarnings = error` in `pyproject.toml`), so the five `runner_module` / `recorder_module` class-scoped fixtures in `tests/unit/conformance/test_corpus_framework.py` now **error at setup**, taking down 12 tests and failing the required job.

Reproduced locally with `pytest==9.1.0`: unfixed `main` → `40 passed, 12 errors`; pytest 9.0.3 (older, what was cached) → all green, which is why it slipped in.

## Fix

These fixtures only `importlib`-load and return a module — they never touch `self`. Declare them `@staticmethod` (pytest's recommended replacement). No behaviour change.

## Verification (local, `pytest==9.1.0` matching CI)

- Affected file: `40 passed, 12 errors` → **`52 passed, 0 errors`**.
- Full unit tier: **2836 passed**. Property tier: **54 passed**.
- `ruff check` + `ruff format --check` clean.
- `grep` confirms these were the only class-scoped fixtures in `tests/`.

## Checklist

- [x] Tests — this *is* a test-infra fix; all tiers green under pytest 9.1.0
- [x] Docs — n/a
- [x] Changelog — n/a (test-only; no user-visible change)
- [x] ADR — n/a
- [x] Migration — n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test fixture structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->