### PR TITLE
ci(linkcheck): raise lychee max_redirects 20 -> 25 for GCP docs host move

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -19,9 +19,9 @@
 # Default check timeout per URL.
 timeout = 20
 
-# Don't follow more than 20 redirects (catches infinite-loop CDNs).
-# Bumped from 5 → 10 → 15 → 20 to absorb Google Cloud docs' CDN/locale
-# redirect chain (``cloud.google.com → docs.cloud.google.com →
+# Don't follow more than 25 redirects (catches infinite-loop CDNs).
+# Bumped from 5 → 10 → 15 → 20 → 25 to absorb Google Cloud docs'
+# CDN/locale redirect chain (``cloud.google.com → docs.cloud.google.com →
 # locale-prefixed → canonical``) which keeps growing with their
 # CDN topology. PR #101 (2026-05-28) bumped 10 → 15 to clear PR #100's
 # failures; PR #110 (2026-05-30) bumped 15 → 20 after the pre-v1.1.2
@@ -29,11 +29,18 @@ timeout = 20
 # been limited by "max-redirects"`` on two GCP docs URLs
 # (``information-schema-columns``, ``standard-sql/transactions``)
 # referenced from ``docs/reference/conformance-coverage-matrix.md``.
-# Same URLs resolve fine in a browser — the hop count from the runner
-# egress region is the variable. 20 absorbs the latest observed chain
+# Issue #141 (2026-06-11 nightly) hit the same limit on
+# ``reference/rest`` and ``standard-sql/date_functions``: the
+# ``cloud.google.com`` host now issues a 301 to ``docs.cloud.google.com``
+# (a permanent host move), adding one hop on top of the locale chain,
+# so 20 → 25. If this recurs, the next step is migrating the source
+# URLs to ``docs.cloud.google.com`` (the new canonical host) rather
+# than raising the cap further.
+# Same URLs resolve fine in a browser; the hop count from the runner
+# egress region is the variable. 25 absorbs the latest observed chain
 # with headroom; infinite-loop CDNs cap out much higher (40+) so we
 # still catch the pathological cases.
-max_redirects = 20
+max_redirects = 25
 
 # Retry failed URLs on transient errors. Calibrated against the
 # v1.0.2 release CI cycle (PR #43, 2026-05-23) where lychee hit


### PR DESCRIPTION
## Problem

The nightly lychee run (#141) reported link rot on two `cloud.google.com` docs URLs referenced from `docs/reference/conformance-coverage-matrix.md`:

- `https://cloud.google.com/bigquery/docs/reference/rest`
- `https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions`

both as `[302] Rejected status code ... Redirects may have been limited by "max-redirects"`.

## Root cause

Google moved its cloud docs host: `cloud.google.com/...` now returns a **301 Moved Permanently** to `docs.cloud.google.com/...` (verified by `curl`). That adds one hop on top of the existing locale/CDN chain the config already documents. The links are **not** dead, they resolve `301 -> 200`, and lychee successfully followed the chain for the other ~500 `cloud.google.com` links that night (counted under "Successful"/"Redirected"). Only the two longest chains overran the `max_redirects = 20` budget from the GitHub runner's egress region (the hop count is region-dependent, which is why only 2 of ~500 flaked).

## Fix

Bump `max_redirects` `20 -> 25`, consistent with the documented `5 -> 10 -> 15 -> 20` progression, and record the host move plus the escalation path in the comment. This keeps full link validation: genuine 4xx/dead links still fail the gate; we only tolerate a slightly longer redirect chain, still well under the 40+ threshold that catches infinite-loop CDNs.

Rejected the larger alternative (rewriting ~500 URLs to `docs.cloud.google.com` across the generated matrix, guides, and immutable ADRs): disproportionate, and it bets on an in-flight Google migration being permanent. If this recurs, the comment notes that host migration is the next step.

## Verification

- TOML parses; `max_redirects = 25`.
- `lychee` (Docker) against both URLs with the new config: `2 OK, 0 Errors, 2 Redirects`.
- Note: the failure is region-dependent (hop count from the runner), so the authoritative check is the `Verify links` CI run on this PR from GitHub's egress.

## Checklist

- [x] Tests — n/a (linkcheck config only)
- [x] Docs — config comment updated with the host-move rationale + escalation path
- [x] Changelog — n/a (CI config; no user-visible change)
- [x] ADR — n/a (no architectural change; existing config strategy retained)
- [x] Migration — n/a

Closes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated link-validation settings to allow longer redirect chains by increasing the redirect limit.
  * Refreshed the configuration notes to reflect observed redirect behavior on specific documentation URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->