### PR TITLE
fix(deps): adopt starlette 1.x to clear CVEs without adopting httpx2

### DIFF
--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -93,11 +93,3 @@ CVE-2026-45409
 # fix version is available; tracked for the same dependency-refresh
 # sweep that bumps idna / requests.
 PYSEC-2026-89
-
-# starlette 0.52.1 — PYSEC-2026-161 (fix in 1.0.1). The starlette
-# version is gated by fastapi's compatibility range; the next
-# fastapi minor (>0.118) will pull starlette 1.0.1 transitively.
-# Tracked for the same dependency-refresh sweep that bumps idna /
-# requests / markdown. Advisory rolled into the pip-audit DB after
-# the v1.0.0 release-candidate baseline was checked clean.
-PYSEC-2026-161

--- a/docs/adr/0044-starlette-1x-adoption.md
+++ b/docs/adr/0044-starlette-1x-adoption.md
@@ -1,0 +1,78 @@
+# ADR 0044: Adopt starlette 1.x (security) without adopting httpx2
+
+- **Status**: Accepted
+
+## Context
+
+`pip-audit` flagged four advisories against `starlette` 0.52.1, the ASGI
+foundation under FastAPI that serves the emulator's REST API:
+
+- `CVE-2026-48818` (fixed in starlette 1.1.0)
+- `CVE-2026-48817` (fixed in starlette 1.1.0)
+- `CVE-2026-54282` (fixed in starlette 1.3.0)
+- `CVE-2026-54283` (fixed in starlette 1.3.1)
+
+Every fix ships in the starlette 1.x line. The dependency had been held at
+`starlette>=0.46,<1.0`. The ceiling pin's stated reason was a feared
+`httpx` to `httpx2` migration in `starlette.testclient` (which FastAPI's
+`TestClient` re-exports), deferred to "its own PR." A prior advisory,
+`PYSEC-2026-161`, was carried in `.pip-audit-ignore` for the same reason: its
+only fix was in the capped 1.x line.
+
+Empirically, the feared migration is narrower than the pin assumed:
+
+- `fastapi` 0.137 (the current floor's resolution) already accepts
+  `starlette` 1.3.1 and resolves with plain `httpx` 0.28; there is no runtime
+  `httpx2` requirement.
+- `starlette.testclient` in 1.x prefers an optional `httpx2` package and, when
+  it is absent, falls back to plain `httpx` while emitting a
+  `StarletteDeprecationWarning`. The only concrete breakage was that the
+  project's warnings-as-errors test policy turned that import-time deprecation
+  into a collection error for every `TestClient`-based test.
+
+The security exposure is real (a runtime dependency), though the emulator's
+threat model is a local, trusted developer or CI environment rather than an
+internet-facing service.
+
+## Decisions
+
+### 1. Floor `starlette>=1.3.1`
+
+1.3.1 is the lowest release that clears all four advisories plus the
+previously-ignored `PYSEC-2026-161`. `fastapi` and `httpx` are left at their
+existing floors; no FastAPI bump is required.
+
+### 2. Keep plain `httpx`; do not adopt `httpx2`
+
+`httpx2` is a separate, distinct HTTP-client package whose provenance and
+maintenance are not yet vetted for this dependency graph, and the security fix
+that motivated this change lives in `starlette` itself, not in the test
+client. Plain `httpx` remains fully supported by `starlette.testclient` as the
+fallback, so the test client keeps working unchanged.
+
+### 3. Scope-ignore the test-client deprecation warning
+
+A single `filterwarnings` entry in `pyproject.toml` ignores exactly the
+"Using `httpx` with `starlette.testclient` is deprecated" message
+(`starlette.exceptions.StarletteDeprecationWarning`). The ignore is matched by
+message so any other starlette deprecation still fails the warnings-as-errors
+gate. Adopting `httpx2`, or revisiting if a future starlette release removes
+the plain-`httpx` fallback, is left as follow-up.
+
+### 4. Drop the obsolete `PYSEC-2026-161` ignore
+
+That entry existed only because the fix was gated behind the `<1.0` cap. With
+the floor at 1.3.1 the advisory is genuinely patched, so the ignore is removed
+rather than carried as dead configuration.
+
+## Consequences
+
+- `pip-audit` reports no known vulnerabilities; the four CVEs and
+  `PYSEC-2026-161` are resolved by the upgrade, not suppressed.
+- The long-standing `starlette<1.0` deferral and its tracking comment are
+  retired.
+- One narrowly-scoped warning ignore is added to the test configuration; the
+  rest of the warnings-as-errors discipline is unchanged.
+- A future move to `httpx2` (or a forced move, if starlette drops the
+  plain-`httpx` fallback) is a self-contained follow-up that does not block the
+  security fix.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -229,6 +229,7 @@ nav:
       - "0041 Cyclomatic-complexity ratchet to rank B + campaign retrospective": adr/0041-complexity-ratchet-to-b.md
       - "0042 Per-module-average ratchet to rank B (no-refactor follow-on)": adr/0042-module-ceiling-ratchet-to-b.md
       - "0043 EXPORT DATA statement (Cloud Storage)": adr/0043-export-data-statement.md
+      - "0044 Adopt starlette 1.x (security) without adopting httpx2": adr/0044-starlette-1x-adoption.md
   - RFCs:
       - Overview: rfcs/README.md
       - "0001 EXPORT DATA statement (Cloud Storage)": rfcs/0001-export-data-statement.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,18 +89,18 @@ dependencies = [
     "prometheus-client>=0.20",
     "orjson>=3.10",
     "httpx>=0.27",
-    # Ceiling pin on starlette to dodge the 1.0.0 release line's switch
-    # from ``httpx`` to ``httpx2`` in starlette.testclient (FastAPI's
-    # TestClient relies on this). Adopting starlette 1.x cleanly needs
-    # a coordinated httpx -> httpx2 migration across the dep graph
-    # (FastAPI's TestClient + our explicit httpx>=0.27 dep). Pinning
-    # to the 0.x line keeps the existing testclient working until that
-    # migration is planned and landed in its own PR.
+    # Floor pin on starlette at the 1.x line to clear four advisories
+    # whose only fixes ship in 1.x: CVE-2026-48818 / CVE-2026-48817
+    # (fixed 1.1.0), CVE-2026-54282 (fixed 1.3.0), CVE-2026-54283
+    # (fixed 1.3.1). 1.3.1 is the lowest release covering all four.
     #
-    # The floor matches FastAPI 0.135's own ``starlette>=0.46`` floor:
-    # explicit so any future loosening of FastAPI's transitive
-    # constraint doesn't open a security-drift window on starlette.
-    "starlette>=0.46,<1.0",
+    # The earlier ``<1.0`` ceiling was kept to avoid a feared
+    # ``httpx -> httpx2`` migration in ``starlette.testclient``. That
+    # turned out to be a non-issue: starlette 1.3.1 resolves cleanly
+    # with the current ``fastapi`` (0.137) and plain ``httpx`` 0.28
+    # (there is no ``httpx2`` package), and FastAPI's TestClient keeps
+    # working unchanged. See ADR 0044.
+    "starlette>=1.3.1",
     "alembic>=1.13",
     # Floor pin on alembic's transitive Mako dep to dodge CVE-2026-44307
     # (template-injection in the Babel string-extractor). 1.3.12 is the
@@ -505,6 +505,20 @@ filterwarnings = [
     # finalizer happened to GC). The underlying resources are safely
     # cleaned up by the runtime; the warning is purely diagnostic.
     "ignore::pytest.PytestUnraisableExceptionWarning",
+    # starlette 1.x's ``starlette.testclient`` (re-exported by
+    # ``fastapi.testclient.TestClient``) emits a
+    # ``StarletteDeprecationWarning`` at import when it falls back to
+    # plain ``httpx`` because the optional ``httpx2`` package is not
+    # installed. With the ``"error"`` filter above this turns every
+    # TestClient-based test into a collection error. We deliberately
+    # keep plain ``httpx`` (still fully supported as the fallback) and
+    # do NOT add ``httpx2``: it is an unvetted, separate HTTP-client
+    # package and the security fix that motivated the starlette 1.x
+    # bump lives in starlette itself, not the test client. Scope the
+    # ignore to this exact message so any other starlette deprecation
+    # still surfaces. Revisit if starlette removes the httpx fallback
+    # or once httpx2 is vetted for the dependency graph. See ADR 0044.
+    "ignore:Using `httpx` with `starlette.testclient` is deprecated:starlette.exceptions.StarletteDeprecationWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Problem

`pip-audit` (the `Lint + type-check` gate) is failing on **main and every PR** with four advisories against **starlette 0.52.1**, the ASGI layer under FastAPI that serves the emulator's REST API:

| Advisory | Fixed in |
|---|---|
| CVE-2026-48818 | starlette 1.1.0 |
| CVE-2026-48817 | starlette 1.1.0 |
| CVE-2026-54282 | starlette 1.3.0 |
| CVE-2026-54283 | starlette 1.3.1 |

Every fix ships in the 1.x line, which was capped out by `starlette>=0.46,<1.0`. (Surfaced while addressing the #141 link-rot PR, but it is an independent, pre-existing breakage.)

## Why the cap existed, and why it was safe to lift

The ceiling pin's stated reason was a feared `httpx -> httpx2` migration in `starlette.testclient`. Empirically that is narrower than assumed:

- `fastapi` 0.137 already accepts `starlette` 1.3.1 and resolves with plain `httpx` 0.28; there is **no runtime `httpx2` requirement** and no FastAPI bump needed.
- `starlette.testclient` 1.x prefers an optional `httpx2` package and falls back to plain `httpx` when it is absent, emitting a `StarletteDeprecationWarning`. The only concrete breakage was the warnings-as-errors policy turning that import-time deprecation into a collection error for `TestClient`-based tests.

## Fix

- Floor `starlette>=1.3.1` (lowest release clearing all four CVEs + the previously-ignored `PYSEC-2026-161`).
- **Do not adopt `httpx2`** (separate, unvetted HTTP-client package; the security fix is in starlette itself, not the test client). Keep plain `httpx`, which starlette still supports.
- Add one **message-scoped** `filterwarnings` ignore for the testclient deprecation, so any *other* starlette deprecation still fails the gate.
- Drop the now-obsolete `PYSEC-2026-161` ignore from `.pip-audit-ignore` (genuinely patched by the bump, not suppressed).
- Record the decision in [ADR 0044](docs/adr/0044-starlette-1x-adoption.md).

## Verification (clean venv on starlette 1.3.1 + fastapi 0.137 + httpx 0.28)

- Unit **2836 passed**, property **54 passed**, integration **266 passed** (1 skip: avro-tools not on local PATH).
- `mkdocs build --strict` clean (ADR wired into nav).
- `pip-audit` (with `.pip-audit-ignore`): **No known vulnerabilities found**.

## Checklist

- [x] Tests — full unit/property/integration green on the new starlette
- [x] Docs — ADR 0044 added + mkdocs nav; pyproject/`.pip-audit-ignore` comments updated
- [x] Changelog — n/a (authored at release time; no `[Unreleased]` section)
- [x] ADR — 0044
- [x] Migration — n/a (no API/behavior change; dependency floor only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Upgraded Starlette from 0.46 to version 1.3.1.

* **Documentation**
  * Updated architecture decision records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->