### PR TITLE
ci(dependabot): group example and e2e security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,3 +66,87 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore(deps)"
+
+  # ----------------------------------------------------------------------
+  # Example + e2e manifests: GROUP security updates; no version updates.
+  #
+  # The example lock files and e2e client manifests are deliberately
+  # pinned snapshots, so Dependabot must not version-update their hundreds
+  # of transitively-pinned dependencies. ``open-pull-requests-limit: 0``
+  # disables version updates for each block while leaving security updates
+  # on (security updates are not counted against that limit).
+  #
+  # Dependabot security updates fire for vulnerable dependencies in these
+  # manifests regardless of this file (they are driven by the dependency
+  # graph, not by a version-update ``updates`` block). Without a matching
+  # block they arrive ungrouped: one pull request per dependency per
+  # directory, so a single shared CVE (e.g. ``cryptography``) fans out into
+  # one PR per example. The ``applies-to: security-updates`` group below
+  # collapses each wave into one pull request per ecosystem, spanning every
+  # affected directory.
+  #
+  # Go modules (``gomod``) and Maven (``maven``) are covered for the same
+  # reason; the scio example uses sbt, which Dependabot does not support,
+  # so it is intentionally absent.
+  # ----------------------------------------------------------------------
+  - package-ecosystem: pip
+    directories:
+      - "/docs/examples/python/*"
+      - "/docs/examples/docker-compose/full-stack/app"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 0
+    groups:
+      example-pip-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: npm
+    directories:
+      - "/docs/examples/nodejs/*"
+      - "/tests/e2e/nodejs_client"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      example-npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: gomod
+    directories:
+      - "/docs/examples/go/*"
+      - "/tests/e2e/go_client"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      example-gomod-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: maven
+    directories:
+      - "/docs/examples/java/spring-boot"
+      - "/tests/e2e/java_client"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      example-maven-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## What

Group Dependabot **security** updates for the example and e2e dependency manifests, so a wave of CVE patches arrives as one pull request per ecosystem instead of one per dependency per directory.

## Why

The example lock files (`docs/examples/**`) and e2e client manifests (`tests/e2e/**`) are not listed in any version-update `updates` block, so the bumps Dependabot opens against them are **security updates**, driven by the dependency graph rather than this config. Without a matching block they arrive ungrouped: one PR per vulnerable dependency per directory. A single shared CVE fans out badly, for example `cryptography` 48.0.0 -> 48.0.1 opened four separate PRs (#153, #154, #156, #158) across the python examples; the recent wave was eight PRs total (#152 through #159).

## How

Add `pip`, `npm`, `gomod`, and `maven` `updates` blocks covering the example and e2e directories. Each block:

- sets `open-pull-requests-limit: 0`, which disables **version** updates while leaving security updates on (security updates are not counted against that limit). These manifests are deliberately pinned snapshots, so we do not want their hundreds of transitively-pinned dependencies version-bumped.
- defines a group with `applies-to: security-updates` and `patterns: ["*"]`, so each security wave collapses into one grouped PR per ecosystem, spanning every affected directory.

The `scio` example uses sbt, which Dependabot does not support, so it is intentionally absent. The existing root `pip` / `github-actions` / `docker` blocks are unchanged.

This is the version-controlled half of the feature; it pairs with the repo-level "Group security updates" setting (Settings -> Code security) if you also want GitHub's default by-directory grouping without config.

## Checklist

- [x] No code or public surface change (CI automation config only); no tests, ADR, RFC, or changelog entry required.
- [x] YAML validated (parses, `version: 2`, 7 well-formed `updates` entries).
- [x] Conventional Commit, signed, DCO sign-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated dependency management configuration to include documentation and test client directories. Weekly security updates are now intelligently grouped and consolidated across multiple package ecosystems including npm, pip, Maven, and Go modules. This enhancement reduces notification volume while maintaining rapid vulnerability response times and streamlined development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->