### PR TITLE
fix(testing): de-flake in-process server startup (extension prewarm + clean teardown)

### DIFF
--- a/.github/actions/prewarm-duckdb-extensions/action.yml
+++ b/.github/actions/prewarm-duckdb-extensions/action.yml
@@ -1,0 +1,49 @@
+name: Prewarm DuckDB extensions
+description: >-
+  Make the DuckDB ``spatial`` and ``avro`` extensions available in the runner's
+  local extension cache before tests run. The in-process emulator installs
+  these during ``DuckDBEngine.start``; doing it here keeps the network fetch
+  from ``extensions.duckdb.org`` out of the test hot path, where an
+  intermittent stall under CI load hangs server startup and aborts the run
+  (exit 134). The extension dir is cached across runs (keyed on the installed
+  DuckDB version), so the network is only touched on a cold cache; the install
+  step is bounded and retried so a transient stall fails this (retryable) step
+  cleanly rather than hanging deep inside pytest. Run after the project
+  dependencies are installed (so the same ``duckdb`` build populates the cache
+  the tests read) and before pytest.
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve DuckDB version (cache key)
+      id: duckdb
+      shell: bash
+      run: echo "version=$(python -c 'import duckdb; print(duckdb.__version__)')" >> "$GITHUB_OUTPUT"
+    - name: Restore DuckDB extension cache
+      id: cache
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.duckdb/extensions
+        key: duckdb-ext-${{ runner.os }}-${{ steps.duckdb.outputs.version }}-spatial-avro
+    - name: Install spatial + avro (network only on a cold cache)
+      shell: bash
+      run: |
+        install_exts() {
+          timeout 90 python -c "import duckdb; c = duckdb.connect(); [c.execute(q) for e in ('spatial', 'avro') for q in (f'INSTALL {e}', f'LOAD {e}')]"
+        }
+        for attempt in 1 2 3; do
+          if install_exts; then
+            echo "DuckDB extensions installed and loadable (attempt ${attempt})."
+            exit 0
+          fi
+          echo "::warning::DuckDB extension prewarm attempt ${attempt} failed or timed out; retrying."
+          sleep 5
+        done
+        echo "::error::DuckDB extension prewarm failed after 3 attempts."
+        exit 1
+    - name: Save DuckDB extension cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.duckdb/extensions
+        key: duckdb-ext-${{ runner.os }}-${{ steps.duckdb.outputs.version }}-spatial-avro

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,all]"
+      # Prewarm DuckDB extensions so engine-backed unit tests read them from
+      # the local cache rather than fetching over the network mid-test.
+      # Linux-only: the prewarm uses ``timeout``, absent from the macOS /
+      # Windows matrix cells' bash.
+      - uses: ./.github/actions/prewarm-duckdb-extensions
+        if: runner.os == 'Linux'
       - name: Unit tests
         run: pytest tests/unit -m unit
       - name: Property tests
@@ -97,6 +103,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends avro-tools || \
             echo "::warning::avro-tools apt package unavailable; the cross-impl test will skip"
+      - uses: ./.github/actions/prewarm-duckdb-extensions
       - name: Integration tests
         run: pytest tests/integration -m integration
 
@@ -127,6 +134,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,all]"
+      - uses: ./.github/actions/prewarm-duckdb-extensions
       - name: Replay conformance corpus (offline; no BQ creds)
         run: pytest tests/conformance -m conformance --junit-xml=conformance.xml
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -154,6 +162,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,all]"
+      - uses: ./.github/actions/prewarm-duckdb-extensions
       - name: Combined coverage (unit + property + integration)
         run: |
           pytest tests/unit tests/property tests/integration \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -112,12 +112,13 @@ jobs:
             -e BQEMU_ADMIN_ENABLED=1 \
             -e BQEMU_GCS_LOCAL_ROOT=/var/lib/bqemu-gcs \
             "$BQEMU_IMAGE"
-          # Wait up to 60s for /healthz to respond.
-          for _ in $(seq 1 120); do
+          # Wait up to 90s for /healthz to respond (headroom for slow
+          # container startup under shared-CI load).
+          for _ in $(seq 1 180); do
             if curl -sf http://localhost:9050/healthz > /dev/null; then exit 0; fi
             sleep 0.5
           done
-          echo "::error::bqemulator did not become ready in 60s"
+          echo "::error::bqemulator did not become ready in 90s"
           docker logs bqemu || true
           exit 1
       - name: Install + test
@@ -178,11 +179,11 @@ jobs:
             -e BQEMU_ADMIN_ENABLED=1 \
             -e BQEMU_GCS_LOCAL_ROOT=/var/lib/bqemu-gcs \
             "$BQEMU_IMAGE"
-          for _ in $(seq 1 120); do
+          for _ in $(seq 1 180); do
             if curl -sf http://localhost:9050/healthz > /dev/null; then exit 0; fi
             sleep 0.5
           done
-          echo "::error::bqemulator did not become ready in 60s"
+          echo "::error::bqemulator did not become ready in 90s"
           docker logs bqemu || true
           exit 1
       - name: Test
@@ -238,11 +239,11 @@ jobs:
             -e BQEMU_ADMIN_ENABLED=1 \
             -e BQEMU_GCS_LOCAL_ROOT=/var/lib/bqemu-gcs \
             "$BQEMU_IMAGE"
-          for _ in $(seq 1 120); do
+          for _ in $(seq 1 180); do
             if curl -sf http://localhost:9050/healthz > /dev/null; then exit 0; fi
             sleep 0.5
           done
-          echo "::error::bqemulator did not become ready in 60s"
+          echo "::error::bqemulator did not become ready in 90s"
           docker logs bqemu || true
           exit 1
       - name: Test

--- a/src/bqemulator/testing/_thread_runner.py
+++ b/src/bqemulator/testing/_thread_runner.py
@@ -17,6 +17,16 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover
     from bqemulator.config import Settings
 
+# Grace period for the in-process test server to signal readiness. The
+# wait returns the instant the server is up (typically well under a
+# second), so this bound governs only the worst case: a shared CI runner
+# so overloaded that a healthy startup is merely slow. Sized generously
+# because a tighter bound intermittently tripped under that contention. A
+# genuine startup *error* short-circuits the wait (the background thread
+# captures it and signals immediately), so this longer bound only delays
+# surfacing a true hang, never a real error, and never slows a normal run.
+_STARTUP_TIMEOUT_SECONDS = 90
+
 
 class ThreadedEmulator:
     """Runs an :class:`EmulatorServer` on a background thread + event loop."""
@@ -31,7 +41,7 @@ class ThreadedEmulator:
         self._stopped = threading.Event()
         # Captured if ``server.start()`` raised on the background
         # thread; surfaced from the foreground ``start()`` call so test
-        # code sees the actual error (not just a 30s timeout).
+        # code sees the actual error (not just a startup timeout).
         self._startup_error: BaseException | None = None
 
     def start(self) -> None:
@@ -44,14 +54,17 @@ class ThreadedEmulator:
            captures the exception, sets ``_started`` so we unblock, and
            we re-raise here. The captured exception is more actionable
            than a generic timeout.
-        3. Neither happens within 30 s — surface a timeout.
+        3. Neither happens within ``_STARTUP_TIMEOUT_SECONDS`` — surface
+           a timeout.
         """
         self._thread = threading.Thread(target=self._run, name="bqemu-server", daemon=True)
         self._thread.start()
-        if not self._started.wait(timeout=30):
+        if not self._started.wait(timeout=_STARTUP_TIMEOUT_SECONDS):
             if self._startup_error is not None:
                 raise self._startup_error
-            raise RuntimeError("bqemulator test server failed to start within 30s")
+            raise RuntimeError(
+                f"bqemulator test server failed to start within {_STARTUP_TIMEOUT_SECONDS}s"
+            )
         # Event fired — either the server is up, or startup raised and
         # captured the error before signalling. The latter has
         # ``_startup_error`` set; surface it now.
@@ -59,14 +72,33 @@ class ThreadedEmulator:
             raise self._startup_error
 
     def stop(self) -> None:
-        """Stop the server thread."""
-        if self._loop is None or self._thread is None:
+        """Stop the server thread. Idempotent and safe after a failed start.
+
+        ``start`` may have raised (timeout, or a captured startup error), in
+        which case the background thread's loop is already closed or wedged.
+        Every loop interaction is guarded and the thread is always joined
+        (bounded), so callers can run ``stop`` unconditionally in a ``finally``
+        to reclaim the background thread instead of leaking it into interpreter
+        shutdown (which aborts with "terminate called without an active
+        exception"). Test teardown must never raise.
+        """
+        if self._thread is None:
             return
-        fut = asyncio.run_coroutine_threadsafe(self.server.stop(), self._loop)
-        # Best-effort wait for clean shutdown; test teardown must never raise.
-        with contextlib.suppress(Exception):
-            fut.result(timeout=10)
-        self._loop.call_soon_threadsafe(self._loop.stop)
+        # Do loop work only when the loop exists and is still open, but always
+        # join the thread below, even in the narrow window where ``_run`` has
+        # started but not yet assigned ``_loop`` — otherwise the thread leaks.
+        if self._loop is not None and not self._loop.is_closed():
+            # Only a cleanly-started server has something to gracefully stop.
+            # On a failed or wedged start, scheduling ``server.stop()`` would
+            # create a coroutine the closed/hung loop never awaits (a
+            # ``RuntimeWarning`` the suite treats as an error); skip it and just
+            # unwind the loop and join the thread.
+            if self._started.is_set() and self._startup_error is None:
+                with contextlib.suppress(Exception):
+                    fut = asyncio.run_coroutine_threadsafe(self.server.stop(), self._loop)
+                    fut.result(timeout=10)
+            with contextlib.suppress(Exception):
+                self._loop.call_soon_threadsafe(self._loop.stop)
         self._thread.join(timeout=10)
 
     def _run(self) -> None:
@@ -82,7 +114,8 @@ class ThreadedEmulator:
             loop.run_until_complete(_start_then_park())
         except BaseException as exc:  # noqa: BLE001 — re-raised in start()
             # Capture and signal the waiter so the foreground call
-            # surfaces the actual cause instead of timing out at 30s.
+            # surfaces the actual cause instead of timing out after the
+            # startup grace period.
             self._startup_error = exc
             self._started.set()
             loop.close()

--- a/src/bqemulator/testing/fixtures.py
+++ b/src/bqemulator/testing/fixtures.py
@@ -87,11 +87,17 @@ def bqemu_server(
     from bqemulator.testing._thread_runner import ThreadedEmulator
 
     threaded = ThreadedEmulator(bqemu_settings)
-    threaded.start()
-
     previous = os.environ.get("BIGQUERY_EMULATOR_HOST")
-    os.environ["BIGQUERY_EMULATOR_HOST"] = f"{bqemu_settings.rest_host}:{threaded.server.rest_port}"
     try:
+        # ``start()`` runs inside the ``try`` so a failed or slow startup still
+        # reaches ``threaded.stop()`` in the ``finally``. Otherwise a
+        # half-started server leaks its background thread (and the native gRPC /
+        # DuckDB resources it holds) into interpreter shutdown, which aborts the
+        # process with "terminate called without an active exception".
+        threaded.start()
+        os.environ["BIGQUERY_EMULATOR_HOST"] = (
+            f"{bqemu_settings.rest_host}:{threaded.server.rest_port}"
+        )
         yield threaded.server
     finally:
         if previous is None:

--- a/src/bqemulator/testing/testcontainers.py
+++ b/src/bqemulator/testing/testcontainers.py
@@ -16,6 +16,7 @@ Example::
 
 from __future__ import annotations
 
+import contextlib
 import os
 import re
 from typing import Self
@@ -28,6 +29,12 @@ DEFAULT_IMAGE = "ghcr.io/jjviscomi/bqemulator:latest"
 DEFAULT_REST_PORT = 9050
 DEFAULT_GRPC_PORT = 9060
 _READY_RE = re.compile(r"rest\.listen")
+# Grace period for the container's REST listener to log readiness.
+# ``wait_for_logs`` returns the instant the pattern matches, so this bounds
+# only a slow start under shared-CI load (where a tighter window
+# intermittently elapsed while the container was still booting), never a
+# normal run.
+_READY_TIMEOUT_SECONDS = 90
 
 
 class BigQueryEmulatorContainer(DockerContainer):
@@ -87,9 +94,17 @@ class BigQueryEmulatorContainer(DockerContainer):
         wrapper don't need to edit their own pytest filter list.
         """
         super().start()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            wait_for_logs(self, _READY_RE.pattern, timeout=30)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                wait_for_logs(self, _READY_RE.pattern, timeout=_READY_TIMEOUT_SECONDS)
+        except Exception:
+            # The container started but never signalled readiness in time. Stop
+            # it before re-raising so a caller that runs ``start()`` before its
+            # own ``try``/``finally`` does not leak a running container.
+            with contextlib.suppress(Exception):
+                self.stop()
+            raise
         return self
 
     def get_rest_url(self) -> str:

--- a/tests/unit/testing/test_thread_runner.py
+++ b/tests/unit/testing/test_thread_runner.py
@@ -1,0 +1,57 @@
+"""Unit tests for the threaded in-process emulator runner."""
+
+from __future__ import annotations
+
+import pytest
+
+from bqemulator.config import PersistenceMode, Settings
+from bqemulator.testing._thread_runner import ThreadedEmulator
+
+pytestmark = pytest.mark.unit
+
+
+def _ephemeral_settings() -> Settings:
+    return Settings(
+        persistence_mode=PersistenceMode.EPHEMERAL,
+        rest_host="127.0.0.1",
+        rest_port=0,
+        grpc_host="127.0.0.1",
+        grpc_port=0,
+    )
+
+
+class _BoomServer:
+    """Stand-in server whose startup fails immediately."""
+
+    async def start(self) -> None:
+        raise RuntimeError("boom")
+
+    async def stop(self) -> None:  # pragma: no cover - unreachable on the error path
+        return
+
+
+def test_failed_start_surfaces_error_then_stop_reclaims_thread() -> None:
+    """A failed startup surfaces the real error, and ``stop`` stays safe.
+
+    Regression guard for the abort-on-failed-start path: ``stop`` must not
+    raise when the background loop is already closed (the startup-error path
+    closes it), and it must join the background thread rather than leak it into
+    interpreter shutdown (which aborts with "terminate called without an active
+    exception"). Mirrors the ``bqemu_server`` fixture calling ``stop`` from its
+    ``finally`` even when ``start`` raised.
+    """
+    runner = ThreadedEmulator(_ephemeral_settings())
+    runner.server = _BoomServer()  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError, match="boom"):
+        runner.start()
+
+    # Safe to call after a failed start: the loop is already closed, so this
+    # skips loop work and just joins the (already-finished) background thread.
+    runner.stop()
+    assert runner._thread is not None
+    assert not runner._thread.is_alive()
+
+    # ``stop`` is idempotent: a second call is a no-op and must not raise.
+    runner.stop()
+    assert not runner._thread.is_alive()


### PR DESCRIPTION
## What

De-flake the intermittent in-process emulator startup failures seen across recent CI runs (integration and conformance jobs failing with `bqemulator test server failed to start within …s` and a native `terminate called without an active exception` / exit 134).

## Root cause

The session-scoped in-process emulator (`bqemu_server` fixture) intermittently hung in `DuckDBEngine.start`. In the failing conformance run the server logged `bqemulator.start` but **never** `rest.listen`, which isolates the hang to the only step in that range without an inner timeout: the network `INSTALL spatial` / `INSTALL avro` against `extensions.duckdb.org`. On a cold extension cache under shared-CI load that fetch stalls, so startup never completes.

That stall then turned into a hard abort: the `bqemu_server` fixture called `start()` **before** its `try` block, so a failed start skipped the `finally` and abandoned the background daemon thread, which still held native gRPC / DuckDB resources. At interpreter exit those were torn down uncleanly, aborting the process (exit 134).

A timeout widening alone does not fix this: a true network stall is a hang, not slowness, so a longer wait only delays the failure. The fix removes the network from the test hot path and makes any residual failure clean.

## Changes

1. **CI — take the network out of the hot path (the real fix).** A new composite action `.github/actions/prewarm-duckdb-extensions` installs `spatial` + `avro` into the runner's local extension cache, bounded by `timeout` and retried, before pytest. Wired into the `unit` (Linux only — `timeout` is absent on the macOS / Windows bash), `integration`, `conformance`, and `coverage` jobs. `DuckDBEngine.start` then finds the extensions locally and never fetches mid-test.
2. **Fixture — always tear down.** `bqemu_server` runs `start()` inside the `try`, so `stop()` always reclaims the background thread, even on a failed start, instead of leaking it into interpreter shutdown.
3. **`ThreadedEmulator.stop` — safe after a failed start.** Guards every event-loop interaction and only attempts a graceful `server.stop()` for a cleanly-started server, so it never raises, never leaks the thread, and never schedules an un-awaited coroutine (a `RuntimeWarning` the suite treats as an error).
4. **Timeouts.** Widen the readiness waits as headroom for genuinely slow (non-hung) startups: the in-process startup and testcontainers waits 30s → 90s, and the three inline `/healthz` polls in `e2e.yml` 60s → 90s. These waits return as soon as the server is ready, so the happy path is unchanged.
5. **Test.** Add a unit test for the failed-start cleanup path (`stop()` after a startup error must not raise and must join the thread).

## Confidence / scope

The root cause is identified with high confidence from the logs (start-but-no-`rest.listen`, exit 134). The flake is intermittent and CI-load-dependent, so I cannot reproduce it locally; this PR removes the network dependency that triggers it and makes any residual startup failure fail cleanly and re-runnably rather than aborting. The macOS / Windows `unit` matrix cells also call `engine.start` but were never observed flaking and are not prewarmed here (a cross-platform prewarm would be a follow-up if it surfaces).

## Checklist

- [x] No public API or product behavior change (test harness + CI only).
- [x] `ruff`, `mypy --strict`, and `actionlint` pass on the changed files; new unit test passes under warnings-as-errors.
- [x] Conventional Commit, signed, DCO sign-off. No changelog entry (authored at release time) and no ADR (no architectural decision).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved BigQuery emulator startup reliability with 90s timeouts and immediate surfacing of startup failures.
  * Made emulator shutdown resilient after failed/aborted starts and ensured environment/host cleanup even on slow startup failures.
* **CI / Test Reliability**
  * Added DuckDB extension prewarming (`spatial`, `avro`) with caching and retries before tests.
  * Extended E2E `/healthz` readiness waits to 90s.
* **Tests**
  * Added a regression test covering startup failure propagation and safe thread cleanup afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->