### PR TITLE
fix(streaming): straddle pyarrow stub versions on the MessageReader ignore

### DIFF
--- a/src/bqemulator/streaming/read_session.py
+++ b/src/bqemulator/streaming/read_session.py
@@ -439,10 +439,11 @@ def serialize_arrow_record_batch(batch: pa.RecordBatch) -> bytes:
     #   [schema][dict-1]...[dict-N][batch][EOS]
     # Either way we want the RecordBatch message — loop until we
     # find one. ``MessageReader`` is re-exported by the
-    # ``pyarrow.ipc`` module but the stubs don't list it; the
-    # ignore matches the pattern used elsewhere in this file for
-    # ``new_stream``.
-    reader = pa.ipc.MessageReader.open_stream(  # type: ignore[attr-defined]
+    # ``pyarrow.ipc`` module, but only some stub versions list it
+    # (newer pyarrow ships it, older ones do not); ``unused-ignore``
+    # keeps the suppression cross-version-compatible, matching the
+    # ``new_stream`` ignores elsewhere in this file.
+    reader = pa.ipc.MessageReader.open_stream(  # type: ignore[attr-defined,unused-ignore]
         pa.BufferReader(stream_bytes)
     )
     batch_msg = None


### PR DESCRIPTION
## What

`make lint` (mypy --strict) was failing on main:

    src/bqemulator/streaming/read_session.py:445: error: Unused "type: ignore"

## Why

pyarrow is unpinned (`pyarrow>=14.0`, no lock). Newer pyarrow (23.x+) added a type stub for `pa.ipc.MessageReader.open_stream`, so the bare `# type: ignore[attr-defined]` on that call became unused, and mypy --strict (`warn_unused_ignores`) treats an unused ignore as an error. This is the unpinned-tooling-drift class: the same thing that previously hit `pa.ipc.new_stream`, already fixed with the `unused-ignore` straddle at lines 141 and 431.

## Fix

Add `unused-ignore` to the codes (`# type: ignore[attr-defined,unused-ignore]`) so the suppression is tolerated whether or not the installed pyarrow ships the stub, matching the existing `new_stream` ignores. Also correct the comment, which claimed the stubs never list `MessageReader`.

## Verification

`PYTHONPATH=src mypy src` returns Success (no issues, pyarrow 23.0.1). Full lint suite (ruff, ruff format, bandit, interrogate, typos) is green. Comment-only / type-ignore change; no runtime behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved type compatibility handling for different pyarrow library versions to ensure consistent behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->