### PR TITLE
release: bump to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ new release.
 See [`docs/architecture/contributing/documentation-style-guide.md`](docs/architecture/contributing/documentation-style-guide.md)
 for the full entry-form rules and worked examples.
 
-## [1.3.0] - 2026-06-19
+## [1.3.0] - 2026-06-20
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ new release.
 See [`docs/architecture/contributing/documentation-style-guide.md`](docs/architecture/contributing/documentation-style-guide.md)
 for the full entry-form rules and worked examples.
 
+## [1.3.0] - 2026-06-19
+
+### Changed
+
+- Adopt `starlette 1.x` to clear security advisories without pulling in `httpx 2.x`.
+- Bump GitHub Actions: `actions/checkout` 6.0.3 → 7.0.0, `softprops/action-gh-release` 3.0.0 → 3.0.1, `actions/setup-java` 5.2.0 → 5.3.0, `codecov/codecov-action` 6.0.1 → 7.0.0.
+
+### Added
+
+- Infer the schema for `autodetect` CSV and JSON load jobs from the source data via DuckDB, with full BigQuery parity for nested types: a JSON object maps to a `RECORD`, an array to a `REPEATED` field, and an array of objects to a `REPEATED RECORD`, recursively, using the legacy REST type names and rejecting an array of arrays that BigQuery cannot represent ([ADR 0045](docs/adr/0045-autodetect-schema-inference.md)).
+
 ## [1.2.0] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ DuckDB-backed, SQLGlot-powered, and tested against the real service. Point the o
 [![E2E](https://github.com/jjviscomi/bqemulator/actions/workflows/e2e.yml/badge.svg)](https://github.com/jjviscomi/bqemulator/actions/workflows/e2e.yml)
 [![Conformance](https://github.com/jjviscomi/bqemulator/actions/workflows/conformance.yml/badge.svg)](https://github.com/jjviscomi/bqemulator/actions/workflows/conformance.yml)
 [![Docs](https://github.com/jjviscomi/bqemulator/actions/workflows/docs.yml/badge.svg)](https://jjviscomi.github.io/bqemulator/)
-[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg?cacheSeconds=120&v=1.2.0)](https://pypi.org/project/bqemulator/)
-[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg?cacheSeconds=120&v=1.2.0)](https://pypi.org/project/bqemulator/)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jjviscomi/bqemulator/badge?v=1.2.0)](https://scorecard.dev/viewer/?uri=github.com/jjviscomi/bqemulator)
+[![PyPI](https://img.shields.io/pypi/v/bqemulator.svg?cacheSeconds=120&v=1.3.0)](https://pypi.org/project/bqemulator/)
+[![Python](https://img.shields.io/pypi/pyversions/bqemulator.svg?cacheSeconds=120&v=1.3.0)](https://pypi.org/project/bqemulator/)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jjviscomi/bqemulator/badge?v=1.3.0)](https://scorecard.dev/viewer/?uri=github.com/jjviscomi/bqemulator)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
@@ -201,7 +201,7 @@ See the [`docker-compose/full-stack`](docs/examples/docker-compose/full-stack/) 
 
 ## What works today
 
-`bqemulator` is at **v1.2.0** — second minor on the production-stable
+`bqemulator` is at **v1.3.0** — third minor on the production-stable
 line. SemVer applies: breaking changes ship only in MAJOR,
 deprecations live ≥2 MINOR or 6 months. The [compatibility matrix](https://jjviscomi.github.io/bqemulator/latest/reference/compatibility-matrix/) is auto-generated from the conformance corpus on every CI run; the [conformance coverage matrix](https://jjviscomi.github.io/bqemulator/latest/reference/conformance-coverage-matrix/) breaks down support by surface item.
 
@@ -272,7 +272,7 @@ Every example under [`docs/examples/`](docs/examples/) is a complete, runnable p
 
 ## Project status
 
-`bqemulator` is at **v1.2.0** — second minor on the production-stable
+`bqemulator` is at **v1.3.0** — third minor on the production-stable
 line. SemVer applies: breaking changes ship only in MAJOR
 versions, preceded by ≥1 MINOR with deprecation warnings;
 deprecated APIs remain for ≥2 MINOR versions or 6 months.
@@ -287,8 +287,8 @@ Maturity signals:
 - ✅ Fuzz-tier (`Atheris`) harnesses on the SQL translator, dynamic-protobuf decoder, and Arrow bridge.
 - ✅ Differential-tier row-order perturbation of the entire conformance corpus passes.
 - ✅ Performance baselines committed for `darwin-arm64`, with regression gates (`pytest-benchmark` `--benchmark-compare-fail=median:10%`).
-- ✅ PyPI publish via Trusted Publishing (sigstore-attested wheels) — `pip install bqemulator==1.2.0` resolves from [PyPI](https://pypi.org/project/bqemulator/).
-- ✅ GHCR publish with keyless cosign signatures — `docker pull ghcr.io/jjviscomi/bqemulator:1.2.0` resolves and the image is cosign-verifiable.
+- ✅ PyPI publish via Trusted Publishing (sigstore-attested wheels) — `pip install bqemulator==1.3.0` resolves from [PyPI](https://pypi.org/project/bqemulator/).
+- ✅ GHCR publish with keyless cosign signatures — `docker pull ghcr.io/jjviscomi/bqemulator:1.3.0` resolves and the image is cosign-verifiable.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for the complete release-by-release inventory.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ Check the health endpoint:
 
 ```bash
 curl http://localhost:9050/healthz
-# {"status":"ok","version":"1.2.0"}
+# {"status":"ok","version":"1.3.0"}
 ```
 
 ## Point a client at it

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ A local emulator for Google BigQuery. Run it on your laptop or in CI and
 point the official Google Cloud client libraries at it.
 
 !!! note "Status"
-    **v1.2.0** — production-stable. SemVer applies: breaking changes
+    **v1.3.0** — production-stable. SemVer applies: breaking changes
     ship only in MAJOR, preceded by ≥1 MINOR with deprecation
     warnings; deprecated APIs remain for ≥2 MINOR or 6 months. See
     the [compatibility matrix](reference/compatibility-matrix.md) for

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -57,7 +57,7 @@ catalog. No row data is copied.
 ## `bqemulator version`
 
 ```
-bqemulator 1.2.0
+bqemulator 1.3.0
 ```
 
 ## Using Google's `bq` CLI against the emulator

--- a/src/bqemulator/__init__.py
+++ b/src/bqemulator/__init__.py
@@ -15,4 +15,4 @@ __all__ = ["__version__"]
 
 # Single source of truth for the version; hatchling reads this via
 # `[tool.hatch.version] path = "src/bqemulator/__init__.py"`.
-__version__ = "1.2.0"
+__version__ = "1.3.0"


### PR DESCRIPTION
Release **v1.3.0**.

### Changed
- Adopt `starlette 1.x` to clear security advisories without pulling in `httpx 2.x`.
- Bump GitHub Actions: `actions/checkout` 6.0.3 → 7.0.0, `softprops/action-gh-release` 3.0.0 → 3.0.1, `actions/setup-java` 5.2.0 → 5.3.0, `codecov/codecov-action` 6.0.1 → 7.0.0.

### Added
- Autodetect schema inference for CSV/JSON load jobs with full nested RECORD/REPEATED parity (#149, [ADR 0045](docs/adr/0045-autodetect-schema-inference.md)).

Bumps `__version__` 1.2.0 → 1.3.0, stamps the CHANGELOG, and refreshes version strings in the README + docs. After squash-merge, the `v1.3.0` tag is reconciled onto the merged commit and pushed to trigger the PyPI + GHCR publish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: v1.3.0

* **New Features**
  * DuckDB-based schema inference for autodetect CSV/JSON load jobs with BigQuery-nested-type parity.

* **Changed**
  * Updated to Starlette 1.x.
  * Updated GitHub Actions versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->