### PR TITLE
refactor(sql): unify scripted and standalone inner-query pipeline

### DIFF
--- a/docs/adr/0046-unified-inner-query-pipeline.md
+++ b/docs/adr/0046-unified-inner-query-pipeline.md
@@ -78,11 +78,11 @@ documented intent.
 
 ## Consequences
 
-- **Positive:** The two execution paths cannot drift again, because there
-  is one rewrite chain. Materialized-view reads, `FOR SYSTEM_TIME AS OF`
-  time-travel, and type-directed translation rules now behave identically
-  whether a SELECT runs standalone or inside a script (including the
-  `EXPORT DATA` inner SELECT). A regression suite
+- **Positive:** The shared rewrite + translation chain cannot drift
+  again, because there is one implementation. Materialized-view reads,
+  `FOR SYSTEM_TIME AS OF` time-travel, and type-directed translation
+  rules now behave identically whether a SELECT runs standalone or inside
+  a script (including the `EXPORT DATA` inner SELECT). A regression suite
   (`tests/integration/test_scripted_inner_query_parity.py`) pins the
   parity directly.
 - **Negative / limitations:**
@@ -92,6 +92,14 @@ documented intent.
     resolution and is not evaluated as a timestamp. Literal and
     expression `AS OF` targets (the common case) resolve correctly; a
     variable `AS OF` target was non-functional before this change as well.
+  - The shared chain covers the rewrite and translation steps, not the
+    error-shaping that follows. The standalone path runs table-reference
+    qualification inside its error mapper, so a malformed-id
+    `ValidationError` is reshaped to BigQuery's `Function not found`
+    envelope; the scripted path raises that qualification error before
+    its execution `try`, so it surfaces unmapped. This pre-existing
+    difference is preserved, not introduced here, and is narrow (it only
+    affects the wire shape of a malformed-identifier error in a script).
   - The shared chain parses the statement for materialized-view and
     time-travel detection; both short-circuit when their markers are
     absent, so the cost is bounded for queries that use neither.

--- a/docs/adr/0046-unified-inner-query-pipeline.md
+++ b/docs/adr/0046-unified-inner-query-pipeline.md
@@ -1,0 +1,90 @@
+# ADR 0046: Unified Inner-Query Rewrite Pipeline
+
+## Status
+
+Accepted
+
+## Context
+
+A BigQuery `SELECT` reaches DuckDB through one of two execution chains,
+chosen by whether the job is a single statement or a multi-statement /
+control-flow script:
+
+- **Standalone** (`jobs/executor.py`): `execute_query_job` to
+  `_run_query_body` to `_run_single_sql`, which applies the canonical
+  rewrite chain before translation.
+- **Scripted** (`scripting/interpreter.py`): `_exec_sql` dispatches to
+  `_run_query` / `_run_statement_with_params` / `_run_query_with_params`,
+  each of which re-implemented the rewrite chain inline.
+
+The two chains drifted. The scripted chain re-implemented row-access
+enforcement, `INFORMATION_SCHEMA` expansion, `UNNEST` offset rewriting,
+and wildcard-table expansion, but omitted three steps the standalone
+chain applied:
+
+1. **Materialized-view refresh** (`refresh_dependent_mvs`): a script that
+   read a stale materialized view returned stale rows.
+2. **Time-travel resolution** (`rewrite_for_system_time`): `FOR
+   SYSTEM_TIME AS OF` inside a script was passed through untranslated, so
+   the clause reached DuckDB (which has no such syntax) and the query
+   silently returned the wrong rows instead of the historical snapshot.
+3. **Schema-annotated translation** (`build_catalog_schema` plus the
+   translator's `schema=` argument): scripted SELECTs translated without
+   the per-table type snapshot, so type-directed rules such as
+   `AvgDecimalRule` did not fire.
+
+This affected the scripted path generally, and the `EXPORT DATA` inner
+SELECT specifically, which the interpreter runs through `_run_query`.
+
+## Decision
+
+Extract the canonical chain into a single shared module,
+`sql/inner_query.py`, with two functions:
+
+- `refresh_dependent_mvs(project_id, bq_sql, ctx)`: walks the BigQuery
+  AST and refreshes any stale materialized view the query reads.
+- `rewrite_and_translate_select(bq_sql, *, project_id, ctx, caller,
+  translator)`: runs the full chain in order (materialized-view refresh,
+  time-travel resolution, row-access enforcement, `INFORMATION_SCHEMA`
+  expansion, `UNNEST` offset rewriting, wildcard-table expansion,
+  schema-annotated BigQuery to DuckDB translation, table-reference
+  qualification) and returns executable DuckDB SQL.
+
+Both `_run_single_sql` and the three interpreter methods call this shared
+function. Concerns that genuinely differ between the two paths stay at
+the call site, layered on top of the shared chain:
+
+- **Scripting-specific pre-rewrites** run in the interpreter before the
+  shared chain: temp-routine call qualification (`_rewrite_temp_calls`)
+  and `@var` to positional-placeholder substitution
+  (`_rewrite_vars_to_params`).
+- **Parameter binding and execution** remain caller-owned: standalone
+  binds BigQuery named query parameters and fetches Arrow; the
+  interpreter prepends the positional parameters its `@var` and `USING`
+  handling emits, and chooses `fetch_arrow` (row-producing) or `execute`
+  (dynamic DDL/DML, with last-statement-wins shaping).
+
+No RFC accompanies this change: there is no change to public API, SQL
+semantics, persistence format, or governance. The observable effect is
+that scripted SELECTs now match standalone SELECTs, which is the
+documented intent.
+
+## Consequences
+
+- **Positive:** The two execution paths cannot drift again, because there
+  is one rewrite chain. Materialized-view reads, `FOR SYSTEM_TIME AS OF`
+  time-travel, and type-directed translation rules now behave identically
+  whether a SELECT runs standalone or inside a script (including the
+  `EXPORT DATA` inner SELECT). A regression suite
+  (`tests/integration/test_scripted_inner_query_parity.py`) pins the
+  parity directly.
+- **Negative / limitations:**
+  - Scripting-specific pre-rewrites run before the shared chain, so a
+    declared script variable used inside a `FOR SYSTEM_TIME AS OF`
+    expression is substituted to a placeholder before time-travel
+    resolution and is not evaluated as a timestamp. Literal and
+    expression `AS OF` targets (the common case) resolve correctly; a
+    variable `AS OF` target was non-functional before this change as well.
+  - The shared chain parses the statement for materialized-view and
+    time-travel detection; both short-circuit when their markers are
+    absent, so the cost is bounded for queries that use neither.

--- a/docs/adr/0046-unified-inner-query-pipeline.md
+++ b/docs/adr/0046-unified-inner-query-pipeline.md
@@ -46,9 +46,9 @@ Extract the canonical chain into a single shared module,
 - `rewrite_and_translate_statement(bq_sql, *, project_id, ctx, caller,
   translator)`: runs the full chain in order (materialized-view refresh,
   time-travel resolution, row-access enforcement, `INFORMATION_SCHEMA`
-  expansion, `UNNEST` offset rewriting, wildcard-table expansion,
-  schema-annotated BigQuery to DuckDB translation, table-reference
-  qualification) and returns executable DuckDB SQL.
+  expansion, `UNNEST` offset rewriting, wildcard-table expansion, and
+  schema-annotated BigQuery to DuckDB translation) and returns the
+  translated DuckDB SQL.
 
 Both `_run_single_sql` and the three interpreter methods call this shared
 function. Concerns that genuinely differ between the two paths stay at
@@ -58,11 +58,18 @@ the call site, layered on top of the shared chain:
   shared chain: temp-routine call qualification (`_rewrite_temp_calls`)
   and `@var` to positional-placeholder substitution
   (`_rewrite_vars_to_params`).
-- **Parameter binding and execution** remain caller-owned: standalone
-  binds BigQuery named query parameters and fetches Arrow; the
-  interpreter prepends the positional parameters its `@var` and `USING`
-  handling emits, and chooses `fetch_arrow` (row-producing) or `execute`
-  (dynamic DDL/DML, with last-statement-wins shaping).
+- **Table-reference qualification, parameter binding, and execution**
+  remain caller-owned. Standalone qualifies refs (`rewrite_table_refs`),
+  binds BigQuery named query parameters, and fetches Arrow; the
+  interpreter qualifies refs, prepends the positional parameters its
+  `@var` and `USING` handling emits, and chooses `fetch_arrow`
+  (row-producing) or `execute` (dynamic DDL/DML, with last-statement-wins
+  shaping). Keeping qualification at the call site is deliberate: a
+  malformed-id `ValidationError` from `rewrite_table_refs` is a
+  pre-execution domain error that the caller's `try` reshapes via
+  `translate_runtime_error`, whereas a translation failure raised by the
+  shared helper (e.g. an unsupported feature) must surface unwrapped as a
+  `501`, so it is raised before the caller's `try`.
 
 No RFC accompanies this change: there is no change to public API, SQL
 semantics, persistence format, or governance. The observable effect is

--- a/docs/adr/0046-unified-inner-query-pipeline.md
+++ b/docs/adr/0046-unified-inner-query-pipeline.md
@@ -43,7 +43,7 @@ Extract the canonical chain into a single shared module,
 
 - `refresh_dependent_mvs(project_id, bq_sql, ctx)`: walks the BigQuery
   AST and refreshes any stale materialized view the query reads.
-- `rewrite_and_translate_select(bq_sql, *, project_id, ctx, caller,
+- `rewrite_and_translate_statement(bq_sql, *, project_id, ctx, caller,
   translator)`: runs the full chain in order (materialized-view refresh,
   time-travel resolution, row-access enforcement, `INFORMATION_SCHEMA`
   expansion, `UNNEST` offset rewriting, wildcard-table expansion,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -231,6 +231,7 @@ nav:
       - "0043 EXPORT DATA statement (Cloud Storage)": adr/0043-export-data-statement.md
       - "0044 Adopt starlette 1.x (security) without adopting httpx2": adr/0044-starlette-1x-adoption.md
       - "0045 Autodetect schema inference via DuckDB": adr/0045-autodetect-schema-inference.md
+      - "0046 Unified inner-query rewrite pipeline": adr/0046-unified-inner-query-pipeline.md
   - RFCs:
       - Overview: rfcs/README.md
       - "0001 EXPORT DATA statement (Cloud Storage)": rfcs/0001-export-data-statement.md

--- a/src/bqemulator/jobs/executor.py
+++ b/src/bqemulator/jobs/executor.py
@@ -55,7 +55,7 @@ from bqemulator.row_access.identity import CallerIdentity
 from bqemulator.scripting.ast import SqlStmt
 from bqemulator.scripting.interpreter import ScriptInterpreter
 from bqemulator.scripting.parser import parse_script
-from bqemulator.sql.inner_query import rewrite_and_translate_select
+from bqemulator.sql.inner_query import rewrite_and_translate_statement
 from bqemulator.sql.parameters import bind_parameters
 from bqemulator.sql.translator import SQLTranslator
 from bqemulator.storage.sql_identifiers import quoted_table_ref
@@ -833,7 +833,7 @@ async def _run_single_sql(
     caller: CallerIdentity,
 ) -> pa.Table:
     """Legacy fast path for a single SQL statement with BQ query params."""
-    duckdb_sql = await rewrite_and_translate_select(
+    duckdb_sql = await rewrite_and_translate_statement(
         bq_sql,
         project_id=project_id,
         ctx=ctx,

--- a/src/bqemulator/jobs/executor.py
+++ b/src/bqemulator/jobs/executor.py
@@ -33,7 +33,6 @@ from bqemulator.domain.errors import (
     resource_not_found,
 )
 from bqemulator.domain.events import TableDataChanged
-from bqemulator.domain.result import Err, Ok
 from bqemulator.jobs.avro_reader import (
     is_decimal_logical_avro,
     read_avro_to_arrow,
@@ -56,10 +55,8 @@ from bqemulator.row_access.identity import CallerIdentity
 from bqemulator.scripting.ast import SqlStmt
 from bqemulator.scripting.interpreter import ScriptInterpreter
 from bqemulator.scripting.parser import parse_script
-from bqemulator.sql.catalog_schema import build_catalog_schema
+from bqemulator.sql.inner_query import rewrite_and_translate_select
 from bqemulator.sql.parameters import bind_parameters
-from bqemulator.sql.rewriter.row_access_filter import rewrite_for_row_access
-from bqemulator.sql.table_rewriter import rewrite_table_refs
 from bqemulator.sql.translator import SQLTranslator
 from bqemulator.storage.sql_identifiers import quoted_table_ref
 from bqemulator.versioning.ddl import (
@@ -67,8 +64,6 @@ from bqemulator.versioning.ddl import (
     execute_versioning_ddl,
     is_versioning_ddl,
 )
-from bqemulator.versioning.materialized_views import MaterializedViewManager
-from bqemulator.versioning.time_travel import rewrite_for_system_time
 
 if TYPE_CHECKING:
     from bqemulator.api.dependencies import AppContext
@@ -838,43 +833,14 @@ async def _run_single_sql(
     caller: CallerIdentity,
 ) -> pa.Table:
     """Legacy fast path for a single SQL statement with BQ query params."""
-    from bqemulator.sql.rewriter.information_schema import (
-        expand_information_schema,
-    )
-    from bqemulator.sql.rewriter.unnest_offset import rewrite_unnest_offset
-    from bqemulator.sql.rewriter.wildcard_expander import expand_wildcard_tables
-
-    # Refresh any stale materialized views this query reads.
-    await _refresh_dependent_mvs(project_id, bq_sql, ctx)
-    # Resolve FOR SYSTEM_TIME AS OF before the translator runs.
-    bq_sql = rewrite_for_system_time(bq_sql, project_id, ctx.snapshots, ctx.engine)
-    # Enforce row access policies before any other rewrite.
-    bq_sql = rewrite_for_row_access(
+    duckdb_sql = await rewrite_and_translate_select(
         bq_sql,
         project_id=project_id,
+        ctx=ctx,
         caller=caller,
-        catalog=ctx.catalog,
+        translator=_translator,
     )
-    bq_sql = expand_information_schema(bq_sql, project_id, ctx.catalog)
-    bq_sql = rewrite_unnest_offset(bq_sql)
-    bq_sql = expand_wildcard_tables(bq_sql, project_id, ctx.catalog)
-    # ADR 0023 §1.B: build a per-table schema snapshot so the translator's
-    # ``annotate_types`` pass can resolve column types — the
-    # ``AvgDecimalRule`` consults the annotated operand type to decide
-    # whether to wrap ``AVG`` in a DECIMAL cast.
-    schema_dict = build_catalog_schema(bq_sql, project_id=project_id, catalog=ctx.catalog)
-    translate_result = _translator.translate(
-        bq_sql,
-        schema=schema_dict or None,
-        caller=caller,
-    )
-    match translate_result:
-        case Err(error):
-            raise error
-        case Ok(duckdb_sql):
-            pass
     try:
-        duckdb_sql = rewrite_table_refs(duckdb_sql, project_id)
         duckdb_sql, param_values = bind_parameters(duckdb_sql, query_params)
         return ctx.engine.fetch_arrow(duckdb_sql, param_values or None)
     except DomainError as exc:
@@ -2784,40 +2750,6 @@ def _parse_fallback_tables(body: str) -> list[Any]:
     except Exception:  # noqa: BLE001
         return []
     return list(parsed.find_all(_exp.Table))
-
-
-async def _refresh_dependent_mvs(
-    project_id: str,
-    bq_sql: str,
-    ctx: AppContext,
-) -> None:
-    """Refresh any materialized view this query reads, if stale.
-
-    Walks the BigQuery AST, collects every table reference, and asks
-    the MV manager to refresh_if_stale. No-op when the query touches no
-    MV.
-    """
-    import sqlglot
-    from sqlglot import exp
-
-    try:
-        tree = sqlglot.parse_one(bq_sql, read="bigquery")
-    except Exception:  # noqa: BLE001
-        return
-
-    manager = MaterializedViewManager(ctx)
-    for table_node in tree.find_all(exp.Table):
-        if isinstance(table_node.this, exp.Anonymous):
-            continue
-        name = table_node.name
-        dataset = table_node.db
-        if not name or not dataset:
-            continue
-        proj = table_node.catalog or project_id
-        meta = ctx.catalog.get_table(proj, dataset, name)
-        if meta is None or meta.table_type != "MATERIALIZED_VIEW":
-            continue
-        await manager.refresh_if_stale(proj, dataset, name)
 
 
 __all__ = [

--- a/src/bqemulator/jobs/executor.py
+++ b/src/bqemulator/jobs/executor.py
@@ -57,6 +57,7 @@ from bqemulator.scripting.interpreter import ScriptInterpreter
 from bqemulator.scripting.parser import parse_script
 from bqemulator.sql.inner_query import rewrite_and_translate_statement
 from bqemulator.sql.parameters import bind_parameters
+from bqemulator.sql.table_rewriter import rewrite_table_refs
 from bqemulator.sql.translator import SQLTranslator
 from bqemulator.storage.sql_identifiers import quoted_table_ref
 from bqemulator.versioning.ddl import (
@@ -833,14 +834,23 @@ async def _run_single_sql(
     caller: CallerIdentity,
 ) -> pa.Table:
     """Legacy fast path for a single SQL statement with BQ query params."""
-    duckdb_sql = await rewrite_and_translate_statement(
+    # Run the rewrite + translate chain BEFORE the try so a translation
+    # failure (e.g. an unsupported feature -> UnsupportedFeatureError)
+    # surfaces unwrapped as its own ``501`` rather than being reshaped by
+    # translate_runtime_error into a generic ``invalidQuery``.
+    translated_sql = await rewrite_and_translate_statement(
         bq_sql,
         project_id=project_id,
         ctx=ctx,
         caller=caller,
         translator=_translator,
     )
+    duckdb_sql = translated_sql
     try:
+        # Table-ref qualification stays inside the try: a malformed-id
+        # ValidationError from rewrite_table_refs is a pre-execution
+        # domain error that must be shaped by translate_runtime_error.
+        duckdb_sql = rewrite_table_refs(translated_sql, project_id)
         duckdb_sql, param_values = bind_parameters(duckdb_sql, query_params)
         return ctx.engine.fetch_arrow(duckdb_sql, param_values or None)
     except DomainError as exc:

--- a/src/bqemulator/scripting/interpreter.py
+++ b/src/bqemulator/scripting/interpreter.py
@@ -41,7 +41,6 @@ from bqemulator.domain.errors import (
     ResourceRef,
     resource_not_found,
 )
-from bqemulator.domain.result import Err, Ok
 from bqemulator.observability.logging_ import get_logger
 from bqemulator.row_access.identity import CallerIdentity
 from bqemulator.scripting.ast import (
@@ -71,14 +70,8 @@ from bqemulator.scripting.exceptions import (
 )
 from bqemulator.scripting.frames import FrameStack
 from bqemulator.scripting.parser import parse_script
+from bqemulator.sql.inner_query import rewrite_and_translate_select
 from bqemulator.sql.parameters import bind_parameters
-from bqemulator.sql.rewriter.information_schema import (
-    expand_information_schema,
-)
-from bqemulator.sql.rewriter.row_access_filter import rewrite_for_row_access
-from bqemulator.sql.rewriter.unnest_offset import rewrite_unnest_offset
-from bqemulator.sql.rewriter.wildcard_expander import expand_wildcard_tables
-from bqemulator.sql.table_rewriter import rewrite_table_refs
 from bqemulator.sql.translator import SQLTranslator
 from bqemulator.udf.temp_registry import TempRoutineRegistry
 from bqemulator.versioning.ddl import (
@@ -857,25 +850,13 @@ class ScriptInterpreter:
         """Translate + execute a BigQuery SELECT, returning an Arrow table."""
         bq_sql = self._rewrite_temp_calls(bq_sql)
         rewritten, param_values = _rewrite_vars_to_params(bq_sql, self._frames)
-        rewritten = rewrite_for_row_access(
+        duckdb_sql = await rewrite_and_translate_select(
             rewritten,
             project_id=self._project_id,
+            ctx=self._ctx,
             caller=self._caller,
-            catalog=self._ctx.catalog,
+            translator=self._translator,
         )
-        rewritten = expand_information_schema(
-            rewritten,
-            self._project_id,
-            self._ctx.catalog,
-        )
-        rewritten = rewrite_unnest_offset(rewritten)
-        expanded = expand_wildcard_tables(rewritten, self._project_id, self._ctx.catalog)
-        match self._translator.translate(expanded, caller=self._caller):
-            case Ok(duckdb_sql):
-                pass
-            case Err(error):
-                raise error
-        duckdb_sql = rewrite_table_refs(duckdb_sql, self._project_id)
         duckdb_sql, final_params = bind_parameters(duckdb_sql, None)
         # Merge the script variable positional params with any placeholders
         # bind_parameters emitted (none in practice for script SQL).
@@ -903,25 +884,13 @@ class ScriptInterpreter:
         # Translate first, then merge any @var substitutions AND the using_values.
         bq_sql = self._rewrite_temp_calls(bq_sql)
         rewritten, script_params = _rewrite_vars_to_params(bq_sql, self._frames)
-        rewritten = rewrite_for_row_access(
+        duckdb_sql = await rewrite_and_translate_select(
             rewritten,
             project_id=self._project_id,
+            ctx=self._ctx,
             caller=self._caller,
-            catalog=self._ctx.catalog,
+            translator=self._translator,
         )
-        rewritten = expand_information_schema(
-            rewritten,
-            self._project_id,
-            self._ctx.catalog,
-        )
-        rewritten = rewrite_unnest_offset(rewritten)
-        expanded = expand_wildcard_tables(rewritten, self._project_id, self._ctx.catalog)
-        match self._translator.translate(expanded, caller=self._caller):
-            case Ok(duckdb_sql):
-                pass
-            case Err(error):
-                raise error
-        duckdb_sql = rewrite_table_refs(duckdb_sql, self._project_id)
         # The using_values land on the original ?'s; our @-substitutions emit
         # additional ?'s at the front. Concatenation preserves order because
         # _rewrite_vars_to_params visits left-to-right.
@@ -948,25 +917,13 @@ class ScriptInterpreter:
         """Execute a SELECT with positional USING parameters and return the result."""
         bq_sql = self._rewrite_temp_calls(bq_sql)
         rewritten, script_params = _rewrite_vars_to_params(bq_sql, self._frames)
-        rewritten = rewrite_for_row_access(
+        duckdb_sql = await rewrite_and_translate_select(
             rewritten,
             project_id=self._project_id,
+            ctx=self._ctx,
             caller=self._caller,
-            catalog=self._ctx.catalog,
+            translator=self._translator,
         )
-        rewritten = expand_information_schema(
-            rewritten,
-            self._project_id,
-            self._ctx.catalog,
-        )
-        rewritten = rewrite_unnest_offset(rewritten)
-        expanded = expand_wildcard_tables(rewritten, self._project_id, self._ctx.catalog)
-        match self._translator.translate(expanded, caller=self._caller):
-            case Ok(duckdb_sql):
-                pass
-            case Err(error):
-                raise error
-        duckdb_sql = rewrite_table_refs(duckdb_sql, self._project_id)
         combined = script_params + using_values
         return self._ctx.engine.fetch_arrow(duckdb_sql, combined or None)
 

--- a/src/bqemulator/scripting/interpreter.py
+++ b/src/bqemulator/scripting/interpreter.py
@@ -70,7 +70,7 @@ from bqemulator.scripting.exceptions import (
 )
 from bqemulator.scripting.frames import FrameStack
 from bqemulator.scripting.parser import parse_script
-from bqemulator.sql.inner_query import rewrite_and_translate_select
+from bqemulator.sql.inner_query import rewrite_and_translate_statement
 from bqemulator.sql.parameters import bind_parameters
 from bqemulator.sql.translator import SQLTranslator
 from bqemulator.udf.temp_registry import TempRoutineRegistry
@@ -850,7 +850,7 @@ class ScriptInterpreter:
         """Translate + execute a BigQuery SELECT, returning an Arrow table."""
         bq_sql = self._rewrite_temp_calls(bq_sql)
         rewritten, param_values = _rewrite_vars_to_params(bq_sql, self._frames)
-        duckdb_sql = await rewrite_and_translate_select(
+        duckdb_sql = await rewrite_and_translate_statement(
             rewritten,
             project_id=self._project_id,
             ctx=self._ctx,
@@ -884,7 +884,7 @@ class ScriptInterpreter:
         # Translate first, then merge any @var substitutions AND the using_values.
         bq_sql = self._rewrite_temp_calls(bq_sql)
         rewritten, script_params = _rewrite_vars_to_params(bq_sql, self._frames)
-        duckdb_sql = await rewrite_and_translate_select(
+        duckdb_sql = await rewrite_and_translate_statement(
             rewritten,
             project_id=self._project_id,
             ctx=self._ctx,
@@ -917,7 +917,7 @@ class ScriptInterpreter:
         """Execute a SELECT with positional USING parameters and return the result."""
         bq_sql = self._rewrite_temp_calls(bq_sql)
         rewritten, script_params = _rewrite_vars_to_params(bq_sql, self._frames)
-        duckdb_sql = await rewrite_and_translate_select(
+        duckdb_sql = await rewrite_and_translate_statement(
             rewritten,
             project_id=self._project_id,
             ctx=self._ctx,

--- a/src/bqemulator/scripting/interpreter.py
+++ b/src/bqemulator/scripting/interpreter.py
@@ -72,6 +72,7 @@ from bqemulator.scripting.frames import FrameStack
 from bqemulator.scripting.parser import parse_script
 from bqemulator.sql.inner_query import rewrite_and_translate_statement
 from bqemulator.sql.parameters import bind_parameters
+from bqemulator.sql.table_rewriter import rewrite_table_refs
 from bqemulator.sql.translator import SQLTranslator
 from bqemulator.udf.temp_registry import TempRoutineRegistry
 from bqemulator.versioning.ddl import (
@@ -850,13 +851,14 @@ class ScriptInterpreter:
         """Translate + execute a BigQuery SELECT, returning an Arrow table."""
         bq_sql = self._rewrite_temp_calls(bq_sql)
         rewritten, param_values = _rewrite_vars_to_params(bq_sql, self._frames)
-        duckdb_sql = await rewrite_and_translate_statement(
+        translated = await rewrite_and_translate_statement(
             rewritten,
             project_id=self._project_id,
             ctx=self._ctx,
             caller=self._caller,
             translator=self._translator,
         )
+        duckdb_sql = rewrite_table_refs(translated, self._project_id)
         duckdb_sql, final_params = bind_parameters(duckdb_sql, None)
         # Merge the script variable positional params with any placeholders
         # bind_parameters emitted (none in practice for script SQL).
@@ -884,13 +886,14 @@ class ScriptInterpreter:
         # Translate first, then merge any @var substitutions AND the using_values.
         bq_sql = self._rewrite_temp_calls(bq_sql)
         rewritten, script_params = _rewrite_vars_to_params(bq_sql, self._frames)
-        duckdb_sql = await rewrite_and_translate_statement(
+        translated = await rewrite_and_translate_statement(
             rewritten,
             project_id=self._project_id,
             ctx=self._ctx,
             caller=self._caller,
             translator=self._translator,
         )
+        duckdb_sql = rewrite_table_refs(translated, self._project_id)
         # The using_values land on the original ?'s; our @-substitutions emit
         # additional ?'s at the front. Concatenation preserves order because
         # _rewrite_vars_to_params visits left-to-right.
@@ -917,13 +920,14 @@ class ScriptInterpreter:
         """Execute a SELECT with positional USING parameters and return the result."""
         bq_sql = self._rewrite_temp_calls(bq_sql)
         rewritten, script_params = _rewrite_vars_to_params(bq_sql, self._frames)
-        duckdb_sql = await rewrite_and_translate_statement(
+        translated = await rewrite_and_translate_statement(
             rewritten,
             project_id=self._project_id,
             ctx=self._ctx,
             caller=self._caller,
             translator=self._translator,
         )
+        duckdb_sql = rewrite_table_refs(translated, self._project_id)
         combined = script_params + using_values
         return self._ctx.engine.fetch_arrow(duckdb_sql, combined or None)
 

--- a/src/bqemulator/sql/inner_query.py
+++ b/src/bqemulator/sql/inner_query.py
@@ -53,6 +53,13 @@ async def refresh_dependent_mvs(project_id: str, bq_sql: str, ctx: AppContext) -
     MV manager to ``refresh_if_stale``. No-op when the query touches no
     materialized view.
     """
+    # When the catalog holds no materialized views at all, refresh is a
+    # guaranteed no-op, so skip parsing entirely. This keeps the hot path
+    # cheap for the common no-MV case — notably for scripted statements,
+    # which now route every statement through this chain.
+    if not ctx.catalog.list_all_materialized_views():
+        return
+
     import sqlglot
     from sqlglot import exp
 

--- a/src/bqemulator/sql/inner_query.py
+++ b/src/bqemulator/sql/inner_query.py
@@ -1,7 +1,7 @@
 """Canonical inner-query rewrite and translation pipeline.
 
-A BigQuery ``SELECT`` reaches DuckDB through one rewrite chain
-regardless of whether it runs as a standalone single-statement job
+A BigQuery statement reaches DuckDB through one rewrite chain regardless
+of whether it runs as a standalone single-statement job
 (:func:`bqemulator.jobs.executor._run_single_sql`) or inside a script
 (:class:`bqemulator.scripting.interpreter.ScriptInterpreter`). This
 module is that single chain so the two execution paths cannot drift:
@@ -17,7 +17,7 @@ substitution and ``USING`` values), execution (``fetch_arrow`` for
 row-producing statements, ``execute`` for dynamic DDL/DML), and
 error-shaping. Scripting-specific pre-rewrites (``_rewrite_temp_calls``,
 ``_rewrite_vars_to_params``) run in the interpreter before the SQL is
-handed to :func:`rewrite_and_translate_select`.
+handed to :func:`rewrite_and_translate_statement`.
 """
 
 from __future__ import annotations
@@ -70,7 +70,7 @@ async def refresh_dependent_mvs(project_id: str, bq_sql: str, ctx: AppContext) -
         await manager.refresh_if_stale(proj, dataset, name)
 
 
-async def rewrite_and_translate_select(
+async def rewrite_and_translate_statement(
     bq_sql: str,
     *,
     project_id: str,
@@ -78,7 +78,14 @@ async def rewrite_and_translate_select(
     caller: CallerIdentity,
     translator: SQLTranslator,
 ) -> str:
-    """Run the canonical rewrite chain and return executable DuckDB SQL.
+    """Run the canonical rewrite chain on one statement, returning DuckDB SQL.
+
+    Handles any single BigQuery statement, not only ``SELECT``: the
+    standalone job path and the scripting interpreter (including
+    ``EXECUTE IMMEDIATE`` dynamic DDL/DML) both route through here. The
+    materialized-view refresh and time-travel passes are no-ops for a
+    statement that reads no table or carries no ``FOR SYSTEM_TIME``
+    clause, so applying the full chain uniformly is safe.
 
     Applies, in order: materialized-view refresh, ``FOR SYSTEM_TIME AS
     OF`` time-travel resolution, row-access enforcement,
@@ -90,7 +97,7 @@ async def rewrite_and_translate_select(
     binding and execution (and their runtime error-shaping) are the
     caller's responsibility.
     """
-    # Refresh any stale materialized views this query reads.
+    # Refresh any stale materialized views this statement reads.
     await refresh_dependent_mvs(project_id, bq_sql, ctx)
     # Resolve FOR SYSTEM_TIME AS OF before the translator runs.
     bq_sql = rewrite_for_system_time(bq_sql, project_id, ctx.snapshots, ctx.engine)
@@ -117,4 +124,4 @@ async def rewrite_and_translate_select(
     return rewrite_table_refs(duckdb_sql, project_id)
 
 
-__all__ = ["refresh_dependent_mvs", "rewrite_and_translate_select"]
+__all__ = ["refresh_dependent_mvs", "rewrite_and_translate_statement"]

--- a/src/bqemulator/sql/inner_query.py
+++ b/src/bqemulator/sql/inner_query.py
@@ -4,11 +4,12 @@ A BigQuery statement reaches DuckDB through one rewrite chain regardless
 of whether it runs as a standalone single-statement job
 (:func:`bqemulator.jobs.executor._run_single_sql`) or inside a script
 (:class:`bqemulator.scripting.interpreter.ScriptInterpreter`). This
-module is that single chain so the two execution paths cannot drift:
-materialized-view refresh, ``FOR SYSTEM_TIME AS OF`` time-travel
-resolution, row-access enforcement, ``INFORMATION_SCHEMA`` expansion,
-``UNNEST`` offset rewriting, wildcard-table expansion, and
-schema-annotated BigQuery to DuckDB translation.
+module is the single shared chain both execution paths run, so their
+rewrite and translation behaviour stays identical: materialized-view
+refresh, ``FOR SYSTEM_TIME AS OF`` time-travel resolution, row-access
+enforcement, ``INFORMATION_SCHEMA`` expansion, ``UNNEST`` offset
+rewriting, wildcard-table expansion, and schema-annotated BigQuery to
+DuckDB translation.
 
 Callers layer their own concerns on top of the translated SQL it
 returns: table-reference qualification (``rewrite_table_refs``),
@@ -17,11 +18,11 @@ positional placeholders the scripting interpreter emits for ``@var``
 substitution and ``USING`` values), execution (``fetch_arrow`` for
 row-producing statements, ``execute`` for dynamic DDL/DML), and
 error-shaping. Qualification, binding, and execution stay at the call
-site so each caller wraps them in its own ``try`` — the standalone path
+site so each caller wraps them in its own ``try``. The standalone path
 reshapes a malformed-id ``ValidationError`` from qualification via
 ``translate_runtime_error``, whereas an unsupported-feature error from
 the translation step inside this helper must surface unwrapped (as a
-``501``), so it is deliberately raised before the caller's ``try``.
+``501``), so it is raised before the caller's ``try``.
 Scripting-specific pre-rewrites (``_rewrite_temp_calls``,
 ``_rewrite_vars_to_params``) run in the interpreter before the SQL is
 handed to :func:`rewrite_and_translate_statement`.
@@ -57,8 +58,8 @@ async def refresh_dependent_mvs(project_id: str, bq_sql: str, ctx: AppContext) -
     """
     # When the catalog holds no materialized views at all, refresh is a
     # guaranteed no-op, so skip parsing entirely. This keeps the hot path
-    # cheap for the common no-MV case — notably for scripted statements,
-    # which now route every statement through this chain.
+    # cheap for the common no-MV case, notably for scripted statements,
+    # which route every statement through this chain.
     if not ctx.catalog.list_all_materialized_views():
         return
 
@@ -83,7 +84,7 @@ def _referenced_materialized_views(
 
     try:
         tree = sqlglot.parse_one(bq_sql, read="bigquery")
-    except Exception:  # noqa: BLE001 — fall through so later layers error cleanly
+    except Exception:  # noqa: BLE001  (parse failure falls through to later layers)
         return
 
     seen: set[tuple[str, str, str]] = set()
@@ -149,7 +150,7 @@ async def rewrite_and_translate_statement(
     bq_sql = rewrite_unnest_offset(bq_sql)
     bq_sql = expand_wildcard_tables(bq_sql, project_id, ctx.catalog)
     # ADR 0023 §1.B: build a per-table schema snapshot so the translator's
-    # ``annotate_types`` pass can resolve column types — the
+    # ``annotate_types`` pass can resolve column types; the
     # ``AvgDecimalRule`` consults the annotated operand type to decide
     # whether to wrap ``AVG`` in a DECIMAL cast.
     schema_dict = build_catalog_schema(bq_sql, project_id=project_id, catalog=ctx.catalog)

--- a/src/bqemulator/sql/inner_query.py
+++ b/src/bqemulator/sql/inner_query.py
@@ -7,15 +7,22 @@ of whether it runs as a standalone single-statement job
 module is that single chain so the two execution paths cannot drift:
 materialized-view refresh, ``FOR SYSTEM_TIME AS OF`` time-travel
 resolution, row-access enforcement, ``INFORMATION_SCHEMA`` expansion,
-``UNNEST`` offset rewriting, wildcard-table expansion, schema-annotated
-BigQuery to DuckDB translation, and table-reference qualification.
+``UNNEST`` offset rewriting, wildcard-table expansion, and
+schema-annotated BigQuery to DuckDB translation.
 
-Callers layer their own concerns on top of the DuckDB SQL it returns:
+Callers layer their own concerns on top of the translated SQL it
+returns: table-reference qualification (``rewrite_table_refs``),
 parameter binding (named query parameters for standalone jobs, the
 positional placeholders the scripting interpreter emits for ``@var``
 substitution and ``USING`` values), execution (``fetch_arrow`` for
 row-producing statements, ``execute`` for dynamic DDL/DML), and
-error-shaping. Scripting-specific pre-rewrites (``_rewrite_temp_calls``,
+error-shaping. Qualification, binding, and execution stay at the call
+site so each caller wraps them in its own ``try`` — the standalone path
+reshapes a malformed-id ``ValidationError`` from qualification via
+``translate_runtime_error``, whereas an unsupported-feature error from
+the translation step inside this helper must surface unwrapped (as a
+``501``), so it is deliberately raised before the caller's ``try``.
+Scripting-specific pre-rewrites (``_rewrite_temp_calls``,
 ``_rewrite_vars_to_params``) run in the interpreter before the SQL is
 handed to :func:`rewrite_and_translate_statement`.
 """
@@ -30,7 +37,6 @@ from bqemulator.sql.rewriter.information_schema import expand_information_schema
 from bqemulator.sql.rewriter.row_access_filter import rewrite_for_row_access
 from bqemulator.sql.rewriter.unnest_offset import rewrite_unnest_offset
 from bqemulator.sql.rewriter.wildcard_expander import expand_wildcard_tables
-from bqemulator.sql.table_rewriter import rewrite_table_refs
 from bqemulator.versioning.materialized_views import MaterializedViewManager
 from bqemulator.versioning.time_travel import rewrite_for_system_time
 
@@ -90,12 +96,15 @@ async def rewrite_and_translate_statement(
     Applies, in order: materialized-view refresh, ``FOR SYSTEM_TIME AS
     OF`` time-travel resolution, row-access enforcement,
     ``INFORMATION_SCHEMA`` expansion, ``UNNEST`` offset rewriting,
-    wildcard-table expansion, schema-annotated BigQuery to DuckDB
-    translation, and table-reference qualification.
+    wildcard-table expansion, and schema-annotated BigQuery to DuckDB
+    translation. Returns the translated DuckDB SQL.
 
-    Raises the translator's error on a failed translation. Parameter
-    binding and execution (and their runtime error-shaping) are the
-    caller's responsibility.
+    Table-reference qualification (``rewrite_table_refs``), parameter
+    binding, and execution are the caller's responsibility, so the
+    caller's ``try`` can shape their failures. A failed translation is
+    raised here, before the caller's ``try``, so an unsupported-feature
+    error reaches the wire unwrapped as a ``501`` rather than being
+    reshaped into a generic ``invalidQuery``.
     """
     # Refresh any stale materialized views this statement reads.
     await refresh_dependent_mvs(project_id, bq_sql, ctx)
@@ -121,7 +130,7 @@ async def rewrite_and_translate_statement(
             raise error
         case Ok(duckdb_sql):
             pass
-    return rewrite_table_refs(duckdb_sql, project_id)
+    return duckdb_sql
 
 
 __all__ = ["refresh_dependent_mvs", "rewrite_and_translate_statement"]

--- a/src/bqemulator/sql/inner_query.py
+++ b/src/bqemulator/sql/inner_query.py
@@ -1,0 +1,120 @@
+"""Canonical inner-query rewrite and translation pipeline.
+
+A BigQuery ``SELECT`` reaches DuckDB through one rewrite chain
+regardless of whether it runs as a standalone single-statement job
+(:func:`bqemulator.jobs.executor._run_single_sql`) or inside a script
+(:class:`bqemulator.scripting.interpreter.ScriptInterpreter`). This
+module is that single chain so the two execution paths cannot drift:
+materialized-view refresh, ``FOR SYSTEM_TIME AS OF`` time-travel
+resolution, row-access enforcement, ``INFORMATION_SCHEMA`` expansion,
+``UNNEST`` offset rewriting, wildcard-table expansion, schema-annotated
+BigQuery to DuckDB translation, and table-reference qualification.
+
+Callers layer their own concerns on top of the DuckDB SQL it returns:
+parameter binding (named query parameters for standalone jobs, the
+positional placeholders the scripting interpreter emits for ``@var``
+substitution and ``USING`` values), execution (``fetch_arrow`` for
+row-producing statements, ``execute`` for dynamic DDL/DML), and
+error-shaping. Scripting-specific pre-rewrites (``_rewrite_temp_calls``,
+``_rewrite_vars_to_params``) run in the interpreter before the SQL is
+handed to :func:`rewrite_and_translate_select`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bqemulator.domain.result import Err, Ok
+from bqemulator.sql.catalog_schema import build_catalog_schema
+from bqemulator.sql.rewriter.information_schema import expand_information_schema
+from bqemulator.sql.rewriter.row_access_filter import rewrite_for_row_access
+from bqemulator.sql.rewriter.unnest_offset import rewrite_unnest_offset
+from bqemulator.sql.rewriter.wildcard_expander import expand_wildcard_tables
+from bqemulator.sql.table_rewriter import rewrite_table_refs
+from bqemulator.versioning.materialized_views import MaterializedViewManager
+from bqemulator.versioning.time_travel import rewrite_for_system_time
+
+if TYPE_CHECKING:
+    from bqemulator.api.dependencies import AppContext
+    from bqemulator.row_access.identity import CallerIdentity
+    from bqemulator.sql.translator import SQLTranslator
+
+
+async def refresh_dependent_mvs(project_id: str, bq_sql: str, ctx: AppContext) -> None:
+    """Refresh any materialized view this query reads, if stale.
+
+    Walks the BigQuery AST, collects every table reference, and asks the
+    MV manager to ``refresh_if_stale``. No-op when the query touches no
+    materialized view.
+    """
+    import sqlglot
+    from sqlglot import exp
+
+    try:
+        tree = sqlglot.parse_one(bq_sql, read="bigquery")
+    except Exception:  # noqa: BLE001 — fall through so later layers error cleanly
+        return
+
+    manager = MaterializedViewManager(ctx)
+    for table_node in tree.find_all(exp.Table):
+        if isinstance(table_node.this, exp.Anonymous):
+            continue
+        name = table_node.name
+        dataset = table_node.db
+        if not name or not dataset:
+            continue
+        proj = table_node.catalog or project_id
+        meta = ctx.catalog.get_table(proj, dataset, name)
+        if meta is None or meta.table_type != "MATERIALIZED_VIEW":
+            continue
+        await manager.refresh_if_stale(proj, dataset, name)
+
+
+async def rewrite_and_translate_select(
+    bq_sql: str,
+    *,
+    project_id: str,
+    ctx: AppContext,
+    caller: CallerIdentity,
+    translator: SQLTranslator,
+) -> str:
+    """Run the canonical rewrite chain and return executable DuckDB SQL.
+
+    Applies, in order: materialized-view refresh, ``FOR SYSTEM_TIME AS
+    OF`` time-travel resolution, row-access enforcement,
+    ``INFORMATION_SCHEMA`` expansion, ``UNNEST`` offset rewriting,
+    wildcard-table expansion, schema-annotated BigQuery to DuckDB
+    translation, and table-reference qualification.
+
+    Raises the translator's error on a failed translation. Parameter
+    binding and execution (and their runtime error-shaping) are the
+    caller's responsibility.
+    """
+    # Refresh any stale materialized views this query reads.
+    await refresh_dependent_mvs(project_id, bq_sql, ctx)
+    # Resolve FOR SYSTEM_TIME AS OF before the translator runs.
+    bq_sql = rewrite_for_system_time(bq_sql, project_id, ctx.snapshots, ctx.engine)
+    # Enforce row access policies before any other rewrite.
+    bq_sql = rewrite_for_row_access(
+        bq_sql,
+        project_id=project_id,
+        caller=caller,
+        catalog=ctx.catalog,
+    )
+    bq_sql = expand_information_schema(bq_sql, project_id, ctx.catalog)
+    bq_sql = rewrite_unnest_offset(bq_sql)
+    bq_sql = expand_wildcard_tables(bq_sql, project_id, ctx.catalog)
+    # ADR 0023 §1.B: build a per-table schema snapshot so the translator's
+    # ``annotate_types`` pass can resolve column types — the
+    # ``AvgDecimalRule`` consults the annotated operand type to decide
+    # whether to wrap ``AVG`` in a DECIMAL cast.
+    schema_dict = build_catalog_schema(bq_sql, project_id=project_id, catalog=ctx.catalog)
+    match translator.translate(bq_sql, schema=schema_dict or None, caller=caller):
+        case Err(error):
+            raise error
+        case Ok(duckdb_sql):
+            pass
+    return rewrite_table_refs(duckdb_sql, project_id)
+
+
+__all__ = ["refresh_dependent_mvs", "rewrite_and_translate_select"]

--- a/src/bqemulator/sql/inner_query.py
+++ b/src/bqemulator/sql/inner_query.py
@@ -62,6 +62,7 @@ async def refresh_dependent_mvs(project_id: str, bq_sql: str, ctx: AppContext) -
         return
 
     manager = MaterializedViewManager(ctx)
+    seen: set[tuple[str, str, str]] = set()
     for table_node in tree.find_all(exp.Table):
         if isinstance(table_node.this, exp.Anonymous):
             continue
@@ -70,6 +71,11 @@ async def refresh_dependent_mvs(project_id: str, bq_sql: str, ctx: AppContext) -
         if not name or not dataset:
             continue
         proj = table_node.catalog or project_id
+        # A query may reference the same view more than once (self-join,
+        # repeated subquery); refresh each distinct view at most once.
+        if (proj, dataset, name) in seen:
+            continue
+        seen.add((proj, dataset, name))
         meta = ctx.catalog.get_table(proj, dataset, name)
         if meta is None or meta.table_type != "MATERIALIZED_VIEW":
             continue

--- a/src/bqemulator/sql/inner_query.py
+++ b/src/bqemulator/sql/inner_query.py
@@ -41,6 +41,8 @@ from bqemulator.versioning.materialized_views import MaterializedViewManager
 from bqemulator.versioning.time_travel import rewrite_for_system_time
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from bqemulator.api.dependencies import AppContext
     from bqemulator.row_access.identity import CallerIdentity
     from bqemulator.sql.translator import SQLTranslator
@@ -49,9 +51,9 @@ if TYPE_CHECKING:
 async def refresh_dependent_mvs(project_id: str, bq_sql: str, ctx: AppContext) -> None:
     """Refresh any materialized view this query reads, if stale.
 
-    Walks the BigQuery AST, collects every table reference, and asks the
-    MV manager to ``refresh_if_stale``. No-op when the query touches no
-    materialized view.
+    Walks the BigQuery AST, collects every materialized view referenced,
+    and asks the MV manager to ``refresh_if_stale``. No-op when the query
+    touches no materialized view.
     """
     # When the catalog holds no materialized views at all, refresh is a
     # guaranteed no-op, so skip parsing entirely. This keeps the hot path
@@ -60,6 +62,22 @@ async def refresh_dependent_mvs(project_id: str, bq_sql: str, ctx: AppContext) -
     if not ctx.catalog.list_all_materialized_views():
         return
 
+    manager = MaterializedViewManager(ctx)
+    for proj, dataset, name in _referenced_materialized_views(bq_sql, project_id, ctx):
+        await manager.refresh_if_stale(proj, dataset, name)
+
+
+def _referenced_materialized_views(
+    bq_sql: str,
+    project_id: str,
+    ctx: AppContext,
+) -> Iterator[tuple[str, str, str]]:
+    """Yield each distinct materialized view referenced by ``bq_sql``.
+
+    Each ``(project, dataset, table)`` is yielded at most once, so a view
+    referenced more than once (self-join, repeated subquery) is refreshed
+    a single time. Unparseable SQL yields nothing.
+    """
     import sqlglot
     from sqlglot import exp
 
@@ -68,7 +86,6 @@ async def refresh_dependent_mvs(project_id: str, bq_sql: str, ctx: AppContext) -
     except Exception:  # noqa: BLE001 — fall through so later layers error cleanly
         return
 
-    manager = MaterializedViewManager(ctx)
     seen: set[tuple[str, str, str]] = set()
     for table_node in tree.find_all(exp.Table):
         if isinstance(table_node.this, exp.Anonymous):
@@ -77,16 +94,14 @@ async def refresh_dependent_mvs(project_id: str, bq_sql: str, ctx: AppContext) -
         dataset = table_node.db
         if not name or not dataset:
             continue
-        proj = table_node.catalog or project_id
-        # A query may reference the same view more than once (self-join,
-        # repeated subquery); refresh each distinct view at most once.
-        if (proj, dataset, name) in seen:
+        ref = (table_node.catalog or project_id, dataset, name)
+        if ref in seen:
             continue
-        seen.add((proj, dataset, name))
-        meta = ctx.catalog.get_table(proj, dataset, name)
+        seen.add(ref)
+        meta = ctx.catalog.get_table(*ref)
         if meta is None or meta.table_type != "MATERIALIZED_VIEW":
             continue
-        await manager.refresh_if_stale(proj, dataset, name)
+        yield ref
 
 
 async def rewrite_and_translate_statement(

--- a/tests/integration/test_scripted_inner_query_parity.py
+++ b/tests/integration/test_scripted_inner_query_parity.py
@@ -1,17 +1,17 @@
 """Parity between standalone and scripted inner-query execution.
 
-A BigQuery ``SELECT`` reaches DuckDB through one of two execution
+A BigQuery statement reaches DuckDB through one of two execution
 chains: the standalone single-statement path
 (``jobs.executor._run_single_sql``) and the scripted path
 (``scripting.interpreter.ScriptInterpreter._run_query``), chosen by
 whether the job is a multi-statement / control-flow script.
 
-Both chains must apply the same pre-translation rewrites so a SELECT
+Both chains apply the same pre-translation rewrites so a statement
 behaves identically regardless of which path runs it. These tests pin
-the two rewrites the scripted path historically skipped — materialized
-view refresh and ``FOR SYSTEM_TIME AS OF`` time-travel — by running the
-same query standalone and as the final statement of a script and
-asserting identical results.
+the two rewrites that must stay consistent across both paths
+(materialized view refresh and ``FOR SYSTEM_TIME AS OF`` time-travel) by
+running the same query standalone and as the final statement of a
+script and asserting identical results.
 """
 
 from __future__ import annotations
@@ -42,11 +42,14 @@ async def client() -> AsyncIterator[httpx.AsyncClient]:
     await s.start()
     try:
         async with httpx.AsyncClient(base_url=s.rest_url, timeout=20.0) as c:
-            await c.post(
+            # raise_for_status on the bootstrap calls so a setup failure
+            # surfaces here rather than as a misleading assertion later.
+            r = await c.post(
                 "/bigquery/v2/projects/p/datasets",
                 json={"datasetReference": {"projectId": "p", "datasetId": "ds"}},
             )
-            await c.post(
+            r.raise_for_status()
+            r = await c.post(
                 "/bigquery/v2/projects/p/datasets/ds/tables",
                 json={
                     "tableReference": {
@@ -62,6 +65,7 @@ async def client() -> AsyncIterator[httpx.AsyncClient]:
                     },
                 },
             )
+            r.raise_for_status()
             yield c
     finally:
         await s.stop()

--- a/tests/integration/test_scripted_inner_query_parity.py
+++ b/tests/integration/test_scripted_inner_query_parity.py
@@ -1,0 +1,136 @@
+"""Parity between standalone and scripted inner-query execution.
+
+A BigQuery ``SELECT`` reaches DuckDB through one of two execution
+chains: the standalone single-statement path
+(``jobs.executor._run_single_sql``) and the scripted path
+(``scripting.interpreter.ScriptInterpreter._run_query``), chosen by
+whether the job is a multi-statement / control-flow script.
+
+Both chains must apply the same pre-translation rewrites so a SELECT
+behaves identically regardless of which path runs it. These tests pin
+the two rewrites the scripted path historically skipped — materialized
+view refresh and ``FOR SYSTEM_TIME AS OF`` time-travel — by running the
+same query standalone and as the final statement of a script and
+asserting identical results.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from bqemulator.config import PersistenceMode, Settings
+from bqemulator.server import EmulatorServer
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncIterator[httpx.AsyncClient]:
+    settings = Settings(
+        persistence_mode=PersistenceMode.EPHEMERAL,
+        rest_port=0,
+        grpc_port=0,
+    )
+    s = EmulatorServer(settings)
+    await s.start()
+    try:
+        async with httpx.AsyncClient(base_url=s.rest_url, timeout=20.0) as c:
+            await c.post(
+                "/bigquery/v2/projects/p/datasets",
+                json={"datasetReference": {"projectId": "p", "datasetId": "ds"}},
+            )
+            await c.post(
+                "/bigquery/v2/projects/p/datasets/ds/tables",
+                json={
+                    "tableReference": {
+                        "projectId": "p",
+                        "datasetId": "ds",
+                        "tableId": "orders",
+                    },
+                    "schema": {
+                        "fields": [
+                            {"name": "id", "type": "INT64"},
+                            {"name": "amount", "type": "INT64"},
+                        ],
+                    },
+                },
+            )
+            yield c
+    finally:
+        await s.stop()
+
+
+async def _run(client: httpx.AsyncClient, sql: str) -> dict[str, Any]:
+    r = await client.post(
+        "/bigquery/v2/projects/p/queries",
+        json={"query": sql, "useLegacySql": False},
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def _rows(payload: dict[str, Any]) -> list[list[str]]:
+    return [[c["v"] for c in row["f"]] for row in payload.get("rows", [])]
+
+
+def _as_script(sql: str) -> str:
+    """Wrap ``sql`` so the job runs through the scripting interpreter.
+
+    A two-statement script forces ``is_scripted=True`` in
+    ``execute_query_job``; last-statement-wins means the wrapped query's
+    result is the job's result.
+    """
+    return f"SELECT 1;\n{sql.rstrip().rstrip(';')};"
+
+
+async def test_scripted_mv_refreshed_like_standalone(
+    client: httpx.AsyncClient,
+) -> None:
+    """A script that reads a stale MV refreshes it, exactly as standalone does."""
+    await _run(client, "INSERT INTO ds.orders VALUES (1, 10)")
+    await _run(
+        client,
+        "CREATE MATERIALIZED VIEW ds.totals AS SELECT SUM(amount) AS total FROM ds.orders",
+    )
+    # Mutate a base table so the MV is now stale.
+    await _run(client, "INSERT INTO ds.orders VALUES (2, 90)")
+
+    # The scripted read must be the first reader of the stale MV: a
+    # standalone read would refresh it as a side effect and mask the gap.
+    # Standalone auto-refresh on read is pinned by test_materialized_views.
+    select = "SELECT total FROM ds.totals"
+    scripted = await _run(client, _as_script(select))
+
+    assert _rows(scripted) == [["100"]]
+
+
+async def test_scripted_time_travel_matches_standalone(
+    client: httpx.AsyncClient,
+) -> None:
+    """``FOR SYSTEM_TIME AS OF`` reads the pre-change snapshot in a script too."""
+    await _run(client, "INSERT INTO ds.orders VALUES (1, 10)")
+
+    # Establish a boundary strictly between the two writes so the target
+    # resolves to the first snapshot.
+    await asyncio.sleep(0.05)
+    boundary = datetime.now(tz=UTC)
+    await asyncio.sleep(0.05)
+
+    await _run(client, "INSERT INTO ds.orders VALUES (2, 90)")
+
+    target = boundary.isoformat(sep=" ", timespec="microseconds")
+    select = f"SELECT id FROM ds.orders FOR SYSTEM_TIME AS OF TIMESTAMP '{target}' ORDER BY id"
+
+    standalone = await _run(client, select)
+    scripted = await _run(client, _as_script(select))
+
+    # Both must see only the pre-boundary row, not the live table.
+    assert [row[0] for row in _rows(standalone)] == ["1"]
+    assert [row[0] for row in _rows(scripted)] == ["1"]

--- a/tests/integration/test_scripted_inner_query_parity.py
+++ b/tests/integration/test_scripted_inner_query_parity.py
@@ -138,3 +138,37 @@ async def test_scripted_time_travel_matches_standalone(
     # Both must see only the pre-boundary row, not the live table.
     assert [row[0] for row in _rows(standalone)] == ["1"]
     assert [row[0] for row in _rows(scripted)] == ["1"]
+
+
+async def test_scripted_execute_immediate_dml_matches_standalone(
+    client: httpx.AsyncClient,
+) -> None:
+    """Dynamic ``EXECUTE IMMEDIATE`` DML matches the standalone statement.
+
+    The shared chain now runs schema-annotated translation on the
+    scripted path too. For an ``INSERT INTO <existing> SELECT ...`` the
+    target table exists, so the annotation pass can re-serialize the
+    statement through SQLGlot. This pins that a dynamic ``EXECUTE
+    IMMEDIATE`` DML lands the same rows as the standalone statement, so
+    the annotation does not silently rewrite the DML.
+    """
+    await _run(client, "INSERT INTO ds.orders VALUES (1, 10), (2, 20), (3, 5)")
+    await _run(client, "CREATE TABLE ds.copy_direct (id INT64, amount INT64)")
+    await _run(client, "CREATE TABLE ds.copy_script (id INT64, amount INT64)")
+
+    inner = "INSERT INTO ds.{dest} SELECT id, amount FROM ds.orders WHERE amount >= 10"
+
+    # Standalone single-statement INSERT...SELECT (the reference).
+    await _run(client, inner.format(dest="copy_direct"))
+    # Same DML run dynamically; EXECUTE IMMEDIATE is not a plain SqlStmt,
+    # so the job routes through the scripting interpreter.
+    await _run(
+        client,
+        f"EXECUTE IMMEDIATE '{inner.format(dest='copy_script')}'",
+    )
+
+    direct = await _run(client, "SELECT id, amount FROM ds.copy_direct ORDER BY id")
+    scripted = await _run(client, "SELECT id, amount FROM ds.copy_script ORDER BY id")
+
+    assert _rows(scripted) == _rows(direct)
+    assert _rows(scripted) == [["1", "10"], ["2", "20"]]

--- a/tests/integration/test_scripted_inner_query_parity.py
+++ b/tests/integration/test_scripted_inner_query_parity.py
@@ -107,12 +107,15 @@ async def test_scripted_mv_refreshed_like_standalone(
     await _run(client, "INSERT INTO ds.orders VALUES (2, 90)")
 
     # The scripted read must be the first reader of the stale MV: a
-    # standalone read would refresh it as a side effect and mask the gap.
-    # Standalone auto-refresh on read is pinned by test_materialized_views.
+    # standalone read first would refresh it as a side effect and mask a
+    # missing scripted refresh. Run standalone after, when the MV is
+    # already fresh, only to confirm the two paths agree.
     select = "SELECT total FROM ds.totals"
     scripted = await _run(client, _as_script(select))
+    standalone = await _run(client, select)
 
     assert _rows(scripted) == [["100"]]
+    assert _rows(standalone) == _rows(scripted)
 
 
 async def test_scripted_time_travel_matches_standalone(
@@ -145,12 +148,12 @@ async def test_scripted_execute_immediate_dml_matches_standalone(
 ) -> None:
     """Dynamic ``EXECUTE IMMEDIATE`` DML matches the standalone statement.
 
-    The shared chain now runs schema-annotated translation on the
-    scripted path too. For an ``INSERT INTO <existing> SELECT ...`` the
-    target table exists, so the annotation pass can re-serialize the
-    statement through SQLGlot. This pins that a dynamic ``EXECUTE
-    IMMEDIATE`` DML lands the same rows as the standalone statement, so
-    the annotation does not silently rewrite the DML.
+    The shared chain runs schema-annotated translation on the scripted
+    path. For an ``INSERT INTO <existing> SELECT ...`` the target table
+    exists, so the annotation pass can re-serialize the statement through
+    SQLGlot. This pins that a dynamic ``EXECUTE IMMEDIATE`` DML lands the
+    same rows as the standalone statement, so the annotation does not
+    silently rewrite the DML.
     """
     await _run(client, "INSERT INTO ds.orders VALUES (1, 10), (2, 20), (3, 5)")
     await _run(client, "CREATE TABLE ds.copy_direct (id INT64, amount INT64)")

--- a/tests/unit/jobs/test_inner_query_error_boundary.py
+++ b/tests/unit/jobs/test_inner_query_error_boundary.py
@@ -1,22 +1,20 @@
 """Characterization tests for ``_run_single_sql``'s pre-execution error boundary.
 
-The unify refactor (ADR 0046) moved the rewrite + translate chain into a
-shared helper. These tests pin the error-shaping contract that move must
-preserve, and that a review caught regressing:
+``_run_single_sql`` runs the rewrite + translate chain, then qualifies
+table references, binds parameters, and executes. Its error boundary is
+deliberate, and these tests pin both halves:
 
 * a pre-execution domain error from table-reference qualification
   (``rewrite_table_refs``) is reshaped by ``translate_runtime_error``
-  into BigQuery's wire form, so it must run *inside* the caller's
-  ``try``; and
-* a translation failure (an unsupported feature) must surface
-  *unwrapped*, keeping its own ``501`` reason, so it must be raised
-  *before* the ``try`` (routing it through the mapper rewraps it into a
-  generic ``invalidQuery``).
+  into BigQuery's wire form, so qualification runs *inside* the
+  execution ``try``; and
+* a translation failure (an unsupported feature) surfaces *unwrapped*,
+  keeping its own ``501`` reason, so translation is raised *before* the
+  ``try`` (routing it through the mapper would rewrap it into a generic
+  ``invalidQuery``).
 
-Coverage alone never caught this: the ``except`` block executed under
-other tests, but nothing asserted *which* errors it shapes. Both halves
-of the boundary are pinned here so moving either across the ``try`` is
-caught.
+Both behaviours share lines with the happy path, so line coverage does
+not pin them; the assertions here do.
 """
 
 from __future__ import annotations
@@ -110,9 +108,8 @@ async def test_qualification_validation_error_is_reshaped(
 ) -> None:
     """A ``ValidationError`` from ``rewrite_table_refs`` is mapped to BQ shape.
 
-    Qualification runs inside the caller's ``try``; if it ever moves
-    outside (as it briefly did in the unify refactor), the raw
-    ``ValidationError`` escapes unmapped and this fails.
+    Qualification runs inside the execution ``try``, so a raw
+    ``ValidationError`` is reshaped rather than escaping unmapped.
     """
 
     def _raise_validation(*_args: object, **_kwargs: object) -> str:
@@ -134,10 +131,10 @@ async def test_unsupported_feature_translation_error_surfaces_unwrapped(
 ) -> None:
     """An unsupported-feature translation error keeps its ``501`` type.
 
-    The translation step is raised before the caller's ``try``; if it
-    moves inside, ``translate_runtime_error`` rewraps the
-    ``UnsupportedFeatureError`` into a generic ``InvalidQueryError``
-    (``400``) and this fails.
+    Translation is raised before the execution ``try``, so an
+    ``UnsupportedFeatureError`` surfaces unwrapped rather than being
+    rewrapped by ``translate_runtime_error`` into a generic
+    ``InvalidQueryError`` (``400``).
     """
     with pytest.raises(UnsupportedFeatureError):
         await _run_single_sql(

--- a/tests/unit/jobs/test_inner_query_error_boundary.py
+++ b/tests/unit/jobs/test_inner_query_error_boundary.py
@@ -1,0 +1,149 @@
+"""Characterization tests for ``_run_single_sql``'s pre-execution error boundary.
+
+The unify refactor (ADR 0046) moved the rewrite + translate chain into a
+shared helper. These tests pin the error-shaping contract that move must
+preserve, and that a review caught regressing:
+
+* a pre-execution domain error from table-reference qualification
+  (``rewrite_table_refs``) is reshaped by ``translate_runtime_error``
+  into BigQuery's wire form, so it must run *inside* the caller's
+  ``try``; and
+* a translation failure (an unsupported feature) must surface
+  *unwrapped*, keeping its own ``501`` reason, so it must be raised
+  *before* the ``try`` (routing it through the mapper rewraps it into a
+  generic ``invalidQuery``).
+
+Coverage alone never caught this: the ``except`` block executed under
+other tests, but nothing asserted *which* errors it shapes. Both halves
+of the boundary are pinned here so moving either across the ``try`` is
+caught.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+
+from bqemulator.api.dependencies import AppContext
+from bqemulator.catalog.etag import generate_etag
+from bqemulator.catalog.memory_repository import MemoryCatalogRepository
+from bqemulator.catalog.models import DatasetMeta, TableMeta
+from bqemulator.config import Settings
+from bqemulator.domain.clock import FrozenClock
+from bqemulator.domain.errors import (
+    InvalidQueryError,
+    UnsupportedFeatureError,
+    ValidationError,
+)
+from bqemulator.domain.events import EventBus
+from bqemulator.jobs import executor
+from bqemulator.jobs.executor import _run_single_sql
+from bqemulator.observability.metrics import MetricsRegistry
+from bqemulator.row_access.identity import CallerIdentity
+from bqemulator.row_access.policy import RowAccessPolicyManager
+from bqemulator.storage.engine import DuckDBEngine
+from bqemulator.versioning.snapshots import SnapshotManager
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 5, 16, tzinfo=UTC)
+_ANON = CallerIdentity(principal="user:anon@bqemulator.local", is_authenticated=False)
+
+
+@pytest_asyncio.fixture
+async def ctx(ephemeral_settings: Settings) -> AsyncIterator[AppContext]:
+    """In-process ``AppContext`` with a translatable table ``p.ds.t``."""
+    engine = DuckDBEngine(ephemeral_settings)
+    await engine.start()
+    catalog = MemoryCatalogRepository()
+    catalog.create_dataset(
+        DatasetMeta(
+            project_id="p",
+            dataset_id="ds",
+            creation_time=_NOW,
+            last_modified_time=_NOW,
+            etag=generate_etag("p", "ds", str(_NOW)),
+        ),
+    )
+    catalog.create_table(
+        TableMeta(
+            project_id="p",
+            dataset_id="ds",
+            table_id="t",
+            table_type="TABLE",
+            creation_time=_NOW,
+            last_modified_time=_NOW,
+            etag=generate_etag("p", "ds", "t", str(_NOW)),
+        ),
+    )
+    engine.execute('CREATE SCHEMA IF NOT EXISTS "p__ds"')
+    engine.execute('CREATE TABLE "p__ds"."t" (id BIGINT)')
+    context = AppContext(
+        settings=ephemeral_settings,
+        clock=FrozenClock(_NOW),
+        engine=engine,
+        catalog=catalog,
+        metrics=MetricsRegistry(),
+        events=EventBus(),
+        udf_registry=None,
+        snapshots=SnapshotManager(
+            engine=engine,
+            catalog=catalog,
+            clock=FrozenClock(_NOW),
+            events=EventBus(),
+            retention_days=7,
+        ),
+        row_access=RowAccessPolicyManager(catalog=catalog, clock=FrozenClock(_NOW)),
+    )
+    try:
+        yield context
+    finally:
+        await engine.stop()
+
+
+async def test_qualification_validation_error_is_reshaped(
+    ctx: AppContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``ValidationError`` from ``rewrite_table_refs`` is mapped to BQ shape.
+
+    Qualification runs inside the caller's ``try``; if it ever moves
+    outside (as it briefly did in the unify refactor), the raw
+    ``ValidationError`` escapes unmapped and this fails.
+    """
+
+    def _raise_validation(*_args: object, **_kwargs: object) -> str:
+        raise ValidationError("Invalid dataset id for SQL: 'bad.dataset'")
+
+    monkeypatch.setattr(executor, "rewrite_table_refs", _raise_validation)
+
+    with pytest.raises(InvalidQueryError) as excinfo:
+        await _run_single_sql("p", "SELECT id FROM ds.t", None, ctx, caller=_ANON)
+
+    # Reshaped to the BigQuery "Function not found" envelope, not the raw
+    # ValidationError that rewrite_table_refs raised.
+    assert "Function not found" in str(excinfo.value)
+    assert not isinstance(excinfo.value, ValidationError)
+
+
+async def test_unsupported_feature_translation_error_surfaces_unwrapped(
+    ctx: AppContext,
+) -> None:
+    """An unsupported-feature translation error keeps its ``501`` type.
+
+    The translation step is raised before the caller's ``try``; if it
+    moves inside, ``translate_runtime_error`` rewraps the
+    ``UnsupportedFeatureError`` into a generic ``InvalidQueryError``
+    (``400``) and this fails.
+    """
+    with pytest.raises(UnsupportedFeatureError):
+        await _run_single_sql(
+            "p",
+            "SELECT * FROM ML.PREDICT(MODEL m, TABLE t)",
+            None,
+            ctx,
+            caller=_ANON,
+        )

--- a/tests/unit/jobs/test_inner_query_error_boundary.py
+++ b/tests/unit/jobs/test_inner_query_error_boundary.py
@@ -139,7 +139,7 @@ async def test_unsupported_feature_translation_error_surfaces_unwrapped(
     rewrapped by ``translate_runtime_error`` into a generic
     ``InvalidQueryError`` (``400``).
     """
-    with pytest.raises(UnsupportedFeatureError):
+    with pytest.raises(UnsupportedFeatureError) as excinfo:
         await _run_single_sql(
             "p",
             "SELECT * FROM ML.PREDICT(MODEL m, TABLE t)",
@@ -147,3 +147,5 @@ async def test_unsupported_feature_translation_error_surfaces_unwrapped(
             ctx,
             caller=_ANON,
         )
+    # The unsupported feature itself is the cause, not some later failure.
+    assert "ML.PREDICT" in str(excinfo.value)

--- a/tests/unit/jobs/test_inner_query_error_boundary.py
+++ b/tests/unit/jobs/test_inner_query_error_boundary.py
@@ -43,6 +43,7 @@ from bqemulator.observability.metrics import MetricsRegistry
 from bqemulator.row_access.identity import CallerIdentity
 from bqemulator.row_access.policy import RowAccessPolicyManager
 from bqemulator.storage.engine import DuckDBEngine
+from bqemulator.udf.runtime import UDFRegistry
 from bqemulator.versioning.snapshots import SnapshotManager
 
 pytestmark = pytest.mark.unit
@@ -88,7 +89,7 @@ async def ctx(ephemeral_settings: Settings) -> AsyncIterator[AppContext]:
         catalog=catalog,
         metrics=MetricsRegistry(),
         events=events,
-        udf_registry=None,
+        udf_registry=UDFRegistry(ephemeral_settings),
         snapshots=SnapshotManager(
             engine=engine,
             catalog=catalog,

--- a/tests/unit/jobs/test_inner_query_error_boundary.py
+++ b/tests/unit/jobs/test_inner_query_error_boundary.py
@@ -57,6 +57,8 @@ async def ctx(ephemeral_settings: Settings) -> AsyncIterator[AppContext]:
     engine = DuckDBEngine(ephemeral_settings)
     await engine.start()
     catalog = MemoryCatalogRepository()
+    clock = FrozenClock(_NOW)
+    events = EventBus()
     catalog.create_dataset(
         DatasetMeta(
             project_id="p",
@@ -81,20 +83,20 @@ async def ctx(ephemeral_settings: Settings) -> AsyncIterator[AppContext]:
     engine.execute('CREATE TABLE "p__ds"."t" (id BIGINT)')
     context = AppContext(
         settings=ephemeral_settings,
-        clock=FrozenClock(_NOW),
+        clock=clock,
         engine=engine,
         catalog=catalog,
         metrics=MetricsRegistry(),
-        events=EventBus(),
+        events=events,
         udf_registry=None,
         snapshots=SnapshotManager(
             engine=engine,
             catalog=catalog,
-            clock=FrozenClock(_NOW),
-            events=EventBus(),
+            clock=clock,
+            events=events,
             retention_days=7,
         ),
-        row_access=RowAccessPolicyManager(catalog=catalog, clock=FrozenClock(_NOW)),
+        row_access=RowAccessPolicyManager(catalog=catalog, clock=clock),
     )
     try:
         yield context

--- a/tests/unit/sql/test_inner_query.py
+++ b/tests/unit/sql/test_inner_query.py
@@ -32,6 +32,7 @@ from bqemulator.sql.inner_query import (
     refresh_dependent_mvs,
     rewrite_and_translate_statement,
 )
+from bqemulator.sql.table_rewriter import rewrite_table_refs
 from bqemulator.sql.translator import SQLTranslator
 from bqemulator.storage.engine import DuckDBEngine
 from bqemulator.storage.sql_identifiers import quoted_schema, quoted_table_ref
@@ -131,16 +132,17 @@ async def test_rewrite_and_translate_statement_returns_duckdb_sql(
     ctx: AppContext,
     frozen_clock: FrozenClock,
 ) -> None:
-    """The happy path returns table-ref-qualified, executable DuckDB SQL."""
+    """The happy path returns translated DuckDB SQL the caller can qualify and run."""
     _seed_table(ctx, frozen_clock)
-    duckdb_sql = await rewrite_and_translate_statement(
+    translated = await rewrite_and_translate_statement(
         "SELECT id FROM ds.t",
         project_id="p",
         ctx=ctx,
         caller=_ANON,
         translator=SQLTranslator(),
     )
-    # Table refs are qualified to the DuckDB schema and the SQL runs.
+    # The helper translates; the caller qualifies table refs, after which it runs.
+    duckdb_sql = rewrite_table_refs(translated, "p")
     assert quoted_table_ref("p", "ds", "t") in duckdb_sql
     assert ctx.engine.fetch_arrow(duckdb_sql).to_pylist() == [{"id": 1}]
 
@@ -172,7 +174,7 @@ async def test_rewrite_and_translate_statement_ok_branch_with_stub(
     ctx: AppContext,
     frozen_clock: FrozenClock,
 ) -> None:
-    """The Ok branch returns the table-ref rewrite of the translated SQL."""
+    """The Ok branch returns the translator's output unchanged (no qualification)."""
     _seed_table(ctx, frozen_clock)
 
     class _OkTranslator:
@@ -186,4 +188,6 @@ async def test_rewrite_and_translate_statement_ok_branch_with_stub(
         caller=_ANON,
         translator=_OkTranslator(),  # type: ignore[arg-type]
     )
-    assert quoted_table_ref("p", "ds", "t") in result
+    # Table-ref qualification is the caller's step, so the helper returns
+    # the translated SQL verbatim.
+    assert result == "SELECT id FROM p.ds.t"

--- a/tests/unit/sql/test_inner_query.py
+++ b/tests/unit/sql/test_inner_query.py
@@ -1,0 +1,189 @@
+"""Unit tests for the shared inner-query rewrite + translation pipeline.
+
+The pipeline (:mod:`bqemulator.sql.inner_query`) is the single rewrite
+chain shared by standalone single-statement jobs and the scripting
+interpreter. End-to-end behaviour (MV refresh, time-travel, row-access)
+is pinned by the integration suites; these tests cover the module's own
+branches: the parse-failure short-circuit in
+:func:`refresh_dependent_mvs` and the translation-error path in
+:func:`rewrite_and_translate_select`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from bqemulator.api.dependencies import AppContext
+from bqemulator.catalog.etag import generate_etag
+from bqemulator.catalog.memory_repository import MemoryCatalogRepository
+from bqemulator.catalog.models import DatasetMeta, TableMeta
+from bqemulator.config import Settings
+from bqemulator.domain.clock import FrozenClock
+from bqemulator.domain.errors import InvalidQueryError
+from bqemulator.domain.events import EventBus
+from bqemulator.domain.result import Err, Ok
+from bqemulator.observability.metrics import MetricsRegistry
+from bqemulator.row_access.identity import CallerIdentity
+from bqemulator.row_access.policy import RowAccessPolicyManager
+from bqemulator.sql.inner_query import (
+    refresh_dependent_mvs,
+    rewrite_and_translate_select,
+)
+from bqemulator.sql.translator import SQLTranslator
+from bqemulator.storage.engine import DuckDBEngine
+from bqemulator.storage.sql_identifiers import quoted_schema, quoted_table_ref
+from bqemulator.udf.runtime import UDFRegistry
+from bqemulator.versioning.snapshots import SnapshotManager
+
+pytestmark = pytest.mark.unit
+
+_ANON = CallerIdentity(principal="user:anon@bqemulator.local", is_authenticated=False)
+
+
+@pytest_asyncio.fixture
+async def ctx(
+    ephemeral_settings: Settings,
+    frozen_clock: FrozenClock,
+) -> AsyncIterator[AppContext]:
+    """A minimal :class:`AppContext` backed by a real DuckDB engine."""
+    engine = DuckDBEngine(ephemeral_settings)
+    await engine.start()
+    catalog = MemoryCatalogRepository()
+    events = EventBus()
+    snapshots = SnapshotManager(
+        engine=engine,
+        catalog=catalog,
+        clock=frozen_clock,
+        events=events,
+        retention_days=ephemeral_settings.time_travel_retention_days,
+    )
+    context = AppContext(
+        settings=ephemeral_settings,
+        clock=frozen_clock,
+        engine=engine,
+        catalog=catalog,
+        metrics=MetricsRegistry(),
+        events=events,
+        udf_registry=UDFRegistry(ephemeral_settings),
+        snapshots=snapshots,
+        row_access=RowAccessPolicyManager(catalog=catalog, clock=frozen_clock),
+    )
+    try:
+        yield context
+    finally:
+        await engine.stop()
+
+
+def _seed_table(ctx: AppContext, frozen_clock: FrozenClock) -> None:
+    """Create a plain ``p.ds.t`` table with one row."""
+    now = frozen_clock.now()
+    ctx.catalog.create_dataset(
+        DatasetMeta(
+            project_id="p",
+            dataset_id="ds",
+            creation_time=now,
+            last_modified_time=now,
+            etag=generate_etag("p", "ds", str(now)),
+        ),
+    )
+    ctx.catalog.create_table(
+        TableMeta(
+            project_id="p",
+            dataset_id="ds",
+            table_id="t",
+            table_type="TABLE",
+            creation_time=now,
+            last_modified_time=now,
+            etag=generate_etag("p", "ds", "t", str(now)),
+        ),
+    )
+    ctx.engine.execute(f"CREATE SCHEMA IF NOT EXISTS {quoted_schema('p', 'ds')}")
+    ctx.engine.execute(f"CREATE TABLE {quoted_table_ref('p', 'ds', 't')} (id BIGINT)")
+    ctx.engine.execute(f"INSERT INTO {quoted_table_ref('p', 'ds', 't')} VALUES (1)")
+
+
+async def test_refresh_dependent_mvs_ignores_unparseable_sql(ctx: AppContext) -> None:
+    """Unparseable SQL is a no-op — later pipeline layers surface the error."""
+    # Must not raise: the parse failure short-circuits the MV walk.
+    await refresh_dependent_mvs("p", "this is not valid sql @@@", ctx)
+
+
+async def test_refresh_dependent_mvs_skips_plain_table(
+    ctx: AppContext,
+    frozen_clock: FrozenClock,
+) -> None:
+    """A query over a non-materialized-view table triggers no refresh."""
+    _seed_table(ctx, frozen_clock)
+    # No MaterializedViewError / no mutation: a plain table is left alone.
+    await refresh_dependent_mvs("p", "SELECT id FROM ds.t", ctx)
+
+
+async def test_refresh_dependent_mvs_skips_unqualified_refs(ctx: AppContext) -> None:
+    """A bare table reference (e.g. a CTE) has no dataset and is skipped."""
+    # ``cte`` has a name but no dataset, so the MV lookup is bypassed.
+    await refresh_dependent_mvs("p", "WITH cte AS (SELECT 1 AS id) SELECT id FROM cte", ctx)
+
+
+async def test_rewrite_and_translate_select_returns_duckdb_sql(
+    ctx: AppContext,
+    frozen_clock: FrozenClock,
+) -> None:
+    """The happy path returns table-ref-qualified, executable DuckDB SQL."""
+    _seed_table(ctx, frozen_clock)
+    duckdb_sql = await rewrite_and_translate_select(
+        "SELECT id FROM ds.t",
+        project_id="p",
+        ctx=ctx,
+        caller=_ANON,
+        translator=SQLTranslator(),
+    )
+    # Table refs are qualified to the DuckDB schema and the SQL runs.
+    assert quoted_table_ref("p", "ds", "t") in duckdb_sql
+    assert ctx.engine.fetch_arrow(duckdb_sql).to_pylist() == [{"id": 1}]
+
+
+async def test_rewrite_and_translate_select_raises_translator_error(
+    ctx: AppContext,
+    frozen_clock: FrozenClock,
+) -> None:
+    """A failed translation propagates the translator's error verbatim."""
+    _seed_table(ctx, frozen_clock)
+    sentinel = InvalidQueryError("boom")
+
+    class _FailingTranslator:
+        def translate(self, *_args: object, **_kwargs: object) -> Err:
+            return Err(sentinel)
+
+    with pytest.raises(InvalidQueryError) as excinfo:
+        await rewrite_and_translate_select(
+            "SELECT id FROM ds.t",
+            project_id="p",
+            ctx=ctx,
+            caller=_ANON,
+            translator=_FailingTranslator(),  # type: ignore[arg-type]
+        )
+    assert excinfo.value is sentinel
+
+
+async def test_rewrite_and_translate_select_ok_branch_with_stub(
+    ctx: AppContext,
+    frozen_clock: FrozenClock,
+) -> None:
+    """The Ok branch returns the table-ref rewrite of the translated SQL."""
+    _seed_table(ctx, frozen_clock)
+
+    class _OkTranslator:
+        def translate(self, *_args: object, **_kwargs: object) -> Ok:
+            return Ok("SELECT id FROM p.ds.t")
+
+    result = await rewrite_and_translate_select(
+        "SELECT id FROM ds.t",
+        project_id="p",
+        ctx=ctx,
+        caller=_ANON,
+        translator=_OkTranslator(),  # type: ignore[arg-type]
+    )
+    assert quoted_table_ref("p", "ds", "t") in result

--- a/tests/unit/sql/test_inner_query.py
+++ b/tests/unit/sql/test_inner_query.py
@@ -19,7 +19,7 @@ import pytest_asyncio
 from bqemulator.api.dependencies import AppContext
 from bqemulator.catalog.etag import generate_etag
 from bqemulator.catalog.memory_repository import MemoryCatalogRepository
-from bqemulator.catalog.models import DatasetMeta, TableMeta
+from bqemulator.catalog.models import DatasetMeta, MaterializedViewMeta, TableMeta
 from bqemulator.config import Settings
 from bqemulator.domain.clock import FrozenClock
 from bqemulator.domain.errors import InvalidQueryError
@@ -106,8 +106,37 @@ def _seed_table(ctx: AppContext, frozen_clock: FrozenClock) -> None:
     ctx.engine.execute(f"INSERT INTO {quoted_table_ref('p', 'ds', 't')} VALUES (1)")
 
 
-async def test_refresh_dependent_mvs_ignores_unparseable_sql(ctx: AppContext) -> None:
+def _register_mv(ctx: AppContext, frozen_clock: FrozenClock) -> None:
+    """Register a materialized view so the refresh walk runs past the no-MV short-circuit.
+
+    The registered view is never referenced by the test queries; its mere
+    presence in the catalog is what makes ``refresh_dependent_mvs`` parse
+    and walk the statement instead of short-circuiting.
+    """
+    ctx.catalog.upsert_materialized_view(
+        MaterializedViewMeta(
+            project_id="p",
+            dataset_id="ds",
+            table_id="mv",
+            view_query="SELECT 1",
+            base_tables=(),
+            last_refresh_time=frozen_clock.now(),
+        ),
+    )
+
+
+async def test_refresh_dependent_mvs_short_circuits_without_views(ctx: AppContext) -> None:
+    """With no materialized views in the catalog, the walk is skipped entirely."""
+    # No MV registered: returns before parsing, so even malformed SQL is a no-op.
+    await refresh_dependent_mvs("p", "this is not valid sql @@@", ctx)
+
+
+async def test_refresh_dependent_mvs_ignores_unparseable_sql(
+    ctx: AppContext,
+    frozen_clock: FrozenClock,
+) -> None:
     """Unparseable SQL is a no-op — later pipeline layers surface the error."""
+    _register_mv(ctx, frozen_clock)
     # Must not raise: the parse failure short-circuits the MV walk.
     await refresh_dependent_mvs("p", "this is not valid sql @@@", ctx)
 
@@ -118,12 +147,17 @@ async def test_refresh_dependent_mvs_skips_plain_table(
 ) -> None:
     """A query over a non-materialized-view table triggers no refresh."""
     _seed_table(ctx, frozen_clock)
+    _register_mv(ctx, frozen_clock)
     # No MaterializedViewError / no mutation: a plain table is left alone.
     await refresh_dependent_mvs("p", "SELECT id FROM ds.t", ctx)
 
 
-async def test_refresh_dependent_mvs_skips_unqualified_refs(ctx: AppContext) -> None:
+async def test_refresh_dependent_mvs_skips_unqualified_refs(
+    ctx: AppContext,
+    frozen_clock: FrozenClock,
+) -> None:
     """A bare table reference (e.g. a CTE) has no dataset and is skipped."""
+    _register_mv(ctx, frozen_clock)
     # ``cte`` has a name but no dataset, so the MV lookup is bypassed.
     await refresh_dependent_mvs("p", "WITH cte AS (SELECT 1 AS id) SELECT id FROM cte", ctx)
 
@@ -134,6 +168,7 @@ async def test_refresh_dependent_mvs_dedups_repeated_refs(
 ) -> None:
     """A table referenced more than once (self-join) is visited at most once."""
     _seed_table(ctx, frozen_clock)
+    _register_mv(ctx, frozen_clock)
     # ``ds.t`` appears twice; the second occurrence hits the dedup guard.
     await refresh_dependent_mvs(
         "p",

--- a/tests/unit/sql/test_inner_query.py
+++ b/tests/unit/sql/test_inner_query.py
@@ -37,6 +37,7 @@ from bqemulator.sql.translator import SQLTranslator
 from bqemulator.storage.engine import DuckDBEngine
 from bqemulator.storage.sql_identifiers import quoted_schema, quoted_table_ref
 from bqemulator.udf.runtime import UDFRegistry
+from bqemulator.versioning.materialized_views import MaterializedViewManager
 from bqemulator.versioning.snapshots import SnapshotManager
 
 pytestmark = pytest.mark.unit
@@ -78,8 +79,10 @@ async def ctx(
         await engine.stop()
 
 
-def _seed_table(ctx: AppContext, frozen_clock: FrozenClock) -> None:
-    """Create a plain ``p.ds.t`` table with one row."""
+def _ensure_dataset(ctx: AppContext, frozen_clock: FrozenClock) -> None:
+    """Idempotently create dataset ``p.ds`` and its DuckDB schema."""
+    if ctx.catalog.get_dataset("p", "ds") is not None:
+        return
     now = frozen_clock.now()
     ctx.catalog.create_dataset(
         DatasetMeta(
@@ -90,6 +93,13 @@ def _seed_table(ctx: AppContext, frozen_clock: FrozenClock) -> None:
             etag=generate_etag("p", "ds", str(now)),
         ),
     )
+    ctx.engine.execute(f"CREATE SCHEMA IF NOT EXISTS {quoted_schema('p', 'ds')}")
+
+
+def _seed_table(ctx: AppContext, frozen_clock: FrozenClock) -> None:
+    """Create a plain ``p.ds.t`` table with one row."""
+    _ensure_dataset(ctx, frozen_clock)
+    now = frozen_clock.now()
     ctx.catalog.create_table(
         TableMeta(
             project_id="p",
@@ -101,80 +111,142 @@ def _seed_table(ctx: AppContext, frozen_clock: FrozenClock) -> None:
             etag=generate_etag("p", "ds", "t", str(now)),
         ),
     )
-    ctx.engine.execute(f"CREATE SCHEMA IF NOT EXISTS {quoted_schema('p', 'ds')}")
     ctx.engine.execute(f"CREATE TABLE {quoted_table_ref('p', 'ds', 't')} (id BIGINT)")
     ctx.engine.execute(f"INSERT INTO {quoted_table_ref('p', 'ds', 't')} VALUES (1)")
 
 
 def _register_mv(ctx: AppContext, frozen_clock: FrozenClock) -> None:
-    """Register a materialized view so the refresh walk runs past the no-MV short-circuit.
+    """Register materialized view ``p.ds.mv`` the way production does.
 
-    The registered view is never referenced by the test queries; its mere
-    presence in the catalog is what makes ``refresh_dependent_mvs`` parse
-    and walk the statement instead of short-circuiting.
+    ``MaterializedViewManager.create`` writes BOTH a ``TableMeta`` with
+    ``table_type="MATERIALIZED_VIEW"`` (so ``get_table`` resolves it) AND
+    a ``MaterializedViewMeta`` (so ``list_all_materialized_views`` sees
+    it). Mirroring both is what lets ``refresh_dependent_mvs`` classify a
+    reference to ``ds.mv`` as a view and yield it for refresh.
     """
+    _ensure_dataset(ctx, frozen_clock)
+    now = frozen_clock.now()
+    ctx.catalog.create_table(
+        TableMeta(
+            project_id="p",
+            dataset_id="ds",
+            table_id="mv",
+            table_type="MATERIALIZED_VIEW",
+            creation_time=now,
+            last_modified_time=now,
+            etag=generate_etag("p", "ds", "mv", str(now)),
+        ),
+    )
     ctx.catalog.upsert_materialized_view(
         MaterializedViewMeta(
             project_id="p",
             dataset_id="ds",
             table_id="mv",
-            view_query="SELECT 1",
+            view_query="SELECT 1 AS id",
             base_tables=(),
-            last_refresh_time=frozen_clock.now(),
+            last_refresh_time=now,
         ),
     )
 
 
-async def test_refresh_dependent_mvs_short_circuits_without_views(ctx: AppContext) -> None:
+@pytest.fixture
+def refresh_calls(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, ...]]:
+    """Record each ``refresh_if_stale`` call instead of performing it.
+
+    Returns the list of ``(project, dataset, table)`` tuples the walk
+    asked to refresh, so tests can assert exactly which views (and how
+    many times) the chain refreshes.
+    """
+    calls: list[tuple[str, ...]] = []
+
+    async def _spy(_self: object, *ref: str) -> None:
+        calls.append(ref)
+
+    monkeypatch.setattr(MaterializedViewManager, "refresh_if_stale", _spy)
+    return calls
+
+
+async def test_refresh_dependent_mvs_short_circuits_without_views(
+    ctx: AppContext,
+    refresh_calls: list[tuple[str, ...]],
+) -> None:
     """With no materialized views in the catalog, the walk is skipped entirely."""
     # No MV registered: returns before parsing, so even malformed SQL is a no-op.
     await refresh_dependent_mvs("p", "this is not valid sql @@@", ctx)
+    assert refresh_calls == []
 
 
 async def test_refresh_dependent_mvs_ignores_unparseable_sql(
     ctx: AppContext,
     frozen_clock: FrozenClock,
+    refresh_calls: list[tuple[str, ...]],
 ) -> None:
-    """Unparseable SQL is a no-op — later pipeline layers surface the error."""
+    """Unparseable SQL refreshes nothing; later pipeline layers surface the error."""
     _register_mv(ctx, frozen_clock)
-    # Must not raise: the parse failure short-circuits the MV walk.
     await refresh_dependent_mvs("p", "this is not valid sql @@@", ctx)
+    assert refresh_calls == []
 
 
 async def test_refresh_dependent_mvs_skips_plain_table(
     ctx: AppContext,
     frozen_clock: FrozenClock,
+    refresh_calls: list[tuple[str, ...]],
 ) -> None:
     """A query over a non-materialized-view table triggers no refresh."""
     _seed_table(ctx, frozen_clock)
     _register_mv(ctx, frozen_clock)
-    # No MaterializedViewError / no mutation: a plain table is left alone.
     await refresh_dependent_mvs("p", "SELECT id FROM ds.t", ctx)
+    assert refresh_calls == []
 
 
 async def test_refresh_dependent_mvs_skips_unqualified_refs(
     ctx: AppContext,
     frozen_clock: FrozenClock,
+    refresh_calls: list[tuple[str, ...]],
 ) -> None:
     """A bare table reference (e.g. a CTE) has no dataset and is skipped."""
     _register_mv(ctx, frozen_clock)
-    # ``cte`` has a name but no dataset, so the MV lookup is bypassed.
     await refresh_dependent_mvs("p", "WITH cte AS (SELECT 1 AS id) SELECT id FROM cte", ctx)
+    assert refresh_calls == []
+
+
+async def test_refresh_dependent_mvs_skips_anonymous_table_function(
+    ctx: AppContext,
+    frozen_clock: FrozenClock,
+    refresh_calls: list[tuple[str, ...]],
+) -> None:
+    """A table-function call (``Anonymous`` node) is skipped, not treated as a table."""
+    _register_mv(ctx, frozen_clock)
+    # ``ds.tvf(1)`` parses as a Table whose ``this`` is an Anonymous call.
+    await refresh_dependent_mvs("p", "SELECT * FROM ds.tvf(1)", ctx)
+    assert refresh_calls == []
+
+
+async def test_refresh_dependent_mvs_refreshes_referenced_view(
+    ctx: AppContext,
+    frozen_clock: FrozenClock,
+    refresh_calls: list[tuple[str, ...]],
+) -> None:
+    """A query reading a materialized view refreshes exactly that view."""
+    _register_mv(ctx, frozen_clock)
+    await refresh_dependent_mvs("p", "SELECT id FROM ds.mv", ctx)
+    assert refresh_calls == [("p", "ds", "mv")]
 
 
 async def test_refresh_dependent_mvs_dedups_repeated_refs(
     ctx: AppContext,
     frozen_clock: FrozenClock,
+    refresh_calls: list[tuple[str, ...]],
 ) -> None:
-    """A table referenced more than once (self-join) is visited at most once."""
-    _seed_table(ctx, frozen_clock)
+    """A view referenced more than once (self-join) is refreshed exactly once."""
     _register_mv(ctx, frozen_clock)
-    # ``ds.t`` appears twice; the second occurrence hits the dedup guard.
+    # ``ds.mv`` appears twice; the second occurrence hits the dedup guard.
     await refresh_dependent_mvs(
         "p",
-        "SELECT a.id FROM ds.t AS a JOIN ds.t AS b ON a.id = b.id",
+        "SELECT a.id FROM ds.mv AS a JOIN ds.mv AS b ON a.id = b.id",
         ctx,
     )
+    assert refresh_calls == [("p", "ds", "mv")]
 
 
 async def test_rewrite_and_translate_statement_returns_duckdb_sql(

--- a/tests/unit/sql/test_inner_query.py
+++ b/tests/unit/sql/test_inner_query.py
@@ -6,7 +6,7 @@ interpreter. End-to-end behaviour (MV refresh, time-travel, row-access)
 is pinned by the integration suites; these tests cover the module's own
 branches: the parse-failure short-circuit in
 :func:`refresh_dependent_mvs` and the translation-error path in
-:func:`rewrite_and_translate_select`.
+:func:`rewrite_and_translate_statement`.
 """
 
 from __future__ import annotations
@@ -30,7 +30,7 @@ from bqemulator.row_access.identity import CallerIdentity
 from bqemulator.row_access.policy import RowAccessPolicyManager
 from bqemulator.sql.inner_query import (
     refresh_dependent_mvs,
-    rewrite_and_translate_select,
+    rewrite_and_translate_statement,
 )
 from bqemulator.sql.translator import SQLTranslator
 from bqemulator.storage.engine import DuckDBEngine
@@ -127,13 +127,13 @@ async def test_refresh_dependent_mvs_skips_unqualified_refs(ctx: AppContext) -> 
     await refresh_dependent_mvs("p", "WITH cte AS (SELECT 1 AS id) SELECT id FROM cte", ctx)
 
 
-async def test_rewrite_and_translate_select_returns_duckdb_sql(
+async def test_rewrite_and_translate_statement_returns_duckdb_sql(
     ctx: AppContext,
     frozen_clock: FrozenClock,
 ) -> None:
     """The happy path returns table-ref-qualified, executable DuckDB SQL."""
     _seed_table(ctx, frozen_clock)
-    duckdb_sql = await rewrite_and_translate_select(
+    duckdb_sql = await rewrite_and_translate_statement(
         "SELECT id FROM ds.t",
         project_id="p",
         ctx=ctx,
@@ -145,7 +145,7 @@ async def test_rewrite_and_translate_select_returns_duckdb_sql(
     assert ctx.engine.fetch_arrow(duckdb_sql).to_pylist() == [{"id": 1}]
 
 
-async def test_rewrite_and_translate_select_raises_translator_error(
+async def test_rewrite_and_translate_statement_raises_translator_error(
     ctx: AppContext,
     frozen_clock: FrozenClock,
 ) -> None:
@@ -158,7 +158,7 @@ async def test_rewrite_and_translate_select_raises_translator_error(
             return Err(sentinel)
 
     with pytest.raises(InvalidQueryError) as excinfo:
-        await rewrite_and_translate_select(
+        await rewrite_and_translate_statement(
             "SELECT id FROM ds.t",
             project_id="p",
             ctx=ctx,
@@ -168,7 +168,7 @@ async def test_rewrite_and_translate_select_raises_translator_error(
     assert excinfo.value is sentinel
 
 
-async def test_rewrite_and_translate_select_ok_branch_with_stub(
+async def test_rewrite_and_translate_statement_ok_branch_with_stub(
     ctx: AppContext,
     frozen_clock: FrozenClock,
 ) -> None:
@@ -179,7 +179,7 @@ async def test_rewrite_and_translate_select_ok_branch_with_stub(
         def translate(self, *_args: object, **_kwargs: object) -> Ok:
             return Ok("SELECT id FROM p.ds.t")
 
-    result = await rewrite_and_translate_select(
+    result = await rewrite_and_translate_statement(
         "SELECT id FROM ds.t",
         project_id="p",
         ctx=ctx,

--- a/tests/unit/sql/test_inner_query.py
+++ b/tests/unit/sql/test_inner_query.py
@@ -128,6 +128,20 @@ async def test_refresh_dependent_mvs_skips_unqualified_refs(ctx: AppContext) -> 
     await refresh_dependent_mvs("p", "WITH cte AS (SELECT 1 AS id) SELECT id FROM cte", ctx)
 
 
+async def test_refresh_dependent_mvs_dedups_repeated_refs(
+    ctx: AppContext,
+    frozen_clock: FrozenClock,
+) -> None:
+    """A table referenced more than once (self-join) is visited at most once."""
+    _seed_table(ctx, frozen_clock)
+    # ``ds.t`` appears twice; the second occurrence hits the dedup guard.
+    await refresh_dependent_mvs(
+        "p",
+        "SELECT a.id FROM ds.t AS a JOIN ds.t AS b ON a.id = b.id",
+        ctx,
+    )
+
+
 async def test_rewrite_and_translate_statement_returns_duckdb_sql(
     ctx: AppContext,
     frozen_clock: FrozenClock,


### PR DESCRIPTION
## Summary

Unify the scripted and standalone inner-query execution paths behind one
shared rewrite pipeline, so a BigQuery `SELECT` behaves identically whether
it runs as a single-statement job or inside a script.

## Motivation

A `SELECT` reached DuckDB through two parallel rewrite chains chosen by
whether the job was a single statement or a multi-statement / control-flow
script. The scripted path (`scripting/interpreter.py`) re-implemented the
chain inline and had drifted from the standalone path
(`jobs/executor.py::_run_single_sql`), omitting three steps:

1. **Materialized-view refresh** — a script that read a stale MV returned
   stale rows.
2. **`FOR SYSTEM_TIME AS OF` time-travel** — the clause was passed through
   untranslated, so a script silently returned the wrong rows instead of the
   historical snapshot.
3. **Schema-annotated translation** — scripted SELECTs translated without the
   per-table type snapshot, so type-directed rules (e.g. `AvgDecimalRule`)
   did not fire.

This affected scripted SELECTs generally and the `EXPORT DATA` inner SELECT
specifically (the interpreter runs it through the scripted path).

## Changes

- New `src/bqemulator/sql/inner_query.py`: the single canonical chain.
  `rewrite_and_translate_statement` runs MV-refresh, time-travel, row-access,
  `INFORMATION_SCHEMA` expansion, `UNNEST`-offset, wildcard-table expansion,
  and schema-annotated translation, returning the translated DuckDB SQL.
  `refresh_dependent_mvs` moves here from the executor.
- `_run_single_sql` and the three interpreter methods (`_run_query`,
  `_run_statement_with_params`, `_run_query_with_params`) now call the shared
  helper. Concerns that need each caller's own error boundary stay at the
  call site: **table-reference qualification** (`rewrite_table_refs`),
  parameter binding, and execution. This is deliberate — a malformed-id
  `ValidationError` from qualification must be reshaped by the caller's error
  mapper, whereas a translation failure is raised by the helper before the
  caller's `try` so an unsupported feature keeps its own `501`. Scripting
  pre-rewrites (temp-routine calls, `@var` to placeholders) also stay at the
  call sites.
- ADR 0046 documents the decision (no RFC: no public-surface change).

## Testing

- [x] Unit tests added / updated (`tests/unit/sql/test_inner_query.py`)
- [ ] Property tests added / updated (n/a — no combinatorial surface)
- [x] Integration tests added / updated
  (`tests/integration/test_scripted_inner_query_parity.py`, written to fail
  first against the bug, then pass after the fix)
- [x] E2E across all five clients: Python (60), bq CLI (51), Go, Node.js, Java
- [x] `make lint` + `make test-coverage` pass locally
- [x] Coverage on changed files ≥90% (project 91.81%, patch 100% on the diff)

## Documentation

- [ ] User guide (n/a — internal refactor, no user-facing surface change)
- [ ] Reference docs (n/a)
- [ ] Architecture doc (n/a)
- [x] ADR added (`docs/adr/0046-unified-inner-query-pipeline.md`)
- [ ] Runnable example (n/a)

## Release hygiene

- [ ] `CHANGELOG.md` — intentionally deferred to release time per the repo's
  Common Changelog convention (the changelog is authored at release, not
  per-PR); same practice as #135 and #149.
- [ ] Catalog migration (n/a — no schema change)
- [x] No `TODO` / `FIXME` without a linked issue number
- [x] Conventional Commits used

## Related

- Closes the inner-query-unification follow-up spun out of the #135
  `EXPORT DATA` review. Documented by ADR 0046.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR 0046 (“Unified inner-query rewrite pipeline”) and updated ADR navigation.

* **Refactor**
  * Unified the statement rewrite/translation flow used by standalone and scripted execution to keep behavior consistent across materialized view refreshes, time travel (`FOR SYSTEM_TIME AS OF`), row-access policies, `INFORMATION_SCHEMA`, `UNNEST` offsets, and wildcard expansion.

* **Tests**
  * Added integration parity tests for materialized view refresh, time travel, and `EXECUTE IMMEDIATE` DML.
  * Added unit tests covering rewrite/translation behavior and error boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
