### PR TITLE
docs(rfc): RFC 0002 + ADR 0047 — BigQuery ML surface-only scope

### DIFF
--- a/docs/adr/0012-bqml-out-of-scope.md
+++ b/docs/adr/0012-bqml-out-of-scope.md
@@ -1,6 +1,13 @@
 # ADR 0012: BigQuery ML explicitly out of scope for v1
 
-- **Status**: Accepted
+- **Status**: Accepted (partially superseded by [ADR 0047](0047-bigquery-ml-surface.md))
+- **Superseded by**: 0047 (surface-only slice: `CREATE MODEL` metadata, Models
+  REST `list`/`get`/`patch`/`delete`, and `ML.PREDICT` output shape move into
+  scope; training, evaluation, forecasting, generation, and prediction accuracy
+  remain out of scope under this ADR). Note: this ADR's claim that "Models
+  resource CRUD ... insert ... is supported" was never accurate (the Models
+  surface was unimplemented, and BigQuery has no `models.insert`); ADR 0047
+  implements `list`/`get`/`patch`/`delete` only.
 
 ## Context
 

--- a/docs/adr/0012-bqml-out-of-scope.md
+++ b/docs/adr/0012-bqml-out-of-scope.md
@@ -1,13 +1,13 @@
 # ADR 0012: BigQuery ML explicitly out of scope for v1
 
 - **Status**: Accepted (partially superseded by [ADR 0047](0047-bigquery-ml-surface.md))
-- **Superseded by**: 0047 (surface-only slice: `CREATE MODEL` metadata, Models
-  REST `list`/`get`/`patch`/`delete`, and `ML.PREDICT` output shape move into
-  scope; training, evaluation, forecasting, generation, and prediction accuracy
-  remain out of scope under this ADR). Note: this ADR's claim that "Models
-  resource CRUD ... insert ... is supported" was never accurate (the Models
-  surface was unimplemented, and BigQuery has no `models.insert`); ADR 0047
-  implements `list`/`get`/`patch`/`delete` only.
+- **Superseded by**: 0047. The decision below is the v1.0.0 historical record.
+  ADR 0047 redefines the BigQuery ML scope: model-metadata registration via
+  `CREATE MODEL`, the Models REST resource (`list`/`get`/`patch`/`delete`), and
+  the `ML.PREDICT` output shape move into scope, while training, evaluation,
+  forecasting, generation, and prediction accuracy remain out of scope. See
+  ADR 0047 for the current Models-resource scope, including the correction that
+  BigQuery has no Models `insert` method.
 
 ## Context
 

--- a/docs/adr/0012-bqml-out-of-scope.md
+++ b/docs/adr/0012-bqml-out-of-scope.md
@@ -1,7 +1,7 @@
 # ADR 0012: BigQuery ML explicitly out of scope for v1
 
 - **Status**: Accepted (partially superseded by [ADR 0047](0047-bigquery-ml-surface.md))
-- **Superseded by**: 0047. The decision below is the v1.0.0 historical record.
+- **Superseded by**: 0047 (partial). The decision below is the v1.0.0 historical record.
   ADR 0047 redefines the BigQuery ML scope: model-metadata registration via
   `CREATE MODEL`, the Models REST resource (`list`/`get`/`patch`/`delete`), and
   the `ML.PREDICT` output shape move into scope, while training, evaluation,

--- a/docs/adr/0047-bigquery-ml-surface.md
+++ b/docs/adr/0047-bigquery-ml-surface.md
@@ -1,0 +1,141 @@
+# ADR 0047: BigQuery ML surface (metadata, Models REST, ML.PREDICT shape)
+
+- **Status**: Accepted
+- **Supersedes**: 0012 (partially: the surface-only slice below moves into scope;
+  real training, evaluation, and inference accuracy remain out of scope)
+- **Superseded by**: none
+
+## Context
+
+[RFC 0002](../rfcs/0002-bigquery-ml-surface.md) proposes a **surface-only** slice
+of BigQuery ML: register model metadata from `CREATE MODEL`, serve it through the
+Models REST resource, and make `ML.PREDICT` return correctly-shaped but
+deterministic, non-real output. This ADR records the implementation decisions.
+
+[ADR 0012](0012-bqml-out-of-scope.md) put all of BQML out of scope for v1 and
+returned `UnsupportedFeatureError` (HTTP 501) for `CREATE MODEL` / `ML.*`. It also
+stated that "Models resource CRUD ... is supported." Two corrections of record:
+the Models surface was **never implemented** (no route, no catalog entity), and
+the real BigQuery Models REST API has **no `insert` method** (models are created
+only via `CREATE MODEL` query jobs). ADR 0012 noted the decision was
+"reconsiderable for v2"; this ADR is that reconsideration, scoped to the surface
+only.
+
+`CREATE MODEL` and `ML.PREDICT` are addressable in the SQLGlot AST (`exp.Create`
+with `kind == "MODEL"`, and the dedicated `exp.Predict` node), so they can be
+intercepted exactly the way `EXPORT DATA` (`exp.Export`) is
+([ADR 0043](0043-export-data-statement.md)). `ML.EVALUATE` / `ML.FORECAST` do not
+parse and stay on the 501 path.
+
+## Decisions
+
+### 1. Surface-only scope; training stays out
+
+`CREATE MODEL` registers metadata and derives the feature/label schema by
+planning the training query; it does **not** train. `ML.PREDICT` returns
+deterministic, intentionally non-real prediction values. `ML.EVALUATE`,
+`ML.FORECAST`, `ML.GENERATE_*`, `ML.WEIGHTS`, and `TRANSFORM()` remain out of
+scope (still 501). This supersedes ADR 0012 only for the surface; ADR 0012's
+training/inference exclusion still governs.
+
+### 2. Intercept `exp.Create(kind=MODEL)` and `exp.Predict` pre-translation, dual-wired
+
+Classification (`_classify_parsed_tree`) maps `exp.Create` with `kind == "MODEL"`
+to `"CREATE_MODEL"`. Shared `parse_create_model` / `_execute_create_model_job`
+and `_execute_predict` helpers live in `src/bqemulator/jobs/executor.py` and are
+invoked from both `execute_query_job` (standalone) and the scripting interpreter,
+mirroring the `EXPORT DATA` dual-wiring. `"CREATE MODEL"` and `"ML.PREDICT"` are
+removed from `_UNSUPPORTED_KEYWORDS` in `src/bqemulator/sql/translator.py`; the
+AST interception replaces the keyword reject. The training query and the
+`ML.PREDICT` input query run through the shared
+`sql/inner_query.py::rewrite_and_translate_statement` pipeline so every rewrite
+rule, row-access policy, and parameter applies as to a bare `SELECT`.
+
+### 3. `ModelMeta` catalog entity + Models REST resource (no insert)
+
+A frozen, dataset-scoped `ModelMeta` (`(project_id, dataset_id, model_id)`) is
+added to `catalog/models.py`, with `list/get/create/update/delete_models` across
+the repository protocol and its in-memory and DuckDB-backed implementations, a
+`_bqemulator_catalog.models` persistence table, and cascade-delete on dataset
+drop. `src/bqemulator/api/routes/models.py` exposes `list` / `get` / `patch` /
+`delete` (no `insert`, matching BigQuery), modeled on the Routines resource. The
+resource is REST-only; the gRPC adapter is untouched.
+
+### 4. Faithful shapes recorded; `ML.PREDICT` values are a documented divergence
+
+The Models REST shape, the `CREATE_MODEL` job/statementType, the `ML.PREDICT`
+output column shape, and the error envelopes are recorded from real BigQuery and
+asserted exactly. `ML.PREDICT` numeric values cannot match (no training), so
+those fixtures are pinned in `tests/conformance/divergences.py` as
+`xfail(strict=True)` citing this ADR, per
+[ADR 0023](0023-conformance-divergence-baseline.md). Removing the entry when a
+future accuracy slice lands makes the fixture pass.
+
+### 5. Disposition + error parity
+
+`CREATE MODEL` onto an existing model errors `duplicate` (HTTP 409);
+`IF NOT EXISTS` is a no-op; `OR REPLACE` replaces. Missing parent dataset errors
+`notFound` (HTTP 404). `ML.PREDICT` on a missing model errors `notFound`
+(HTTP 404). Unknown/invalid OPTIONS error `invalidQuery` (HTTP 400). These
+envelopes are pinned by recorded conformance fixtures.
+
+## Consequences
+
+### Capability matrix shift
+
+`CREATE MODEL` (metadata), the Models REST resource (`list`/`get`/`patch`/
+`delete`), and `ML.PREDICT` (shape) move from unsupported to supported-surface.
+`out-of-scope.md` is updated: the BQML section keeps training, evaluation,
+forecasting, generation, and prediction-accuracy out of scope and removes the
+inaccurate "Models insert is supported" claim.
+
+### Coverage + test surface
+
+New modules target complete branch coverage; every error path is tested; the
+`CREATE MODEL` / `ML.PREDICT` execution logic and the Models repository join the
+mutation tier ([ADR 0026](0026-mutation-tier-design-contract.md)). Property tests
+cover `CREATE OR REPLACE` idempotency, `ModelMeta` REST round-trip, persistence
+save/reload round-trip, and the `ML.PREDICT` row-count and passthrough
+invariants. Scripted `CREATE MODEL` / `ML.PREDICT` tests prove the dual-wiring.
+
+### Honesty about prediction values
+
+`ML.PREDICT` values are deterministic placeholders, not real predictions. The
+guide and the reference docs carry a prominent callout; the value is chosen to be
+obviously synthetic so it is not mistaken for accurate output.
+
+## Unresolved questions
+
+- The exact `statistics.query` field set for `CREATE_MODEL` and the precise
+  `ML.PREDICT` output column names/types per model task, resolved by recording.
+- The fixed placeholder value for `ML.PREDICT` predictions.
+- Which OPTIONS BigQuery echoes on the model resource versus drops as
+  training-only.
+
+## Alternatives considered
+
+- **Full BQML training** (rejected here): comparable to the rest of the emulator
+  in effort; left to a future RFC.
+- **Keep the clean 501** (rejected): blocks Models API and SQL-shape testing,
+  which is the common local need.
+- **Plausible prediction values** (rejected): invites mistaking stubs for real
+  output; a clearly-synthetic deterministic value is safer.
+- **Add a Models `insert`** (rejected): BigQuery has none; it would be a
+  non-parity invention.
+
+## Related work
+
+- [ADR 0012](0012-bqml-out-of-scope.md): superseded in part by this ADR.
+- [ADR 0043](0043-export-data-statement.md): the statement-interception pattern
+  reused here.
+- [ADR 0023](0023-conformance-divergence-baseline.md): the divergence mechanism
+  for `ML.PREDICT` values.
+- [ADR 0026](0026-mutation-tier-design-contract.md): the mutation tier the new
+  logic joins.
+
+## References
+
+- [RFC 0002](../rfcs/0002-bigquery-ml-surface.md).
+- [BigQuery Models REST resource](https://docs.cloud.google.com/bigquery/docs/reference/rest/v2/models),
+  [CREATE MODEL](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-create),
+  [ML.PREDICT](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-predict).

--- a/docs/reference/out-of-scope.md
+++ b/docs/reference/out-of-scope.md
@@ -13,15 +13,25 @@ encountered, with a link back to this page.
 
 ### BigQuery ML
 
-`CREATE MODEL`, `ML.PREDICT`, `ML.EVALUATE`, `ML.FORECAST`, `ML.GENERATE_*`,
-and all ML-related model types (ARIMA, k-means, matrix factorization, DNN,
-boosted trees, AutoML).
+Model **training** and **inference accuracy** are out of scope: `ML.EVALUATE`,
+`ML.FORECAST`, `ML.GENERATE_*`, `ML.WEIGHTS`, the `TRANSFORM()` clause, and the
+numeric output of any model (ARIMA, k-means, matrix factorization, DNN, boosted
+trees, AutoML, regression). `ML.PREDICT` runs but returns deterministic,
+non-real placeholder values, not accurate predictions.
 
-Only **Models resource CRUD** — list / get / insert / patch / update / delete
-of model metadata — is supported.
+A **surface-only** slice of BigQuery ML *is* supported (see
+[RFC 0002](../rfcs/0002-bigquery-ml-surface.md) and
+[ADR 0047](../adr/0047-bigquery-ml-surface.md)): `CREATE MODEL` registers model
+metadata (the feature/label schema is derived from the training query; no
+training happens), the Models REST resource serves it (`list`, `get`, `patch`,
+`delete`, matching BigQuery, which has no `insert`), and `ML.PREDICT` returns
+correctly-shaped output.
 
-*Rationale*: full BQML would be a project of comparable size to the rest
-of the emulator. See [ADR 0012](../adr/0012-bqml-out-of-scope.md).
+*Rationale*: full BQML training would be a project of comparable size to the
+rest of the emulator. The surface-only slice unblocks SQL-parsing, Models-API,
+and pipeline-shape testing without it. See
+[ADR 0012](../adr/0012-bqml-out-of-scope.md) (the original exclusion, partially
+superseded) and [ADR 0047](../adr/0047-bigquery-ml-surface.md).
 
 ### BI Engine
 

--- a/docs/reference/out-of-scope.md
+++ b/docs/reference/out-of-scope.md
@@ -13,19 +13,18 @@ encountered, with a link back to this page.
 
 ### BigQuery ML
 
-Model **training** and prediction **accuracy** are permanently out of scope: the
-numeric output of any model type (ARIMA, k-means, matrix factorization, DNN,
-boosted trees, AutoML, regression), and `ML.EVALUATE`, `ML.FORECAST`,
-`ML.GENERATE_*`, `ML.WEIGHTS`, and the `TRANSFORM()` clause.
+Model **training** and prediction **accuracy** are out of scope: the numeric
+output of any model type (ARIMA, k-means, matrix factorization, DNN, boosted
+trees, AutoML, regression), and `ML.EVALUATE`, `ML.FORECAST`, `ML.GENERATE_*`,
+`ML.WEIGHTS`, and the `TRANSFORM()` clause.
 
-A **surface-only** slice of BigQuery ML, registering model metadata from
-`CREATE MODEL` (the feature/label schema is derived from the training query; no
-training runs), serving the Models REST resource (`list` / `get` / `patch` /
-`delete`; BigQuery has no `insert`), and returning a deterministic, non-real
-`ML.PREDICT` result shape, is accepted in
+In scope is a **surface-only** slice, defined in
 [RFC 0002](../rfcs/0002-bigquery-ml-surface.md) and
-[ADR 0047](../adr/0047-bigquery-ml-surface.md) and is being implemented in
-phases.
+[ADR 0047](../adr/0047-bigquery-ml-surface.md): model-metadata registration via
+`CREATE MODEL` (the feature/label schema is derived from the training query),
+the Models REST resource (`list` / `get` / `patch` / `delete`; BigQuery has no
+`insert`), and the `ML.PREDICT` output shape (values are deterministic and not
+real predictions).
 
 *Rationale*: full BQML training would be a project of comparable size to the
 rest of the emulator; the surface-only slice unblocks SQL-parsing, Models-API,

--- a/docs/reference/out-of-scope.md
+++ b/docs/reference/out-of-scope.md
@@ -13,25 +13,25 @@ encountered, with a link back to this page.
 
 ### BigQuery ML
 
-Model **training** and **inference accuracy** are out of scope: `ML.EVALUATE`,
-`ML.FORECAST`, `ML.GENERATE_*`, `ML.WEIGHTS`, the `TRANSFORM()` clause, and the
-numeric output of any model (ARIMA, k-means, matrix factorization, DNN, boosted
-trees, AutoML, regression). `ML.PREDICT` runs but returns deterministic,
-non-real placeholder values, not accurate predictions.
+Model **training** and prediction **accuracy** are permanently out of scope: the
+numeric output of any model type (ARIMA, k-means, matrix factorization, DNN,
+boosted trees, AutoML, regression), and `ML.EVALUATE`, `ML.FORECAST`,
+`ML.GENERATE_*`, `ML.WEIGHTS`, and the `TRANSFORM()` clause.
 
-A **surface-only** slice of BigQuery ML *is* supported (see
+A **surface-only** slice of BigQuery ML, registering model metadata from
+`CREATE MODEL` (the feature/label schema is derived from the training query; no
+training runs), serving the Models REST resource (`list` / `get` / `patch` /
+`delete`; BigQuery has no `insert`), and returning a deterministic, non-real
+`ML.PREDICT` result shape, is accepted in
 [RFC 0002](../rfcs/0002-bigquery-ml-surface.md) and
-[ADR 0047](../adr/0047-bigquery-ml-surface.md)): `CREATE MODEL` registers model
-metadata (the feature/label schema is derived from the training query; no
-training happens), the Models REST resource serves it (`list`, `get`, `patch`,
-`delete`, matching BigQuery, which has no `insert`), and `ML.PREDICT` returns
-correctly-shaped output.
+[ADR 0047](../adr/0047-bigquery-ml-surface.md) and is being implemented in
+phases.
 
 *Rationale*: full BQML training would be a project of comparable size to the
-rest of the emulator. The surface-only slice unblocks SQL-parsing, Models-API,
+rest of the emulator; the surface-only slice unblocks SQL-parsing, Models-API,
 and pipeline-shape testing without it. See
 [ADR 0012](../adr/0012-bqml-out-of-scope.md) (the original exclusion, partially
-superseded) and [ADR 0047](../adr/0047-bigquery-ml-surface.md).
+superseded by [ADR 0047](../adr/0047-bigquery-ml-surface.md)).
 
 ### BI Engine
 

--- a/docs/rfcs/0002-bigquery-ml-surface.md
+++ b/docs/rfcs/0002-bigquery-ml-surface.md
@@ -82,11 +82,11 @@ SELECT * FROM ML.PREDICT(MODEL my_dataset.my_model,
 
 The Models REST API serves the registered metadata:
 
-```
-GET  /bigquery/v2/projects/{p}/datasets/{d}/models                  -> list
-GET  /bigquery/v2/projects/{p}/datasets/{d}/models/{m}              -> get
-PATCH/bigquery/v2/projects/{p}/datasets/{d}/models/{m}              -> patch (description, labels, expirationTime)
-DELETE /bigquery/v2/projects/{p}/datasets/{d}/models/{m}            -> delete
+```text
+GET    /bigquery/v2/projects/{p}/datasets/{d}/models             -> list
+GET    /bigquery/v2/projects/{p}/datasets/{d}/models/{m}         -> get
+PATCH  /bigquery/v2/projects/{p}/datasets/{d}/models/{m}         -> patch (description, labels, expirationTime)
+DELETE /bigquery/v2/projects/{p}/datasets/{d}/models/{m}         -> delete
 ```
 
 `bq ls -m my_dataset`, `bq show -m my_dataset.my_model`, and the client-library

--- a/docs/rfcs/0002-bigquery-ml-surface.md
+++ b/docs/rfcs/0002-bigquery-ml-surface.md
@@ -1,0 +1,286 @@
+---
+rfc: "0002"
+title: "BigQuery ML surface (metadata, Models REST, ML.PREDICT shape)"
+status: Accepted
+authors:
+  - "@jjviscomi"
+created: 2026-06-24
+updated: 2026-06-24
+supersedes: null
+superseded-by: null
+---
+
+# RFC 0002: BigQuery ML surface (metadata, Models REST, ML.PREDICT shape)
+
+> Accepted under the maintainer fast-track described in the
+> [RFC lifecycle](README.md): the design is ratified before drafting and
+> implementation proceeds in a phased PR series. The implementation outcome is
+> recorded in [ADR 0047](../adr/0047-bigquery-ml-surface.md), which partially
+> supersedes [ADR 0012](../adr/0012-bqml-out-of-scope.md).
+
+## Summary
+
+Add a **surface-only** slice of BigQuery ML so that BQML SQL and the Models API
+can be exercised against the emulator without a real training runtime:
+
+1. `CREATE MODEL [IF NOT EXISTS | OR REPLACE] ... OPTIONS(...) AS query_statement`
+   runs as a `QUERY` job (`statementType` `CREATE_MODEL`) that registers a model
+   in the catalog. The training query is parsed and validated through the normal
+   pipeline to derive the feature/label schema, but **no model is trained**.
+2. The BigQuery **Models REST resource** (`list` / `get` / `patch` / `delete`,
+   matching the real API, which has **no** `insert`) serves that metadata.
+3. `ML.PREDICT(MODEL ref, (query_statement | TABLE ref))` runs the input query
+   and returns its rows plus deterministic, **explicitly non-real** prediction
+   column(s) shaped like BigQuery's output.
+
+Real training, evaluation, and inference accuracy stay out of scope (they remain
+governed by [ADR 0012](../adr/0012-bqml-out-of-scope.md)). `ML.EVALUATE`,
+`ML.FORECAST`, `ML.GENERATE_*`, `ML.WEIGHTS`, the `TRANSFORM()` clause, and all
+non-trivial model types beyond metadata registration are out of scope for this
+RFC. This RFC establishes the architecture and the parity model that a later,
+separate RFC for accuracy-bearing classical models (linear/logistic regression,
+k-means) can extend.
+
+## Motivation
+
+Today `CREATE MODEL` and `ML.PREDICT` are rejected by the
+`_UNSUPPORTED_KEYWORDS` quick-reject in `src/bqemulator/sql/translator.py` with
+an `UnsupportedFeatureError` (HTTP 501). That is correct and clear, but it leaves
+two real gaps for users whose pipelines touch BQML:
+
+- **No Models API at all.** [ADR 0012](../adr/0012-bqml-out-of-scope.md) states
+  that "Models resource CRUD ... is supported," but in fact **no Models surface
+  exists** in the codebase (no route, no catalog entity), and the BigQuery Models
+  REST API has **no `insert` method** (models are created only via `CREATE MODEL`
+  jobs). A pipeline that lists or reads model metadata cannot run against the
+  emulator, and the documentation overstates current support.
+- **No way to exercise BQML SQL locally.** A dbt model, scheduled query, or
+  orchestration DAG that contains `CREATE MODEL` or `ML.PREDICT` cannot be
+  parsed, planned, or shape-checked offline. The common local-testing need is
+  not numeric accuracy (that is validated against real BigQuery); it is "does my
+  SQL parse, does the model register, does `ML.PREDICT` return the columns my
+  downstream query expects, and does the Models API behave."
+
+Doing nothing keeps BQML a hard 501 wall and keeps the inaccurate "Models CRUD
+is supported" claim in `out-of-scope.md`. This RFC closes the surface gap while
+being honest that values are not real predictions.
+
+## Guide-level explanation
+
+Register a model from a training query, then read it back and predict with it:
+
+```sql
+-- Register a model (no training happens; metadata + schema only)
+CREATE MODEL my_dataset.my_model
+OPTIONS (model_type = 'LINEAR_REG', input_label_cols = ['label']) AS
+SELECT feature_1, feature_2, label FROM my_dataset.training;
+
+-- Predict: input rows are returned with prediction column(s) appended
+SELECT * FROM ML.PREDICT(MODEL my_dataset.my_model,
+                         (SELECT feature_1, feature_2 FROM my_dataset.scoring));
+```
+
+The Models REST API serves the registered metadata:
+
+```
+GET  /bigquery/v2/projects/{p}/datasets/{d}/models                  -> list
+GET  /bigquery/v2/projects/{p}/datasets/{d}/models/{m}              -> get
+PATCH/bigquery/v2/projects/{p}/datasets/{d}/models/{m}              -> patch (description, labels, expirationTime)
+DELETE /bigquery/v2/projects/{p}/datasets/{d}/models/{m}            -> delete
+```
+
+`bq ls -m my_dataset`, `bq show -m my_dataset.my_model`, and the client-library
+`get_model` / `list_models` / `update_model` / `delete_model` calls work against
+these endpoints.
+
+**What is real and what is not.** The model's existence, identity
+(`modelReference`), `modelType`, timestamps, ETag, and the feature/label column
+schema derived from the training query are faithful. `CREATE MODEL` runs as a
+real `QUERY` job with `statementType` `CREATE_MODEL`. **The prediction values
+returned by `ML.PREDICT` are deterministic placeholders, not real model
+output**, and are documented as such everywhere they appear. Use real BigQuery
+when prediction accuracy matters.
+
+`CREATE MODEL` and `ML.PREDICT` also work inside scripts (`BEGIN ... END`),
+because they flow through the same statement-interception path as a standalone
+query job (the path the `EXPORT DATA` statement already uses).
+
+## Reference-level explanation
+
+### Interception architecture
+
+`CREATE MODEL` and `ML.PREDICT` are intercepted **before translation**, mirroring
+the existing `EXPORT DATA` design (see
+[ADR 0043](../adr/0043-export-data-statement.md)). SQLGlot parses the two
+constructs into addressable AST nodes:
+
+- `CREATE MODEL ...` parses to `exp.Create` with `args["kind"] == "MODEL"`, the
+  OPTIONS in `properties`, the training query in `.expression`, and a `replace`
+  flag for `CREATE OR REPLACE`.
+- `ML.PREDICT(MODEL ref, (...))` parses to a dedicated `exp.Predict` node holding
+  the model `Table` and the input `Subquery` or `TABLE`.
+
+(`ML.EVALUATE` / `ML.FORECAST` do not parse in the GoogleSQL dialect and stay on
+the `_UNSUPPORTED_KEYWORDS` 501 path.) Detection and the parse/execute helpers
+live in `src/bqemulator/jobs/executor.py` and are invoked from **both** the
+standalone job entry point (`execute_query_job`) **and** the scripting
+interpreter, the same dual-wiring `EXPORT DATA` uses, so standalone and scripted
+statements share one code path. `"CREATE MODEL"` and `"ML.PREDICT"` are removed
+from `_UNSUPPORTED_KEYWORDS`; the AST interception replaces the keyword reject.
+
+### CREATE MODEL
+
+- **OPTIONS.** `model_type` is required (any BigQuery model-type string is
+  accepted and stored verbatim; this RFC does not train any of them).
+  `input_label_cols` (a string array) names the label column(s); the remaining
+  output columns of the training query are the feature columns. Other OPTIONS are
+  stored as opaque metadata where BigQuery echoes them and rejected when clearly
+  invalid. Unknown top-level OPTIONS are rejected with a clear `InvalidQueryError`
+  rather than silently dropped.
+- **Schema derivation.** The training query (`.expression`) runs through the
+  normal single-statement pipeline
+  (`sql/inner_query.py::rewrite_and_translate_statement` plus the call-site
+  qualification and binding) to validate it and obtain its result schema. Columns
+  named in `input_label_cols` become label columns; the rest become feature
+  columns. No rows are trained on; the query is planned, not persisted as data.
+- **Disposition.** `CREATE MODEL` onto an existing model errors (`duplicate`,
+  HTTP 409, matching BigQuery `Already Exists`). `CREATE MODEL IF NOT EXISTS` is
+  a no-op when the model exists. `CREATE OR REPLACE MODEL` replaces it. A missing
+  parent dataset errors `notFound` (HTTP 404).
+- **Result.** Zero result rows; `statistics.query.statementType` is
+  `CREATE_MODEL`. The exact additional `statistics.query` fields are pinned by
+  conformance recording (see *Parity model*).
+
+### ML.PREDICT
+
+- **Model resolution.** The `MODEL ref` is resolved against the catalog. A
+  missing model errors the way BigQuery does (`notFound`, HTTP 404).
+- **Execution.** The input query (subquery or `TABLE`) runs through the normal
+  pipeline. Output is the input rows with prediction column(s) appended, named to
+  match BigQuery's shape for the model's task (for example `predicted_<label>`
+  for a regressor). Input columns are preserved (passthrough).
+- **Values.** Prediction values are **deterministic and intentionally not
+  plausible real predictions** (so they are never mistaken for accurate output).
+  The exact placeholder is fixed and documented. Row count equals the input row
+  count.
+
+### Models REST resource
+
+`/bigquery/v2/projects/{projectId}/datasets/{datasetId}/models[/{modelId}]` with
+`list`, `get`, `patch`, `delete`, modeled on the existing Routines resource
+(`src/bqemulator/api/routes/routines.py`). **No `insert`** (the real API has
+none; models are born from `CREATE MODEL` jobs). The wire resource uses
+`modelReference` (`projectId` / `datasetId` / `modelId`), `modelType`,
+`creationTime`, `lastModifiedTime`, `etag`, and the derived `featureColumns` /
+`labelColumns`. Patch coalesces the mutable fields BigQuery allows (description,
+labels, expirationTime). The resource is REST-only; there is no gRPC Models
+service in BigQuery, so the gRPC adapter is untouched.
+
+### Catalog + persistence
+
+A new frozen `ModelMeta` catalog entity (dataset-scoped, keyed
+`(project_id, dataset_id, model_id)`) is added with `list/get/create/update/
+delete_models` repository methods across the in-memory and DuckDB-backed
+implementations, a new `_bqemulator_catalog.models` table for persistence, and
+cascade-delete when the parent dataset is dropped with `delete_contents=true`.
+The REST resource has no create endpoint; `create_model` exists for the
+`CREATE MODEL` job and test seeding.
+
+### Parity model
+
+The surface that BigQuery returns **shape-identically regardless of training** is
+recorded faithfully from real BigQuery and asserted exactly:
+
+- the Models REST resource shape (`list` / `get`),
+- the `CREATE MODEL` job resource and `statementType`,
+- the `ML.PREDICT` output **column shape** (names, order, types),
+- the error envelopes (model not found, duplicate, invalid OPTIONS, missing
+  dataset).
+
+The one place the emulator cannot match BigQuery is the **numeric value** of
+`ML.PREDICT` predictions. Those fixtures are recorded from real BigQuery and
+pinned as a documented divergence in
+`tests/conformance/divergences.py` (`pytest.mark.xfail(strict=True)`, citing
+ADR 0047), exactly as other deliberate divergences are handled
+([ADR 0023](../adr/0023-conformance-divergence-baseline.md)). When a future RFC
+adds real classical-model inference, removing that divergence entry makes the
+fixture pass on the next run.
+
+## Drawbacks
+
+- **Predictions are fake.** `ML.PREDICT` returns placeholder values. This is the
+  defining limitation of the surface-only scope; it is mitigated by making the
+  values obviously non-real and documenting it prominently, but a user who does
+  not read the docs could be surprised. The alternative (no `ML.PREDICT` at all)
+  is worse for pipeline testing.
+- **Partial parity is a sharper edge than a clean 501.** A hard
+  `UnsupportedFeatureError` is unambiguous; a statement that "works" but returns
+  fake numbers requires the user to understand the boundary. The divergence
+  registry and docs callouts carry that weight.
+- **Scope-creep gravity.** Once `CREATE MODEL` registers metadata, the natural
+  pull is toward real training (Option B). This RFC draws the line explicitly and
+  leaves training to a separate, future RFC.
+- **Surface coupling.** `CREATE MODEL` reuses the inner-query pipeline and the
+  `EXPORT DATA` interception pattern; a regression in that shared path could
+  affect models. Mitigated by tests on both standalone and scripted paths.
+
+## Rationale and alternatives
+
+- **Surface-only first** (chosen) vs. full BQML vs. nothing. Full BQML training
+  is comparable in effort to the rest of the emulator
+  ([ADR 0012](../adr/0012-bqml-out-of-scope.md)) and is not undertaken here.
+  Surface-only unblocks the most common local-testing needs (SQL parsing, Models
+  API, pipeline shape) at a fraction of the cost and lays the architecture for a
+  later accuracy slice.
+- **AST interception pre-translation** (chosen) vs. translator keyword pass vs. a
+  new REST job type. The chosen point preserves OPTIONS from the AST, runs the
+  inner query through the real pipeline, and covers standalone and scripted
+  statements with one path, exactly as `EXPORT DATA` does.
+- **Obviously-non-real placeholder values** (chosen) vs. plausible-looking
+  numbers vs. NULL. A plausible number invites mistaking stubs for real output;
+  NULL collides with legitimately-null passthrough columns and hides the
+  prediction column's presence. A fixed, clearly-synthetic value is safest.
+- **Models REST without `insert`** (chosen, matches BigQuery) vs. adding an
+  `insert` for convenience. BigQuery has no `models.insert`; adding one would be
+  a non-parity invention.
+
+## Prior art
+
+- [ADR 0012](../adr/0012-bqml-out-of-scope.md): the original BQML out-of-scope
+  decision, which this RFC partially reverses (surface-only in; training out) and
+  whose inaccurate "Models insert is supported" claim it corrects.
+- [ADR 0043](../adr/0043-export-data-statement.md) / RFC 0001: the
+  pre-translation statement-interception pattern (`exp.Export`, dual-wired into
+  standalone and scripted paths) that this RFC reuses for `exp.Create(kind=MODEL)`
+  and `exp.Predict`.
+- [ADR 0023](../adr/0023-conformance-divergence-baseline.md): the documented
+  `xfail(strict=True)` divergence mechanism used here for `ML.PREDICT` values.
+- `src/bqemulator/api/routes/routines.py`: the dataset-scoped REST resource
+  template the Models resource mirrors.
+- Real BigQuery:
+  [Models REST resource](https://docs.cloud.google.com/bigquery/docs/reference/rest/v2/models),
+  [CREATE MODEL](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-create),
+  and
+  [ML.PREDICT](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-predict).
+
+## Unresolved questions
+
+- The exact `statistics.query` field set for a `CREATE_MODEL` job (beyond
+  `statementType`) and the precise `ML.PREDICT` output column names/types per
+  model task are resolved by conformance recording from real BigQuery, then fed
+  back into the implementation.
+- The precise fixed placeholder value for `ML.PREDICT` predictions (a sentinel
+  that is unambiguous yet type-compatible with the prediction column type).
+- Which OPTIONS BigQuery echoes back on the model resource versus which are
+  training-only and dropped.
+
+## Future possibilities
+
+- Real classical-model inference (linear/logistic regression, k-means) with
+  approximate-parity numeric output, via scikit-learn / statsmodels behind an
+  optional dependency extra (the "Option B" follow-on). This removes the
+  `ML.PREDICT`-value divergence for the covered model types.
+- `ML.EVALUATE`, `ML.WEIGHTS`, `ML.FEATURE_INFO`, `ML.TRAINING_INFO` over the
+  registered metadata.
+- `ML.GENERATE_*` (LLM-backed remote models) as a separate, network-dependent
+  surface.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -14,6 +14,17 @@ format, or governance go through an RFC before implementation.
 5. Accepted RFCs drive implementation PRs; the outcome is summarized in
    an ADR in `docs/adr/`.
 
+### Maintainer fast-track
+
+When a maintainer has already ratified a design before drafting (so the
+≥2-week review window would add no signal), the RFC may be accepted on a
+fast-track: it is authored with status `Accepted`, and implementation
+proceeds in the same phased PR series rather than waiting on a separate
+review cycle. A fast-tracked RFC says so in a note under its title and
+still records its implementation outcome in an ADR. This path is for
+maintainer-driven work with a pre-settled design; community-proposed RFCs
+follow the full lifecycle above.
+
 ## When to open an RFC
 
 - New public REST or gRPC endpoints

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -31,3 +31,4 @@ for the PR mechanics.
 | RFC | Title | Status |
 |---|---|---|
 | [0001](0001-export-data-statement.md) | EXPORT DATA statement (Cloud Storage) | Accepted |
+| [0002](0002-bigquery-ml-surface.md) | BigQuery ML surface (metadata, Models REST, ML.PREDICT shape) | Accepted |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -232,9 +232,11 @@ nav:
       - "0044 Adopt starlette 1.x (security) without adopting httpx2": adr/0044-starlette-1x-adoption.md
       - "0045 Autodetect schema inference via DuckDB": adr/0045-autodetect-schema-inference.md
       - "0046 Unified inner-query rewrite pipeline": adr/0046-unified-inner-query-pipeline.md
+      - "0047 BigQuery ML surface (metadata, Models REST, ML.PREDICT shape)": adr/0047-bigquery-ml-surface.md
   - RFCs:
       - Overview: rfcs/README.md
       - "0001 EXPORT DATA statement (Cloud Storage)": rfcs/0001-export-data-statement.md
+      - "0002 BigQuery ML surface (metadata, Models REST, ML.PREDICT shape)": rfcs/0002-bigquery-ml-surface.md
   - Examples:
       - Overview: examples/README.md
       - bq CLI quickstart: examples/bq-cli-quickstart/README.md


### PR DESCRIPTION
## What

First PR of the BigQuery ML **surface-only** workstream (the user's "Option C"). Docs-only, per the RFC gate for new SQL surface + public API. No code changes; this pins the contract that later PRs implement.

The slice (later PRs): `CREATE MODEL` registers model **metadata** (no training); the Models REST resource (`list`/`get`/`patch`/`delete`, matching BigQuery, which has **no** `insert`) serves it; `ML.PREDICT` returns correctly-**shaped** but deterministic, **non-real** output. Real training, evaluation, and prediction accuracy stay out of scope.

## Files

- **`docs/rfcs/0002-bigquery-ml-surface.md`** (new) — the RFC: scope, non-goals, the AST-interception architecture (`exp.Create(kind=MODEL)` + `exp.Predict`, dual-wired into standalone + scripted paths, mirroring `EXPORT DATA`), the parity model (record faithfully-recordable shapes; `ML.PREDICT` *values* are a documented divergence), and the placeholder semantics. Maintainer fast-track like RFC 0001.
- **`docs/adr/0047-bigquery-ml-surface.md`** (new) — implementation decisions; `Supersedes: 0012` in part.
- **`docs/adr/0012-bqml-out-of-scope.md`** — `Superseded by: 0047` status field + a correction of record: the "Models … insert … is supported" claim was never accurate (BigQuery has no `models.insert`, and the surface was unimplemented).
- **`docs/reference/out-of-scope.md`** — BQML section rewritten (heading kept `### BigQuery ML` to preserve the `#bigquery-ml` anchor that `compatibility-matrix.md` links to); surface-only now in scope, training/evaluation/accuracy still out.
- **`docs/rfcs/README.md`**, **`mkdocs.yml`** — register RFC 0002 and ADR 0047 in the nav.

## Why surface-only (not full BQML)

ADR 0012 ruled full BQML out for v1 (training ≈ the effort of the whole emulator) but left it "reconsiderable for v2." Surface-only unblocks the common local needs (SQL parsing, the Models API, pipeline shape) without a training runtime, and lays the architecture for a later accuracy slice (Option B).

## Verification (local)

- [x] `mkdocs build --strict` — clean (exit 0, no anchor warnings; `#bigquery-ml` anchor preserved).
- [x] `lychee` over all changed markdown — 61 OK, 0 errors.
- [x] `typos` — clean.
- [x] No em-dashes in authored prose; CHANGELOG untouched (release-time only).

## Workstream note

This is PR 0 of a multi-PR series, each < 1000 LOC and independently deployable: 1) Models REST + `ModelMeta` + repository, 2) `CREATE MODEL` interception, 3) `ML.PREDICT` interception, 4) conformance corpus + divergence, 5) e2e ×5, 6) guide + runnable example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded BigQuery ML out-of-scope guidance with clearer “surface-only” support, including deterministic placeholder `ML.PREDICT` outputs and the supported Models REST actions.
  * Updated RFC documentation to reflect the new “surface-only” scope and its Accepted status, plus maintainer fast-track guidance.
* **New Features**
  * Added an Accepted RFC defining “surface-only” BigQuery ML behavior for metadata registration, Models REST list/get/patch/delete, and `ML.PREDICT` output shape.
* **Chores**
  * Updated documentation navigation to include the new ADR and RFC entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->