### PR TITLE
feat(models): BigQuery ML Models REST resource + ModelMeta + repository

### DIFF
--- a/docs/reference/api-coverage.md
+++ b/docs/reference/api-coverage.md
@@ -18,7 +18,7 @@ committed inventory has drifted from the source.
 
 > **Auto-generated.** Edit route handlers under [`src/bqemulator/api/routes/`](https://github.com/jjviscomi/bqemulator/blob/main/src/bqemulator/api/routes/) (or the root-level health router under [`src/bqemulator/api/health.py`](https://github.com/jjviscomi/bqemulator/blob/main/src/bqemulator/api/health.py)) and run `make api-coverage` to regenerate this block. `make verify` calls `--check` to refuse merging a PR whose committed inventory has drifted from the live source. Endpoint counts in this block are facts about the codebase; ship-status (v1.0.0 release-quality across all surfaces) is asserted in the [compatibility matrix](compatibility-matrix.md) and gated by the conformance corpus on every PR.
 
-- **Total REST endpoints**: 42 across 9 route modules
+- **Total REST endpoints**: 46 across 10 route modules
 
 | Group | Path | Methods |
 |---|---|---|
@@ -40,6 +40,8 @@ committed inventory has drifted from the source.
 | Jobs | `/bigquery/v2/projects/{project_id}/jobs/{job_id}/delete` | DELETE |
 | Routines | `/bigquery/v2/projects/{project_id}/datasets/{dataset_id}/routines` | GET POST |
 | Routines | `/bigquery/v2/projects/{project_id}/datasets/{dataset_id}/routines/{routine_id}` | GET PUT PATCH DELETE |
+| Models | `/bigquery/v2/projects/{project_id}/datasets/{dataset_id}/models` | GET |
+| Models | `/bigquery/v2/projects/{project_id}/datasets/{dataset_id}/models/{model_id}` | GET PATCH DELETE |
 | RowAccessPolicies | `/bigquery/v2/projects/{project_id}/datasets/{dataset_id}/tables/{table_id}/rowAccessPolicies` | GET POST |
 | RowAccessPolicies | `/bigquery/v2/projects/{project_id}/datasets/{dataset_id}/tables/{table_id}/rowAccessPolicies:batchDelete` | POST |
 | RowAccessPolicies | `/bigquery/v2/projects/{project_id}/datasets/{dataset_id}/tables/{table_id}/rowAccessPolicies/{policy_id}` | GET PUT DELETE |

--- a/scripts/generate_api_coverage.py
+++ b/scripts/generate_api_coverage.py
@@ -230,6 +230,7 @@ def _group_label(source_file: str) -> str:
         "tabledata": "TableData",
         "jobs": "Jobs",
         "routines": "Routines",
+        "models": "Models",
         "row_access_policies": "RowAccessPolicies",
         "upload": "Upload host",
     }.get(stem, stem.title())
@@ -293,6 +294,7 @@ def _render_rest_table(endpoints: list[RestEndpoint]) -> str:
         "TableData",
         "Jobs",
         "Routines",
+        "Models",
         "RowAccessPolicies",
         "Upload host",
     ]

--- a/src/bqemulator/api/app.py
+++ b/src/bqemulator/api/app.py
@@ -23,6 +23,7 @@ from bqemulator.api.middleware import (
 )
 from bqemulator.api.routes.datasets import router as datasets_router
 from bqemulator.api.routes.jobs import router as jobs_router
+from bqemulator.api.routes.models import router as models_router
 from bqemulator.api.routes.projects import router as projects_router
 from bqemulator.api.routes.routines import router as routines_router
 from bqemulator.api.routes.row_access_policies import (
@@ -68,6 +69,7 @@ def create_app(context: AppContext) -> FastAPI:
     app.include_router(tables_router)
     app.include_router(tabledata_router)
     app.include_router(routines_router)
+    app.include_router(models_router)
     app.include_router(row_access_policies_router)
     app.include_router(jobs_router)
     # Upload host (multipart + resumable). Mounted at

--- a/src/bqemulator/api/routes/models.py
+++ b/src/bqemulator/api/routes/models.py
@@ -53,7 +53,9 @@ def _to_millis(value: datetime) -> str:
 
 
 def _from_millis(value: str | int) -> datetime:
-    """Parse a BigQuery millisecond-epoch value into a UTC datetime."""
+    """Parse a millisecond-epoch string/int into a UTC datetime (rejects bool/float)."""
+    if isinstance(value, bool) or not isinstance(value, str | int):
+        raise TypeError("expirationTime must be a string or integer")
     return datetime.fromtimestamp(int(value) / 1000, tz=UTC)
 
 

--- a/src/bqemulator/api/routes/models.py
+++ b/src/bqemulator/api/routes/models.py
@@ -41,11 +41,6 @@ router = APIRouter(prefix="/bigquery/v2", tags=["models"])
 
 _Ctx = Annotated[AppContext, Depends(get_context)]
 
-#: Default page size when a client does not supply ``maxResults``. Mirrors
-#: the datasets route's generous default so a single page returns every
-#: model in any realistic local dataset.
-_DEFAULT_PAGE_SIZE = 1000
-
 
 # ---------------------------------------------------------------------------
 # Serialization helpers
@@ -208,6 +203,8 @@ async def patch_model(
 ) -> dict[str, Any]:
     """Partial update of a model's mutable metadata."""
     body = await request.json()
+    if not isinstance(body, dict):
+        raise ValidationError("Request body must be a JSON object")
     # Read-modify-write under the lock so concurrent PATCHes can't lose updates.
     async with ctx.engine.write_lock():
         existing = ctx.catalog.get_model(project_id, dataset_id, model_id)

--- a/src/bqemulator/api/routes/models.py
+++ b/src/bqemulator/api/routes/models.py
@@ -1,0 +1,217 @@
+"""Models (BigQuery ML) REST routes.
+
+Endpoints:
+    GET    /bigquery/v2/projects/{p}/datasets/{d}/models           — list
+    GET    /bigquery/v2/projects/{p}/datasets/{d}/models/{m}       — get
+    PATCH  /bigquery/v2/projects/{p}/datasets/{d}/models/{m}       — patch
+    DELETE /bigquery/v2/projects/{p}/datasets/{d}/models/{m}       — delete
+
+The BigQuery Models REST resource has **no** ``insert`` method — models
+are created only by ``CREATE MODEL`` jobs (wired in a later change).
+Only the mutable fields documented by the official client
+(``description``, ``friendlyName``, ``labels``, ``expirationTime``,
+``encryptionConfiguration``) are accepted on ``PATCH``; ``modelType``,
+``featureColumns``, ``labelColumns``, ``creationTime``, and ``location``
+are read-only and carried through unchanged. See ADR 0047 / RFC 0002 for
+the surface-only BigQuery ML scope.
+
+Reference:
+    https://docs.cloud.google.com/bigquery/docs/reference/rest/v2/models
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Request, Response, status
+
+from bqemulator.api.dependencies import AppContext, get_context
+from bqemulator.api.routes._rest_helpers import body_or_existing
+from bqemulator.catalog.etag import generate_etag
+from bqemulator.catalog.models import ModelMeta
+from bqemulator.domain.errors import ResourceRef, resource_not_found
+
+router = APIRouter(prefix="/bigquery/v2", tags=["models"])
+
+_Ctx = Annotated[AppContext, Depends(get_context)]
+
+#: Default page size when a client does not supply ``maxResults``. Mirrors
+#: the datasets route's generous default so a single page returns every
+#: model in any realistic local dataset.
+_DEFAULT_PAGE_SIZE = 1000
+
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_millis(value: datetime) -> str:
+    """Render a datetime as BigQuery's millisecond-epoch string."""
+    return str(int(value.timestamp() * 1000))
+
+
+def _from_millis(value: str | int) -> datetime:
+    """Parse a BigQuery millisecond-epoch value into a UTC datetime."""
+    return datetime.fromtimestamp(int(value) / 1000, tz=UTC)
+
+
+def _model_to_rest(m: ModelMeta) -> dict[str, Any]:
+    """Serialize a :class:`ModelMeta` to the BigQuery REST shape.
+
+    Emits only documented BigQuery fields. ``training_query`` is internal
+    provenance and is intentionally never surfaced. A top-level ``kind``
+    is intentionally omitted: the documented Model resource carries none,
+    and the conformance corpus (recorded from real BigQuery) is the
+    source of truth for the exact response envelope.
+    """
+    body: dict[str, Any] = {
+        "etag": m.etag,
+        "modelReference": {
+            "projectId": m.project_id,
+            "datasetId": m.dataset_id,
+            "modelId": m.model_id,
+        },
+        "creationTime": _to_millis(m.creation_time),
+        "lastModifiedTime": _to_millis(m.last_modified_time),
+        "modelType": m.model_type,
+        "location": m.location,
+    }
+    if m.friendly_name:
+        body["friendlyName"] = m.friendly_name
+    if m.description:
+        body["description"] = m.description
+    if m.labels:
+        body["labels"] = dict(m.labels)
+    if m.expiration_time is not None:
+        body["expirationTime"] = _to_millis(m.expiration_time)
+    if m.feature_columns:
+        body["featureColumns"] = [dict(c) for c in m.feature_columns]
+    if m.label_columns:
+        body["labelColumns"] = [dict(c) for c in m.label_columns]
+    if m.encryption_configuration is not None:
+        body["encryptionConfiguration"] = dict(m.encryption_configuration)
+    return body
+
+
+def _patched_expiration(body: dict[str, Any], existing: ModelMeta) -> datetime | None:
+    """Resolve ``expirationTime`` for a PATCH, honouring explicit null.
+
+    A body value of ``null`` clears the expiry; an absent key leaves the
+    existing value untouched; a millis value sets it.
+    """
+    if "expirationTime" not in body:
+        return existing.expiration_time
+    raw = body["expirationTime"]
+    return None if raw is None else _from_millis(raw)
+
+
+def _rest_to_model_meta(
+    body: dict[str, Any],
+    clock: Any,
+    existing: ModelMeta,
+) -> ModelMeta:
+    """Apply a PATCH body to an existing model, returning the updated meta.
+
+    Only the mutable fields are read from ``body``; every read-only field
+    (identity, ``model_type``, feature/label columns, ``location``,
+    ``creation_time``, training-query provenance) is preserved from
+    ``existing`` via :meth:`ModelMeta.model_copy`.
+    """
+    now = clock.now()
+    return existing.model_copy(
+        update={
+            "friendly_name": body_or_existing(
+                body, "friendlyName", existing, "friendly_name", None
+            ),
+            "description": body_or_existing(body, "description", existing, "description", None),
+            "labels": body_or_existing(body, "labels", existing, "labels", {}),
+            "expiration_time": _patched_expiration(body, existing),
+            "encryption_configuration": body_or_existing(
+                body, "encryptionConfiguration", existing, "encryption_configuration", None
+            ),
+            "last_modified_time": now,
+            "etag": generate_etag(
+                existing.project_id, existing.dataset_id, existing.model_id, str(now)
+            ),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/projects/{project_id}/datasets/{dataset_id}/models")
+def list_models(
+    project_id: str,
+    dataset_id: str,
+    ctx: _Ctx,
+) -> dict[str, Any]:
+    """List the models in a dataset.
+
+    Returns every model in a single ``models`` array, ordered by
+    ``model_id`` for a stable response. This mirrors BigQuery's
+    single-page ``ListModelsResponse`` (which carries ``models`` and an
+    optional ``nextPageToken``) for the page sizes a local emulator
+    serves; the codebase's other list endpoints do not paginate either.
+    """
+    models = sorted(
+        ctx.catalog.list_models(project_id, dataset_id),
+        key=lambda m: m.model_id,
+    )
+    return {"models": [_model_to_rest(m) for m in models]}
+
+
+@router.get("/projects/{project_id}/datasets/{dataset_id}/models/{model_id}")
+def get_model(
+    project_id: str,
+    dataset_id: str,
+    model_id: str,
+    ctx: _Ctx,
+) -> dict[str, Any]:
+    """Get a model by ID."""
+    m = ctx.catalog.get_model(project_id, dataset_id, model_id)
+    if m is None:
+        raise resource_not_found(ResourceRef("model", project_id, dataset_id, model_id))
+    return _model_to_rest(m)
+
+
+@router.patch("/projects/{project_id}/datasets/{dataset_id}/models/{model_id}")
+async def patch_model(
+    project_id: str,
+    dataset_id: str,
+    model_id: str,
+    request: Request,
+    ctx: _Ctx,
+) -> dict[str, Any]:
+    """Partial update of a model's mutable metadata."""
+    existing = ctx.catalog.get_model(project_id, dataset_id, model_id)
+    if existing is None:
+        raise resource_not_found(ResourceRef("model", project_id, dataset_id, model_id))
+    body = await request.json()
+    updated = _rest_to_model_meta(body, ctx.clock, existing)
+    async with ctx.engine.write_lock():
+        result = ctx.catalog.update_model(updated)
+    return _model_to_rest(result)
+
+
+@router.delete(
+    "/projects/{project_id}/datasets/{dataset_id}/models/{model_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_model(
+    project_id: str,
+    dataset_id: str,
+    model_id: str,
+    ctx: _Ctx,
+) -> Response:
+    """Delete a model."""
+    existing = ctx.catalog.get_model(project_id, dataset_id, model_id)
+    if existing is None:
+        raise resource_not_found(ResourceRef("model", project_id, dataset_id, model_id))
+    async with ctx.engine.write_lock():
+        ctx.catalog.delete_model(project_id, dataset_id, model_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/bqemulator/api/routes/models.py
+++ b/src/bqemulator/api/routes/models.py
@@ -54,7 +54,7 @@ def _to_millis(value: datetime) -> str:
 
 def _from_millis(value: str | int) -> datetime:
     """Parse a millisecond-epoch string/int into a UTC datetime (rejects bool/float)."""
-    if isinstance(value, bool) or not isinstance(value, str | int):
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
         raise TypeError("expirationTime must be a string or integer")
     return datetime.fromtimestamp(int(value) / 1000, tz=UTC)
 

--- a/src/bqemulator/api/routes/models.py
+++ b/src/bqemulator/api/routes/models.py
@@ -25,12 +25,17 @@ from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Request, Response, status
+from pydantic import ValidationError as PydanticValidationError
 
 from bqemulator.api.dependencies import AppContext, get_context
 from bqemulator.api.routes._rest_helpers import body_or_existing
 from bqemulator.catalog.etag import generate_etag
 from bqemulator.catalog.models import ModelMeta
-from bqemulator.domain.errors import ResourceRef, resource_not_found
+from bqemulator.domain.errors import (
+    ResourceRef,
+    ValidationError,
+    resource_not_found,
+)
 
 router = APIRouter(prefix="/bigquery/v2", tags=["models"])
 
@@ -60,11 +65,9 @@ def _from_millis(value: str | int) -> datetime:
 def _model_to_rest(m: ModelMeta) -> dict[str, Any]:
     """Serialize a :class:`ModelMeta` to the BigQuery REST shape.
 
-    Emits only documented BigQuery fields. ``training_query`` is internal
-    provenance and is intentionally never surfaced. A top-level ``kind``
-    is intentionally omitted: the documented Model resource carries none,
-    and the conformance corpus (recorded from real BigQuery) is the
-    source of truth for the exact response envelope.
+    Emits only documented BigQuery fields; the internal ``training_query``
+    provenance and a top-level ``kind`` are intentionally omitted (the
+    conformance corpus pins the exact envelope in a later change).
     """
     body: dict[str, Any] = {
         "etag": m.etag,
@@ -99,12 +102,19 @@ def _patched_expiration(body: dict[str, Any], existing: ModelMeta) -> datetime |
     """Resolve ``expirationTime`` for a PATCH, honouring explicit null.
 
     A body value of ``null`` clears the expiry; an absent key leaves the
-    existing value untouched; a millis value sets it.
+    existing value untouched; a millis value sets it. A non-numeric or
+    out-of-range value is rejected with a 400 rather than surfacing as a
+    500.
     """
     if "expirationTime" not in body:
         return existing.expiration_time
     raw = body["expirationTime"]
-    return None if raw is None else _from_millis(raw)
+    if raw is None:
+        return None
+    try:
+        return _from_millis(raw)
+    except (ValueError, TypeError, OverflowError, OSError) as exc:
+        raise ValidationError(f"Invalid expirationTime: {raw!r}") from exc
 
 
 def _rest_to_model_meta(
@@ -117,26 +127,37 @@ def _rest_to_model_meta(
     Only the mutable fields are read from ``body``; every read-only field
     (identity, ``model_type``, feature/label columns, ``location``,
     ``creation_time``, training-query provenance) is preserved from
-    ``existing`` via :meth:`ModelMeta.model_copy`.
+    ``existing``. The result is built through the validating constructor
+    (not ``model_copy``, which skips validation) so an ill-typed mutable
+    field — e.g. ``labels: null`` — is rejected with a 400 instead of
+    being persisted as a row that would later fail catalog hydration.
     """
     now = clock.now()
-    return existing.model_copy(
-        update={
-            "friendly_name": body_or_existing(
-                body, "friendlyName", existing, "friendly_name", None
-            ),
-            "description": body_or_existing(body, "description", existing, "description", None),
-            "labels": body_or_existing(body, "labels", existing, "labels", {}),
-            "expiration_time": _patched_expiration(body, existing),
-            "encryption_configuration": body_or_existing(
+    try:
+        return ModelMeta(
+            project_id=existing.project_id,
+            dataset_id=existing.dataset_id,
+            model_id=existing.model_id,
+            model_type=existing.model_type,
+            friendly_name=body_or_existing(body, "friendlyName", existing, "friendly_name", None),
+            description=body_or_existing(body, "description", existing, "description", None),
+            labels=body_or_existing(body, "labels", existing, "labels", {}),
+            location=existing.location,
+            expiration_time=_patched_expiration(body, existing),
+            feature_columns=existing.feature_columns,
+            label_columns=existing.label_columns,
+            encryption_configuration=body_or_existing(
                 body, "encryptionConfiguration", existing, "encryption_configuration", None
             ),
-            "last_modified_time": now,
-            "etag": generate_etag(
+            training_query=existing.training_query,
+            creation_time=existing.creation_time,
+            last_modified_time=now,
+            etag=generate_etag(
                 existing.project_id, existing.dataset_id, existing.model_id, str(now)
             ),
-        },
-    )
+        )
+    except PydanticValidationError as exc:
+        raise ValidationError("Invalid model patch body") from exc
 
 
 # ---------------------------------------------------------------------------
@@ -150,13 +171,11 @@ def list_models(
     dataset_id: str,
     ctx: _Ctx,
 ) -> dict[str, Any]:
-    """List the models in a dataset.
+    """List the models in a dataset, ordered by ``model_id``.
 
-    Returns every model in a single ``models`` array, ordered by
-    ``model_id`` for a stable response. This mirrors BigQuery's
-    single-page ``ListModelsResponse`` (which carries ``models`` and an
-    optional ``nextPageToken``) for the page sizes a local emulator
-    serves; the codebase's other list endpoints do not paginate either.
+    Returns a single ``models`` array, matching BigQuery's single-page
+    ``ListModelsResponse`` for the sizes a local emulator serves; the
+    codebase's other list endpoints do not paginate either.
     """
     models = sorted(
         ctx.catalog.list_models(project_id, dataset_id),

--- a/src/bqemulator/api/routes/models.py
+++ b/src/bqemulator/api/routes/models.py
@@ -6,8 +6,8 @@ Endpoints:
     PATCH  /bigquery/v2/projects/{p}/datasets/{d}/models/{m}       — patch
     DELETE /bigquery/v2/projects/{p}/datasets/{d}/models/{m}       — delete
 
-The BigQuery Models REST resource has **no** ``insert`` method — models
-are created only by ``CREATE MODEL`` jobs (wired in a later change).
+The BigQuery Models REST resource has **no** ``insert`` method: models
+are created only by ``CREATE MODEL`` jobs, not by this resource.
 Only the mutable fields documented by the official client
 (``description``, ``friendlyName``, ``labels``, ``expirationTime``,
 ``encryptionConfiguration``) are accepted on ``PATCH``; ``modelType``,
@@ -67,7 +67,7 @@ def _model_to_rest(m: ModelMeta) -> dict[str, Any]:
 
     Emits only documented BigQuery fields; the internal ``training_query``
     provenance and a top-level ``kind`` are intentionally omitted (the
-    conformance corpus pins the exact envelope in a later change).
+    conformance corpus is the source of truth for the exact envelope).
     """
     body: dict[str, Any] = {
         "etag": m.etag,
@@ -207,12 +207,13 @@ async def patch_model(
     ctx: _Ctx,
 ) -> dict[str, Any]:
     """Partial update of a model's mutable metadata."""
-    existing = ctx.catalog.get_model(project_id, dataset_id, model_id)
-    if existing is None:
-        raise resource_not_found(ResourceRef("model", project_id, dataset_id, model_id))
     body = await request.json()
-    updated = _rest_to_model_meta(body, ctx.clock, existing)
+    # Read-modify-write under the lock so concurrent PATCHes can't lose updates.
     async with ctx.engine.write_lock():
+        existing = ctx.catalog.get_model(project_id, dataset_id, model_id)
+        if existing is None:
+            raise resource_not_found(ResourceRef("model", project_id, dataset_id, model_id))
+        updated = _rest_to_model_meta(body, ctx.clock, existing)
         result = ctx.catalog.update_model(updated)
     return _model_to_rest(result)
 
@@ -228,9 +229,8 @@ async def delete_model(
     ctx: _Ctx,
 ) -> Response:
     """Delete a model."""
-    existing = ctx.catalog.get_model(project_id, dataset_id, model_id)
-    if existing is None:
-        raise resource_not_found(ResourceRef("model", project_id, dataset_id, model_id))
     async with ctx.engine.write_lock():
+        if ctx.catalog.get_model(project_id, dataset_id, model_id) is None:
+            raise resource_not_found(ResourceRef("model", project_id, dataset_id, model_id))
         ctx.catalog.delete_model(project_id, dataset_id, model_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/bqemulator/catalog/__init__.py
+++ b/src/bqemulator/catalog/__init__.py
@@ -20,6 +20,7 @@ from bqemulator.catalog.memory_repository import MemoryCatalogRepository
 from bqemulator.catalog.models import (
     DatasetMeta,
     JobMeta,
+    ModelMeta,
     RoutineMeta,
     TableMeta,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "DuckDBCatalogRepository",
     "JobMeta",
     "MemoryCatalogRepository",
+    "ModelMeta",
     "RoutineMeta",
     "TableMeta",
     "generate_etag",

--- a/src/bqemulator/catalog/duckdb_repository.py
+++ b/src/bqemulator/catalog/duckdb_repository.py
@@ -5,6 +5,7 @@ Stores metadata in tables under the reserved ``_bqemulator_catalog`` schema:
 * ``_bqemulator_catalog.datasets`` — DatasetMeta (one row per dataset).
 * ``_bqemulator_catalog.tables`` — TableMeta (one row per table).
 * ``_bqemulator_catalog.routines`` — RoutineMeta.
+* ``_bqemulator_catalog.models`` — ModelMeta.
 * ``_bqemulator_catalog.jobs`` — JobMeta.
 * ``_bqemulator_catalog.snapshots`` — SnapshotMeta.
 * ``_bqemulator_catalog.materialized_views`` — MaterializedViewMeta.
@@ -35,6 +36,7 @@ from bqemulator.catalog.models import (
     DatasetMeta,
     JobMeta,
     MaterializedViewMeta,
+    ModelMeta,
     PartitionMeta,
     RoutineMeta,
     RowAccessPolicyMeta,
@@ -96,6 +98,7 @@ class DuckDBCatalogRepository(CatalogRepository):
         self._hydrate_datasets()
         self._hydrate_tables()
         self._hydrate_routines()
+        self._hydrate_models()
         self._hydrate_jobs()
         self._hydrate_snapshots()
         self._hydrate_materialized_views()
@@ -105,6 +108,7 @@ class DuckDBCatalogRepository(CatalogRepository):
             datasets=len(self._cache._datasets),  # noqa: SLF001
             tables=len(self._cache._tables),  # noqa: SLF001
             routines=len(self._cache._routines),  # noqa: SLF001
+            models=len(self._cache._models),  # noqa: SLF001
         )
 
     def _surface_corruption(
@@ -177,6 +181,20 @@ class DuckDBCatalogRepository(CatalogRepository):
                 self._surface_corruption(table="routines", row_id=row_id, exc=exc)
                 continue
             self._cache._routines[(meta.project_id, meta.dataset_id, meta.routine_id)] = meta  # noqa: SLF001
+
+    def _hydrate_models(self) -> None:
+        rows = self._engine.execute(
+            f"SELECT project_id, dataset_id, model_id, metadata_json "
+            f'FROM "{CATALOG_SCHEMA}"."models"',
+        ).fetchall()
+        for project_id, dataset_id, model_id, raw in rows:
+            row_id = f"{project_id}.{dataset_id}.{model_id}"
+            try:
+                meta = ModelMeta.model_validate_json(raw)
+            except Exception as exc:  # noqa: BLE001
+                self._surface_corruption(table="models", row_id=row_id, exc=exc)
+                continue
+            self._cache._models[(meta.project_id, meta.dataset_id, meta.model_id)] = meta  # noqa: SLF001
 
     def _hydrate_jobs(self) -> None:
         rows = self._engine.execute(
@@ -375,6 +393,11 @@ class DuckDBCatalogRepository(CatalogRepository):
                 )
                 self._engine.execute(
                     f'DELETE FROM "{CATALOG_SCHEMA}"."routines" '
+                    f"WHERE project_id = ? AND dataset_id = ?",
+                    [project_id, dataset_id],
+                )
+                self._engine.execute(
+                    f'DELETE FROM "{CATALOG_SCHEMA}"."models" '
                     f"WHERE project_id = ? AND dataset_id = ?",
                     [project_id, dataset_id],
                 )
@@ -638,6 +661,80 @@ class DuckDBCatalogRepository(CatalogRepository):
                 routine.creation_time,
                 routine.last_modified_time,
                 routine.etag,
+            ],
+        )
+
+    # ------------------------------------------------------------------
+    # Models
+    # ------------------------------------------------------------------
+
+    def list_models(
+        self,
+        project_id: str,
+        dataset_id: str,
+    ) -> tuple[ModelMeta, ...]:
+        self.ensure_ready()
+        return self._cache.list_models(project_id, dataset_id)
+
+    def get_model(
+        self,
+        project_id: str,
+        dataset_id: str,
+        model_id: str,
+    ) -> ModelMeta | None:
+        self.ensure_ready()
+        return self._cache.get_model(project_id, dataset_id, model_id)
+
+    def create_model(self, model: ModelMeta) -> ModelMeta:
+        self.ensure_ready()
+        created = self._cache.create_model(model)
+        self._write_model(created)
+        return created
+
+    def update_model(self, model: ModelMeta) -> ModelMeta:
+        self.ensure_ready()
+        updated = self._cache.update_model(model)
+        self._write_model(updated)
+        return updated
+
+    def delete_model(
+        self,
+        project_id: str,
+        dataset_id: str,
+        model_id: str,
+        *,
+        not_found_ok: bool = False,
+    ) -> None:
+        self.ensure_ready()
+        had = self._cache.get_model(project_id, dataset_id, model_id) is not None
+        self._cache.delete_model(
+            project_id,
+            dataset_id,
+            model_id,
+            not_found_ok=not_found_ok,
+        )
+        if had:
+            self._engine.execute(
+                f'DELETE FROM "{CATALOG_SCHEMA}"."models" '
+                f"WHERE project_id = ? AND dataset_id = ? AND model_id = ?",
+                [project_id, dataset_id, model_id],
+            )
+
+    def _write_model(self, model: ModelMeta) -> None:
+        self._engine.execute(
+            f'INSERT OR REPLACE INTO "{CATALOG_SCHEMA}"."models" '
+            f"(project_id, dataset_id, model_id, model_type, "
+            f"metadata_json, creation_time, last_modified_time, etag) "
+            f"VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                model.project_id,
+                model.dataset_id,
+                model.model_id,
+                model.model_type,
+                model.model_dump_json(by_alias=True),
+                model.creation_time,
+                model.last_modified_time,
+                model.etag,
             ],
         )
 

--- a/src/bqemulator/catalog/memory_repository.py
+++ b/src/bqemulator/catalog/memory_repository.py
@@ -13,6 +13,7 @@ from bqemulator.catalog.models import (
     DatasetMeta,
     JobMeta,
     MaterializedViewMeta,
+    ModelMeta,
     PartitionMeta,
     RoutineMeta,
     RowAccessPolicyMeta,
@@ -48,6 +49,7 @@ class MemoryCatalogRepository(CatalogRepository):
         self._datasets: dict[tuple[str, str], DatasetMeta] = {}
         self._tables: dict[tuple[str, str, str], TableMeta] = {}
         self._routines: dict[tuple[str, str, str], RoutineMeta] = {}
+        self._models: dict[tuple[str, str, str], ModelMeta] = {}
         self._jobs: dict[tuple[str, str], JobMeta] = {}
         self._snapshots: dict[str, SnapshotMeta] = {}
         self._mviews: dict[tuple[str, str, str], MaterializedViewMeta] = {}
@@ -101,13 +103,16 @@ class MemoryCatalogRepository(CatalogRepository):
             raise resource_not_found(ResourceRef("dataset", project_id, dataset_id))
 
         # Contents check — block the drop unless caller opted into
-        # cascade. Only tables + routines count toward "non-empty" for
-        # this gate; row-access policies / mviews / snapshots cascade
-        # silently because BigQuery itself doesn't surface them as
-        # blocking children.
+        # cascade. Tables, routines, and models count toward "non-empty"
+        # for this gate because they are top-level, user-visible dataset
+        # children (a bare ``bq rm`` / ``deleteContents=false`` fails on
+        # any of them in real BigQuery). Row-access policies / mviews /
+        # snapshots cascade silently because BigQuery does not surface
+        # them as blocking children.
         table_keys = self._keys_in_dataset(self._tables, project_id, dataset_id)
         routine_keys = self._keys_in_dataset(self._routines, project_id, dataset_id)
-        if (table_keys or routine_keys) and not delete_contents:
+        model_keys = self._keys_in_dataset(self._models, project_id, dataset_id)
+        if (table_keys or routine_keys or model_keys) and not delete_contents:
             raise NotFoundError(
                 f"Dataset {project_id}.{dataset_id} is not empty; "
                 "use delete_contents=True to cascade.",
@@ -124,6 +129,7 @@ class MemoryCatalogRepository(CatalogRepository):
         # in-memory catalog mirror needs its own cascade.
         self._delete_keys(self._tables, table_keys)
         self._delete_keys(self._routines, routine_keys)
+        self._delete_keys(self._models, model_keys)
         self._delete_keys(
             self._row_access,
             self._keys_in_dataset(self._row_access, project_id, dataset_id),
@@ -326,6 +332,58 @@ class MemoryCatalogRepository(CatalogRepository):
                 return
             raise resource_not_found(ResourceRef("routine", project_id, dataset_id, routine_id))
         del self._routines[key]
+
+    # -- Models -----------------------------------------------------------
+
+    def list_models(
+        self,
+        project_id: str,
+        dataset_id: str,
+    ) -> tuple[ModelMeta, ...]:
+        return tuple(
+            m for (p, d, _m), m in self._models.items() if p == project_id and d == dataset_id
+        )
+
+    def get_model(
+        self,
+        project_id: str,
+        dataset_id: str,
+        model_id: str,
+    ) -> ModelMeta | None:
+        return self._models.get((project_id, dataset_id, model_id))
+
+    def create_model(self, model: ModelMeta) -> ModelMeta:
+        key = (model.project_id, model.dataset_id, model.model_id)
+        if key in self._models:
+            raise resource_already_exists(ResourceRef("model", *key))
+        if (model.project_id, model.dataset_id) not in self._datasets:
+            raise resource_not_found(
+                ResourceRef("dataset", model.project_id, model.dataset_id),
+            )
+        self._models[key] = model
+        return model
+
+    def update_model(self, model: ModelMeta) -> ModelMeta:
+        key = (model.project_id, model.dataset_id, model.model_id)
+        if key not in self._models:
+            raise resource_not_found(ResourceRef("model", *key))
+        self._models[key] = model
+        return model
+
+    def delete_model(
+        self,
+        project_id: str,
+        dataset_id: str,
+        model_id: str,
+        *,
+        not_found_ok: bool = False,
+    ) -> None:
+        key = (project_id, dataset_id, model_id)
+        if key not in self._models:
+            if not_found_ok:
+                return
+            raise resource_not_found(ResourceRef("model", project_id, dataset_id, model_id))
+        del self._models[key]
 
     # -- Jobs -------------------------------------------------------------
 

--- a/src/bqemulator/catalog/migrations/m004_models.py
+++ b/src/bqemulator/catalog/migrations/m004_models.py
@@ -1,17 +1,10 @@
-"""BigQuery ML model catalog schema.
+"""BigQuery ML model catalog schema (ADR 0047 / RFC 0002).
 
-Adds the persistent ``_bqemulator_catalog.models`` table — one row per
-:class:`~bqemulator.catalog.models.ModelMeta`. Identity is
-``(project_id, dataset_id, model_id)``. The rich model fields
-(feature/label column shapes, labels, encryption, training-query
-provenance) live in the ``metadata_json`` column so they round-trip
-through JSON without a schema change; ``model_type`` and ``etag`` are
-promoted to dedicated columns to match the indexed-column convention
-used by the ``routines`` table.
-
-The DuckDB-backed catalog repository delegates reads to its in-memory
-cache and writes through to this table, exactly as it does for
-routines. See ADR 0047 / RFC 0002 for the surface-only BigQuery ML scope.
+Adds the persistent ``_bqemulator_catalog.models`` table, keyed by
+``(project_id, dataset_id, model_id)``. Rich fields live in
+``metadata_json`` so they evolve without a migration; ``model_type`` and
+``etag`` are promoted to dedicated columns, mirroring the ``routines``
+table convention.
 """
 
 from __future__ import annotations

--- a/src/bqemulator/catalog/migrations/m004_models.py
+++ b/src/bqemulator/catalog/migrations/m004_models.py
@@ -1,0 +1,49 @@
+"""BigQuery ML model catalog schema.
+
+Adds the persistent ``_bqemulator_catalog.models`` table — one row per
+:class:`~bqemulator.catalog.models.ModelMeta`. Identity is
+``(project_id, dataset_id, model_id)``. The rich model fields
+(feature/label column shapes, labels, encryption, training-query
+provenance) live in the ``metadata_json`` column so they round-trip
+through JSON without a schema change; ``model_type`` and ``etag`` are
+promoted to dedicated columns to match the indexed-column convention
+used by the ``routines`` table.
+
+The DuckDB-backed catalog repository delegates reads to its in-memory
+cache and writes through to this table, exactly as it does for
+routines. See ADR 0047 / RFC 0002 for the surface-only BigQuery ML scope.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bqemulator.storage.engine import CATALOG_SCHEMA
+
+if TYPE_CHECKING:  # pragma: no cover
+    from bqemulator.storage.engine import DuckDBEngine
+
+
+__all__ = ["DESCRIPTION", "VERSION", "up"]
+
+VERSION = 4
+DESCRIPTION = "BigQuery ML models catalog table"
+
+
+def up(engine: DuckDBEngine) -> None:
+    """Create the models catalog table."""
+    engine.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS "{CATALOG_SCHEMA}"."models" (
+            project_id VARCHAR NOT NULL,
+            dataset_id VARCHAR NOT NULL,
+            model_id VARCHAR NOT NULL,
+            model_type VARCHAR NOT NULL,
+            metadata_json VARCHAR NOT NULL,
+            creation_time TIMESTAMP WITH TIME ZONE NOT NULL,
+            last_modified_time TIMESTAMP WITH TIME ZONE NOT NULL,
+            etag VARCHAR NOT NULL,
+            PRIMARY KEY (project_id, dataset_id, model_id)
+        )
+        """,
+    )

--- a/src/bqemulator/catalog/migrations/m004_models.py
+++ b/src/bqemulator/catalog/migrations/m004_models.py
@@ -1,10 +1,10 @@
 """BigQuery ML model catalog schema (ADR 0047 / RFC 0002).
 
-Adds the persistent ``_bqemulator_catalog.models`` table, keyed by
+Defines the persistent ``_bqemulator_catalog.models`` table, keyed by
 ``(project_id, dataset_id, model_id)``. Rich fields live in
 ``metadata_json`` so they evolve without a migration; ``model_type`` and
-``etag`` are promoted to dedicated columns, mirroring the ``routines``
-table convention.
+``etag`` are dedicated columns, mirroring the ``routines`` table
+convention.
 """
 
 from __future__ import annotations

--- a/src/bqemulator/catalog/models.py
+++ b/src/bqemulator/catalog/models.py
@@ -335,6 +335,53 @@ class RoutineMeta(_Frozen):
 
 
 # ---------------------------------------------------------------------------
+# Model (BigQuery ML)
+# ---------------------------------------------------------------------------
+
+
+class ModelMeta(_Frozen):
+    """Metadata for a BigQuery ML model (surface-only registration).
+
+    The emulator registers a model's *metadata* so the Models REST
+    resource, ``CREATE MODEL`` DDL, and ``ML.PREDICT`` output *shape*
+    can be exercised locally. It does **not** train a model or store
+    learned weights — ``feature_columns`` / ``label_columns`` describe
+    the model's input/output *shape* only. See ADR 0047 / RFC 0002.
+
+    ``model_type`` is a free-form string rather than a closed
+    :data:`Literal`: BigQuery's ``modelType`` enum is large and grows
+    with each BQML release, and the surface registers any declared type
+    as metadata without interpreting it. The official client likewise
+    treats it as a plain string defaulting to ``MODEL_TYPE_UNSPECIFIED``.
+
+    ``feature_columns`` and ``label_columns`` are stored as opaque
+    ``StandardSqlField`` dicts (``{"name": ..., "type": {"typeKind":
+    ...}}``), mirroring how :class:`RoutineMeta` stores ``return_type``
+    and argument data types. ``training_query`` is bqemulator-internal
+    provenance (the ``AS SELECT`` text a ``CREATE MODEL`` was derived
+    from); it is persisted but never emitted in the REST representation,
+    which carries only documented BigQuery fields.
+    """
+
+    project_id: str
+    dataset_id: str
+    model_id: str
+    model_type: str = "MODEL_TYPE_UNSPECIFIED"
+    friendly_name: str | None = None
+    description: str | None = None
+    labels: dict[str, str] = Field(default_factory=dict)
+    location: str = "US"
+    expiration_time: datetime | None = None
+    feature_columns: tuple[dict[str, Any], ...] = ()
+    label_columns: tuple[dict[str, Any], ...] = ()
+    encryption_configuration: dict[str, Any] | None = None
+    training_query: str | None = None  # bqemulator provenance; not a REST field
+    creation_time: datetime
+    last_modified_time: datetime
+    etag: str
+
+
+# ---------------------------------------------------------------------------
 # Job
 # ---------------------------------------------------------------------------
 
@@ -369,6 +416,7 @@ __all__ = [
     "JobState",
     "JobType",
     "MaterializedViewMeta",
+    "ModelMeta",
     "PartitionMeta",
     "PartitionType",
     "RangePartitioning",

--- a/src/bqemulator/catalog/models.py
+++ b/src/bqemulator/catalog/models.py
@@ -340,27 +340,17 @@ class RoutineMeta(_Frozen):
 
 
 class ModelMeta(_Frozen):
-    """Metadata for a BigQuery ML model (surface-only registration).
+    """Surface-only metadata for a BigQuery ML model (ADR 0047 / RFC 0002).
 
-    The emulator registers a model's *metadata* so the Models REST
-    resource, ``CREATE MODEL`` DDL, and ``ML.PREDICT`` output *shape*
-    can be exercised locally. It does **not** train a model or store
-    learned weights — ``feature_columns`` / ``label_columns`` describe
-    the model's input/output *shape* only. See ADR 0047 / RFC 0002.
-
-    ``model_type`` is a free-form string rather than a closed
-    :data:`Literal`: BigQuery's ``modelType`` enum is large and grows
-    with each BQML release, and the surface registers any declared type
-    as metadata without interpreting it. The official client likewise
-    treats it as a plain string defaulting to ``MODEL_TYPE_UNSPECIFIED``.
-
-    ``feature_columns`` and ``label_columns`` are stored as opaque
-    ``StandardSqlField`` dicts (``{"name": ..., "type": {"typeKind":
-    ...}}``), mirroring how :class:`RoutineMeta` stores ``return_type``
-    and argument data types. ``training_query`` is bqemulator-internal
-    provenance (the ``AS SELECT`` text a ``CREATE MODEL`` was derived
-    from); it is persisted but never emitted in the REST representation,
-    which carries only documented BigQuery fields.
+    Registers a model's *metadata* only — no training, no learned
+    weights. ``model_type`` is a free-form string (BigQuery's enum is
+    large and evolving; the official client also treats it as a plain
+    string). ``feature_columns`` / ``label_columns`` are opaque
+    ``StandardSqlField`` dicts (``{"name", "type": {"typeKind"}}``)
+    describing input/output *shape* only, mirroring how
+    :class:`RoutineMeta` stores typed structures. ``training_query`` is
+    internal provenance (the ``CREATE MODEL`` ``AS SELECT`` text): it is
+    persisted but never emitted in the REST representation.
     """
 
     project_id: str

--- a/src/bqemulator/catalog/repository.py
+++ b/src/bqemulator/catalog/repository.py
@@ -24,6 +24,7 @@ from bqemulator.catalog.models import (
     DatasetMeta,
     JobMeta,
     MaterializedViewMeta,
+    ModelMeta,
     PartitionMeta,
     RoutineMeta,
     RowAccessPolicyMeta,
@@ -187,6 +188,45 @@ class CatalogRepository(Protocol):
         not_found_ok: bool = False,
     ) -> None:
         """Delete a routine."""
+        ...
+
+    # -- Models -----------------------------------------------------------
+
+    def list_models(self, project_id: str, dataset_id: str) -> tuple[ModelMeta, ...]:
+        """Return all models in the dataset (possibly empty)."""
+        ...
+
+    def get_model(
+        self,
+        project_id: str,
+        dataset_id: str,
+        model_id: str,
+    ) -> ModelMeta | None:
+        """Return the model or ``None``."""
+        ...
+
+    def create_model(self, model: ModelMeta) -> ModelMeta:
+        """Insert a new model. Raises AlreadyExistsError on conflict.
+
+        Internal entry point used by ``CREATE MODEL`` execution and test
+        seeding — the Models REST resource has no ``insert`` method, so
+        this is never reached from a public HTTP route.
+        """
+        ...
+
+    def update_model(self, model: ModelMeta) -> ModelMeta:
+        """Replace an existing model. Raises NotFoundError if absent."""
+        ...
+
+    def delete_model(
+        self,
+        project_id: str,
+        dataset_id: str,
+        model_id: str,
+        *,
+        not_found_ok: bool = False,
+    ) -> None:
+        """Delete a model."""
         ...
 
     # -- Jobs -------------------------------------------------------------

--- a/tests/property/test_model_rest_roundtrip.py
+++ b/tests/property/test_model_rest_roundtrip.py
@@ -1,0 +1,87 @@
+"""Hypothesis property tests for Model REST mapping.
+
+Two invariants of the Models REST adapter:
+
+* ``_model_to_rest`` preserves identity, declared type, and feature/label
+  column *shape*, and never leaks the internal training-query provenance.
+* An empty ``PATCH`` carries every read-only field through unchanged and
+  only advances ``lastModifiedTime``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from hypothesis import given
+from hypothesis import strategies as st
+import pytest
+
+from bqemulator.api.routes.models import _model_to_rest, _rest_to_model_meta
+from bqemulator.catalog.models import ModelMeta
+from bqemulator.domain.clock import FrozenClock
+
+pytestmark = pytest.mark.property
+
+_CREATED = datetime(2026, 4, 15, tzinfo=UTC)
+_PATCH_AT = datetime(2026, 5, 1, tzinfo=UTC)
+
+_IDENT = st.from_regex(r"^[a-z][a-z0-9_]{0,15}$", fullmatch=True)
+_COLUMN = st.builds(
+    lambda name, kind: {"name": name, "type": {"typeKind": kind}},
+    _IDENT,
+    st.sampled_from(["INT64", "FLOAT64", "STRING", "BOOL"]),
+)
+
+
+@st.composite
+def _models(draw: st.DrawFn) -> ModelMeta:
+    return ModelMeta(
+        project_id=draw(_IDENT),
+        dataset_id=draw(_IDENT),
+        model_id=draw(_IDENT),
+        model_type=draw(st.sampled_from(["MODEL_TYPE_UNSPECIFIED", "KMEANS", "ARIMA_PLUS"])),
+        description=draw(st.none() | st.text(max_size=20)),
+        friendly_name=draw(st.none() | st.text(max_size=20)),
+        labels=draw(st.dictionaries(_IDENT, _IDENT, max_size=3)),
+        feature_columns=draw(st.lists(_COLUMN, max_size=3).map(tuple)),
+        label_columns=draw(st.lists(_COLUMN, max_size=3).map(tuple)),
+        training_query=draw(st.none() | st.text(max_size=30)),
+        creation_time=_CREATED,
+        last_modified_time=_CREATED,
+        etag="etag-fixed",
+    )
+
+
+@given(model=_models())
+def test_model_to_rest_preserves_shape_and_hides_provenance(model: ModelMeta) -> None:
+    rest = _model_to_rest(model)
+    assert rest["modelReference"] == {
+        "projectId": model.project_id,
+        "datasetId": model.dataset_id,
+        "modelId": model.model_id,
+    }
+    assert rest["modelType"] == model.model_type
+    assert rest["etag"] == model.etag
+    assert rest["location"] == model.location
+    assert rest.get("featureColumns", []) == [dict(c) for c in model.feature_columns]
+    assert rest.get("labelColumns", []) == [dict(c) for c in model.label_columns]
+    # Internal provenance must never surface in the REST representation.
+    assert "training_query" not in rest
+    assert "trainingQuery" not in rest
+
+
+@given(model=_models())
+def test_empty_patch_preserves_read_only_fields(model: ModelMeta) -> None:
+    updated = _rest_to_model_meta({}, FrozenClock(_PATCH_AT), model)
+    # Read-only + (absent-from-body) mutable fields carry through verbatim.
+    assert updated.model_type == model.model_type
+    assert updated.feature_columns == model.feature_columns
+    assert updated.label_columns == model.label_columns
+    assert updated.location == model.location
+    assert updated.training_query == model.training_query
+    assert updated.creation_time == model.creation_time
+    assert updated.description == model.description
+    assert updated.friendly_name == model.friendly_name
+    assert updated.labels == model.labels
+    # Only the modification stamp advances.
+    assert updated.last_modified_time == _PATCH_AT

--- a/tests/unit/api/test_routes_models.py
+++ b/tests/unit/api/test_routes_models.py
@@ -85,7 +85,6 @@ def _seed_model(app: FastAPI, model_id: str = "m1", **overrides: object) -> Mode
         "label_columns": ({"name": "y", "type": {"typeKind": "FLOAT64"}},),
         "labels": {"team": "ds"},
         "description": "seed",
-        "training_query": "SELECT x, y FROM ds.t",
         "creation_time": NOW,
         "last_modified_time": NOW,
         "etag": f"etag-{model_id}",
@@ -172,6 +171,8 @@ class TestModelsPatch:
             {"friendlyName": 123},  # wrong type
             {"expirationTime": "not-a-number"},  # uncoercible
             {"expirationTime": "1e9999"},  # out of range
+            {"expirationTime": True},  # bool is an int subclass; reject it
+            {"expirationTime": 123.4},  # float would truncate silently
         ],
     )
     def test_invalid_patch_returns_400(

--- a/tests/unit/api/test_routes_models.py
+++ b/tests/unit/api/test_routes_models.py
@@ -165,6 +165,30 @@ class TestModelsPatch:
         r = client.patch(f"{_BASE}/nope", json={"description": "x"})
         assert r.status_code == 404
 
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"labels": None},  # null for a non-Optional field
+            {"labels": ["a", "b"]},  # wrong type
+            {"friendlyName": 123},  # wrong type
+            {"expirationTime": "not-a-number"},  # uncoercible
+            {"expirationTime": "1e9999"},  # out of range
+        ],
+    )
+    def test_invalid_patch_returns_400(
+        self,
+        client: TestClient,
+        body: dict[str, object],
+    ) -> None:
+        _seed_model(client.app)  # type: ignore[arg-type]
+        assert client.patch(f"{_BASE}/m1", json=body).status_code == 400
+
+    def test_rejected_patch_leaves_model_unchanged(self, client: TestClient) -> None:
+        # A rejected PATCH must not partially mutate or corrupt the model.
+        _seed_model(client.app)  # type: ignore[arg-type]
+        client.patch(f"{_BASE}/m1", json={"labels": None})
+        assert client.get(f"{_BASE}/m1").json()["labels"] == {"team": "ds"}
+
 
 class TestModelsDelete:
     def test_delete_then_404(self, client: TestClient) -> None:

--- a/tests/unit/api/test_routes_models.py
+++ b/tests/unit/api/test_routes_models.py
@@ -188,6 +188,10 @@ class TestModelsPatch:
         client.patch(f"{_BASE}/m1", json={"labels": None})
         assert client.get(f"{_BASE}/m1").json()["labels"] == {"team": "ds"}
 
+    def test_non_dict_patch_body_returns_400(self, client: TestClient) -> None:
+        _seed_model(client.app)  # type: ignore[arg-type]
+        assert client.patch(f"{_BASE}/m1", json=[1, 2]).status_code == 400
+
 
 class TestModelsDelete:
     def test_delete_then_404(self, client: TestClient) -> None:

--- a/tests/unit/api/test_routes_models.py
+++ b/tests/unit/api/test_routes_models.py
@@ -1,0 +1,176 @@
+"""Unit tests for /models REST routes.
+
+The Models resource has no ``insert`` route, so tests seed models
+directly through the catalog (the path ``CREATE MODEL`` will use) and
+then exercise list / get / patch / delete over HTTP.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+import pytest_asyncio
+
+from bqemulator.api.app import create_app
+from bqemulator.api.dependencies import AppContext
+from bqemulator.catalog.memory_repository import MemoryCatalogRepository
+from bqemulator.catalog.models import DatasetMeta, ModelMeta
+from bqemulator.config import Settings
+from bqemulator.domain.clock import FrozenClock
+from bqemulator.domain.events import EventBus
+from bqemulator.observability.metrics import MetricsRegistry
+from bqemulator.row_access.policy import RowAccessPolicyManager
+from bqemulator.storage.engine import DuckDBEngine
+from bqemulator.udf.runtime import UDFRegistry
+from bqemulator.versioning.snapshots import SnapshotManager
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime(2026, 4, 15, tzinfo=UTC)
+_BASE = "/bigquery/v2/projects/p/datasets/ds/models"
+
+
+@pytest_asyncio.fixture
+async def app(ephemeral_settings: Settings) -> AsyncIterator[FastAPI]:
+    engine = DuckDBEngine(ephemeral_settings)
+    await engine.start()
+    catalog = MemoryCatalogRepository()
+    events = EventBus()
+    ctx = AppContext(
+        settings=ephemeral_settings,
+        clock=FrozenClock(NOW),
+        engine=engine,
+        catalog=catalog,
+        metrics=MetricsRegistry(),
+        events=events,
+        udf_registry=UDFRegistry(ephemeral_settings),
+        snapshots=SnapshotManager(
+            engine=engine,
+            catalog=catalog,
+            clock=FrozenClock(NOW),
+            events=events,
+            retention_days=7,
+        ),
+        row_access=RowAccessPolicyManager(catalog=catalog, clock=FrozenClock(NOW)),
+    )
+    try:
+        yield create_app(ctx)
+    finally:
+        await engine.stop()
+
+
+def _seed_dataset(app: FastAPI, dataset_id: str = "ds") -> None:
+    app.state.context.catalog.create_dataset(
+        DatasetMeta(
+            project_id="p",
+            dataset_id=dataset_id,
+            creation_time=NOW,
+            last_modified_time=NOW,
+            etag="e",
+        ),
+    )
+
+
+def _seed_model(app: FastAPI, model_id: str = "m1", **overrides: object) -> ModelMeta:
+    fields: dict[str, object] = {
+        "project_id": "p",
+        "dataset_id": "ds",
+        "model_id": model_id,
+        "model_type": "LINEAR_REGRESSION",
+        "feature_columns": ({"name": "x", "type": {"typeKind": "FLOAT64"}},),
+        "label_columns": ({"name": "y", "type": {"typeKind": "FLOAT64"}},),
+        "labels": {"team": "ds"},
+        "description": "seed",
+        "training_query": "SELECT x, y FROM ds.t",
+        "creation_time": NOW,
+        "last_modified_time": NOW,
+        "etag": f"etag-{model_id}",
+    }
+    fields.update(overrides)
+    model = ModelMeta(**fields)  # type: ignore[arg-type]
+    return app.state.context.catalog.create_model(model)
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    _seed_dataset(app)
+    return TestClient(app)
+
+
+class TestModelsRead:
+    def test_list_empty(self, client: TestClient) -> None:
+        r = client.get(_BASE)
+        assert r.status_code == 200
+        assert r.json() == {"models": []}
+
+    def test_list_and_get(self, client: TestClient) -> None:
+        _seed_model(client.app)  # type: ignore[arg-type]
+        r = client.get(_BASE)
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body["models"]) == 1
+        assert "nextPageToken" not in body
+        assert body["models"][0]["modelReference"] == {
+            "projectId": "p",
+            "datasetId": "ds",
+            "modelId": "m1",
+        }
+
+        r = client.get(f"{_BASE}/m1")
+        assert r.status_code == 200
+        got = r.json()
+        assert got["modelType"] == "LINEAR_REGRESSION"
+        assert got["featureColumns"][0]["name"] == "x"
+        assert got["labelColumns"][0]["type"] == {"typeKind": "FLOAT64"}
+
+    def test_get_missing_404(self, client: TestClient) -> None:
+        r = client.get(f"{_BASE}/nope")
+        assert r.status_code == 404
+        assert r.json()["error"]["status"] == "NOT_FOUND"
+
+    def test_list_orders_by_model_id(self, client: TestClient) -> None:
+        _seed_model(client.app, "m2")  # type: ignore[arg-type]
+        _seed_model(client.app, "m1")  # type: ignore[arg-type]
+        ids = [m["modelReference"]["modelId"] for m in client.get(_BASE).json()["models"]]
+        assert ids == ["m1", "m2"]
+
+
+class TestModelsPatch:
+    def test_patch_updates_mutable_field(self, client: TestClient) -> None:
+        _seed_model(client.app)  # type: ignore[arg-type]
+        r = client.patch(f"{_BASE}/m1", json={"description": "updated", "friendlyName": "Churn"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["description"] == "updated"
+        assert body["friendlyName"] == "Churn"
+
+    def test_patch_ignores_read_only_model_type(self, client: TestClient) -> None:
+        _seed_model(client.app)  # type: ignore[arg-type]
+        r = client.patch(f"{_BASE}/m1", json={"modelType": "KMEANS"})
+        assert r.status_code == 200
+        assert r.json()["modelType"] == "LINEAR_REGRESSION"
+
+    def test_patch_sets_and_clears_expiration(self, client: TestClient) -> None:
+        _seed_model(client.app)  # type: ignore[arg-type]
+        r = client.patch(f"{_BASE}/m1", json={"expirationTime": "1799999999000"})
+        assert r.json()["expirationTime"] == "1799999999000"
+        r = client.patch(f"{_BASE}/m1", json={"expirationTime": None})
+        assert "expirationTime" not in r.json()
+
+    def test_patch_missing_404(self, client: TestClient) -> None:
+        r = client.patch(f"{_BASE}/nope", json={"description": "x"})
+        assert r.status_code == 404
+
+
+class TestModelsDelete:
+    def test_delete_then_404(self, client: TestClient) -> None:
+        _seed_model(client.app)  # type: ignore[arg-type]
+        assert client.delete(f"{_BASE}/m1").status_code == 204
+        assert client.get(f"{_BASE}/m1").status_code == 404
+
+    def test_delete_missing_404(self, client: TestClient) -> None:
+        assert client.delete(f"{_BASE}/nope").status_code == 404

--- a/tests/unit/api/test_routes_models.py
+++ b/tests/unit/api/test_routes_models.py
@@ -107,22 +107,16 @@ class TestModelsRead:
         assert r.status_code == 200
         assert r.json() == {"models": []}
 
-    def test_list_and_get(self, client: TestClient) -> None:
-        _seed_model(client.app)  # type: ignore[arg-type]
-        r = client.get(_BASE)
-        assert r.status_code == 200
-        body = r.json()
-        assert len(body["models"]) == 1
+    def test_list_orders_then_get(self, client: TestClient) -> None:
+        # Seed out of order; the list must come back sorted by model_id.
+        _seed_model(client.app, "m2")  # type: ignore[arg-type]
+        _seed_model(client.app, "m1")  # type: ignore[arg-type]
+        body = client.get(_BASE).json()
+        assert [m["modelReference"]["modelId"] for m in body["models"]] == ["m1", "m2"]
         assert "nextPageToken" not in body
-        assert body["models"][0]["modelReference"] == {
-            "projectId": "p",
-            "datasetId": "ds",
-            "modelId": "m1",
-        }
+        assert body["models"][0]["modelReference"]["projectId"] == "p"
 
-        r = client.get(f"{_BASE}/m1")
-        assert r.status_code == 200
-        got = r.json()
+        got = client.get(f"{_BASE}/m1").json()
         assert got["modelType"] == "LINEAR_REGRESSION"
         assert got["featureColumns"][0]["name"] == "x"
         assert got["labelColumns"][0]["type"] == {"typeKind": "FLOAT64"}
@@ -132,21 +126,26 @@ class TestModelsRead:
         assert r.status_code == 404
         assert r.json()["error"]["status"] == "NOT_FOUND"
 
-    def test_list_orders_by_model_id(self, client: TestClient) -> None:
-        _seed_model(client.app, "m2")  # type: ignore[arg-type]
-        _seed_model(client.app, "m1")  # type: ignore[arg-type]
-        ids = [m["modelReference"]["modelId"] for m in client.get(_BASE).json()["models"]]
-        assert ids == ["m1", "m2"]
-
 
 class TestModelsPatch:
-    def test_patch_updates_mutable_field(self, client: TestClient) -> None:
+    def test_patch_updates_mutable_fields(self, client: TestClient) -> None:
         _seed_model(client.app)  # type: ignore[arg-type]
-        r = client.patch(f"{_BASE}/m1", json={"description": "updated", "friendlyName": "Churn"})
+        enc = {"kmsKeyName": "projects/p/locations/us/keyRings/r/cryptoKeys/k"}
+        r = client.patch(
+            f"{_BASE}/m1",
+            json={
+                "description": "updated",
+                "friendlyName": "Churn",
+                "labels": {"env": "prod"},
+                "encryptionConfiguration": enc,
+            },
+        )
         assert r.status_code == 200
         body = r.json()
         assert body["description"] == "updated"
         assert body["friendlyName"] == "Churn"
+        assert body["labels"] == {"env": "prod"}
+        assert body["encryptionConfiguration"] == enc
 
     def test_patch_ignores_read_only_model_type(self, client: TestClient) -> None:
         _seed_model(client.app)  # type: ignore[arg-type]

--- a/tests/unit/catalog/test_duckdb_repository.py
+++ b/tests/unit/catalog/test_duckdb_repository.py
@@ -83,8 +83,11 @@ def _model(
         dataset_id=dataset,
         model_id=model,
         model_type="LINEAR_REGRESSION",
+        labels={"team": "ml"},
         feature_columns=({"name": "x", "type": {"typeKind": "FLOAT64"}},),
         label_columns=({"name": "y", "type": {"typeKind": "FLOAT64"}},),
+        encryption_configuration={"kmsKeyName": "projects/p/keys/k"},
+        expiration_time=NOW,
         training_query="SELECT x, y FROM p.sales.t",
         creation_time=NOW,
         last_modified_time=NOW,
@@ -196,10 +199,9 @@ async def test_model_crud_and_on_disk_persistence(persistent_settings: Settings)
     try:
         repo = DuckDBCatalogRepository(reopened)
         got = repo.get_model("p", "sales", "m1")
-        assert got is not None
-        assert got.description == "d"  # the update persisted across reopen
-        assert got.feature_columns == ({"name": "x", "type": {"typeKind": "FLOAT64"}},)
-        assert got.training_query == "SELECT x, y FROM p.sales.t"
+        # Full ModelMeta (including every metadata_json-backed field and the
+        # persisted update) round-trips through the on-disk reopen.
+        assert got == _model().model_copy(update={"description": "d"})
         repo.delete_model("p", "sales", "m1")
         assert repo.get_model("p", "sales", "m1") is None
     finally:

--- a/tests/unit/catalog/test_duckdb_repository.py
+++ b/tests/unit/catalog/test_duckdb_repository.py
@@ -170,8 +170,15 @@ async def test_routine_crud_roundtrips(ephemeral_settings: Settings) -> None:
 
 
 @pytest.mark.asyncio
-async def test_model_crud_roundtrips(ephemeral_settings: Settings) -> None:
-    engine = DuckDBEngine(ephemeral_settings)
+async def test_model_crud_and_on_disk_persistence(persistent_settings: Settings) -> None:
+    """Model CRUD writes through to DuckDB and survives an engine reopen.
+
+    Covers create/get/list/update write-through, then a fresh engine on
+    the same data directory rehydrating the full :class:`ModelMeta`
+    (opaque feature/label column shapes + internal training-query
+    provenance, and the persisted update), then delete write-through.
+    """
+    engine = DuckDBEngine(persistent_settings)
     await engine.start()
     try:
         repo = DuckDBCatalogRepository(engine)
@@ -179,32 +186,8 @@ async def test_model_crud_roundtrips(ephemeral_settings: Settings) -> None:
         m = repo.create_model(_model())
         assert repo.get_model("p", "sales", "m1") == m
         assert repo.list_models("p", "sales") == (m,)
-
-        updated = _model().model_copy(update={"description": "d"})
-        repo.update_model(updated)
+        repo.update_model(_model().model_copy(update={"description": "d"}))
         assert repo.get_model("p", "sales", "m1").description == "d"  # type: ignore[union-attr]
-
-        repo.delete_model("p", "sales", "m1")
-        assert repo.get_model("p", "sales", "m1") is None
-    finally:
-        await engine.stop()
-
-
-@pytest.mark.asyncio
-async def test_model_persists_across_engine_reopen(persistent_settings: Settings) -> None:
-    """A model written to disk rehydrates from a fresh engine + repo.
-
-    Exercises the on-disk persistence path end to end: a second engine
-    opened on the same data directory must reconstruct the full
-    :class:`ModelMeta` — including the opaque feature/label column shapes
-    and the internal training-query provenance — from the JSON column.
-    """
-    engine = DuckDBEngine(persistent_settings)
-    await engine.start()
-    try:
-        repo = DuckDBCatalogRepository(engine)
-        repo.create_dataset(_ds())
-        repo.create_model(_model())
     finally:
         await engine.stop()
 
@@ -214,9 +197,11 @@ async def test_model_persists_across_engine_reopen(persistent_settings: Settings
         repo = DuckDBCatalogRepository(reopened)
         got = repo.get_model("p", "sales", "m1")
         assert got is not None
-        assert got.model_type == "LINEAR_REGRESSION"
+        assert got.description == "d"  # the update persisted across reopen
         assert got.feature_columns == ({"name": "x", "type": {"typeKind": "FLOAT64"}},)
         assert got.training_query == "SELECT x, y FROM p.sales.t"
+        repo.delete_model("p", "sales", "m1")
+        assert repo.get_model("p", "sales", "m1") is None
     finally:
         await reopened.stop()
 

--- a/tests/unit/catalog/test_duckdb_repository.py
+++ b/tests/unit/catalog/test_duckdb_repository.py
@@ -15,6 +15,7 @@ from bqemulator.catalog.duckdb_repository import DuckDBCatalogRepository
 from bqemulator.catalog.models import (
     DatasetMeta,
     MaterializedViewMeta,
+    ModelMeta,
     RoutineMeta,
     RowAccessPolicyMeta,
     SnapshotMeta,
@@ -66,6 +67,25 @@ def _routine(
         routine_type="SCALAR_FUNCTION",
         language="SQL",
         definition_body="x",
+        creation_time=NOW,
+        last_modified_time=NOW,
+        etag="e",
+    )
+
+
+def _model(
+    project: str = "p",
+    dataset: str = "sales",
+    model: str = "m1",
+) -> ModelMeta:
+    return ModelMeta(
+        project_id=project,
+        dataset_id=dataset,
+        model_id=model,
+        model_type="LINEAR_REGRESSION",
+        feature_columns=({"name": "x", "type": {"typeKind": "FLOAT64"}},),
+        label_columns=({"name": "y", "type": {"typeKind": "FLOAT64"}},),
+        training_query="SELECT x, y FROM p.sales.t",
         creation_time=NOW,
         last_modified_time=NOW,
         etag="e",
@@ -150,6 +170,58 @@ async def test_routine_crud_roundtrips(ephemeral_settings: Settings) -> None:
 
 
 @pytest.mark.asyncio
+async def test_model_crud_roundtrips(ephemeral_settings: Settings) -> None:
+    engine = DuckDBEngine(ephemeral_settings)
+    await engine.start()
+    try:
+        repo = DuckDBCatalogRepository(engine)
+        repo.create_dataset(_ds())
+        m = repo.create_model(_model())
+        assert repo.get_model("p", "sales", "m1") == m
+        assert repo.list_models("p", "sales") == (m,)
+
+        updated = _model().model_copy(update={"description": "d"})
+        repo.update_model(updated)
+        assert repo.get_model("p", "sales", "m1").description == "d"  # type: ignore[union-attr]
+
+        repo.delete_model("p", "sales", "m1")
+        assert repo.get_model("p", "sales", "m1") is None
+    finally:
+        await engine.stop()
+
+
+@pytest.mark.asyncio
+async def test_model_persists_across_engine_reopen(persistent_settings: Settings) -> None:
+    """A model written to disk rehydrates from a fresh engine + repo.
+
+    Exercises the on-disk persistence path end to end: a second engine
+    opened on the same data directory must reconstruct the full
+    :class:`ModelMeta` — including the opaque feature/label column shapes
+    and the internal training-query provenance — from the JSON column.
+    """
+    engine = DuckDBEngine(persistent_settings)
+    await engine.start()
+    try:
+        repo = DuckDBCatalogRepository(engine)
+        repo.create_dataset(_ds())
+        repo.create_model(_model())
+    finally:
+        await engine.stop()
+
+    reopened = DuckDBEngine(persistent_settings)
+    await reopened.start()
+    try:
+        repo = DuckDBCatalogRepository(reopened)
+        got = repo.get_model("p", "sales", "m1")
+        assert got is not None
+        assert got.model_type == "LINEAR_REGRESSION"
+        assert got.feature_columns == ({"name": "x", "type": {"typeKind": "FLOAT64"}},)
+        assert got.training_query == "SELECT x, y FROM p.sales.t"
+    finally:
+        await reopened.stop()
+
+
+@pytest.mark.asyncio
 async def test_jobs_upsert_and_list(ephemeral_settings: Settings) -> None:
     from bqemulator.catalog.models import JobMeta
 
@@ -188,6 +260,7 @@ async def test_delete_dataset_not_found_ok(ephemeral_settings: Settings) -> None
         repo.delete_dataset("p", "missing", not_found_ok=True)
         repo.delete_table("p", "missing", "tbl", not_found_ok=True)
         repo.delete_routine("p", "missing", "r", not_found_ok=True)
+        repo.delete_model("p", "missing", "m", not_found_ok=True)
     finally:
         await engine.stop()
 
@@ -256,6 +329,7 @@ async def test_delete_dataset_cascades_through_persistent_tables(
                 last_refresh_time=NOW,
             ),
         )
+        repo.create_model(_model())
 
         # Drop the dataset — every dependent row should go with it.
         repo.delete_dataset("p", "sales", delete_contents=True)
@@ -264,6 +338,7 @@ async def test_delete_dataset_cascades_through_persistent_tables(
         assert repo.list_row_access_policies("p", "sales", "orders") == ()
         assert repo.list_snapshots_for_table("p", "sales", "orders") == ()
         assert repo.get_materialized_view("p", "sales", "orders_mv") is None
+        assert repo.list_models("p", "sales") == ()
 
         # The persistent DuckDB-side rows must also be cleared so a
         # fresh repo on the same engine doesn't rehydrate stale state.
@@ -271,5 +346,6 @@ async def test_delete_dataset_cascades_through_persistent_tables(
         assert rebuilt.list_row_access_policies("p", "sales", "orders") == ()
         assert rebuilt.list_snapshots_for_table("p", "sales", "orders") == ()
         assert rebuilt.get_materialized_view("p", "sales", "orders_mv") is None
+        assert rebuilt.list_models("p", "sales") == ()
     finally:
         await engine.stop()

--- a/tests/unit/catalog/test_memory_repository.py
+++ b/tests/unit/catalog/test_memory_repository.py
@@ -311,15 +311,6 @@ class TestModelCrud:
         with pytest.raises(NotFoundError):
             repo.create_model(make_model())
 
-    def test_crud_roundtrip(self) -> None:
-        repo = MemoryCatalogRepository()
-        repo.create_dataset(make_dataset())
-        m = repo.create_model(make_model())
-        assert repo.get_model("p", "sales", "churn") == m
-        assert repo.list_models("p", "sales") == (m,)
-        repo.delete_model("p", "sales", "churn")
-        assert repo.get_model("p", "sales", "churn") is None
-
     def test_create_duplicate_raises(self) -> None:
         repo = MemoryCatalogRepository()
         repo.create_dataset(make_dataset())

--- a/tests/unit/catalog/test_memory_repository.py
+++ b/tests/unit/catalog/test_memory_repository.py
@@ -14,6 +14,7 @@ from bqemulator.catalog.memory_repository import MemoryCatalogRepository
 from bqemulator.catalog.models import (
     DatasetMeta,
     MaterializedViewMeta,
+    ModelMeta,
     RoutineMeta,
     RowAccessPolicyMeta,
     SnapshotMeta,
@@ -48,6 +49,22 @@ def make_table(
         creation_time=NOW,
         last_modified_time=NOW,
         etag=f"etag-{table}",
+    )
+
+
+def make_model(
+    project: str = "p",
+    dataset: str = "sales",
+    model: str = "churn",
+) -> ModelMeta:
+    return ModelMeta(
+        project_id=project,
+        dataset_id=dataset,
+        model_id=model,
+        model_type="LOGISTIC_REGRESSION",
+        creation_time=NOW,
+        last_modified_time=NOW,
+        etag=f"etag-{model}",
     )
 
 
@@ -171,6 +188,24 @@ class TestDatasetCrud:
         repo.delete_dataset("p", "sales", delete_contents=True)
         assert repo.get_materialized_view("p", "sales", "orders_mv") is None
 
+    def test_delete_with_only_a_model_requires_cascade(self) -> None:
+        """A model is a blocking child, like a table or routine."""
+        repo = MemoryCatalogRepository()
+        repo.create_dataset(make_dataset())
+        repo.create_model(make_model())
+        with pytest.raises(NotFoundError):
+            repo.delete_dataset("p", "sales")
+
+    def test_delete_contents_cascades_models(self) -> None:
+        """``delete_dataset(delete_contents=True)`` must cascade to models."""
+        repo = MemoryCatalogRepository()
+        repo.create_dataset(make_dataset())
+        repo.create_model(make_model())
+        assert repo.list_models("p", "sales")
+
+        repo.delete_dataset("p", "sales", delete_contents=True)
+        assert repo.list_models("p", "sales") == ()
+
     def test_delete_contents_cascades_snapshots(self) -> None:
         """``delete_dataset(delete_contents=True)`` must cascade to snapshots."""
         repo = MemoryCatalogRepository()
@@ -268,6 +303,60 @@ class TestRoutineCrud:
         assert repo.list_routines("p", "sales") == (r,)
         repo.delete_routine("p", "sales", "SafeDivide")
         assert repo.get_routine("p", "sales", "SafeDivide") is None
+
+
+class TestModelCrud:
+    def test_create_requires_parent_dataset(self) -> None:
+        repo = MemoryCatalogRepository()
+        with pytest.raises(NotFoundError):
+            repo.create_model(make_model())
+
+    def test_crud_roundtrip(self) -> None:
+        repo = MemoryCatalogRepository()
+        repo.create_dataset(make_dataset())
+        m = repo.create_model(make_model())
+        assert repo.get_model("p", "sales", "churn") == m
+        assert repo.list_models("p", "sales") == (m,)
+        repo.delete_model("p", "sales", "churn")
+        assert repo.get_model("p", "sales", "churn") is None
+
+    def test_create_duplicate_raises(self) -> None:
+        repo = MemoryCatalogRepository()
+        repo.create_dataset(make_dataset())
+        repo.create_model(make_model())
+        with pytest.raises(AlreadyExistsError):
+            repo.create_model(make_model())
+
+    def test_update_replaces(self) -> None:
+        repo = MemoryCatalogRepository()
+        repo.create_dataset(make_dataset())
+        repo.create_model(make_model())
+        updated = make_model().model_copy(update={"description": "d"})
+        repo.update_model(updated)
+        got = repo.get_model("p", "sales", "churn")
+        assert got is not None and got.description == "d"
+
+    def test_update_missing_raises(self) -> None:
+        repo = MemoryCatalogRepository()
+        with pytest.raises(NotFoundError):
+            repo.update_model(make_model())
+
+    def test_list_scoped_by_dataset(self) -> None:
+        repo = MemoryCatalogRepository()
+        repo.create_dataset(make_dataset())
+        repo.create_dataset(make_dataset(dataset="other"))
+        repo.create_model(make_model())
+        repo.create_model(make_model(dataset="other", model="m2"))
+        assert {m.model_id for m in repo.list_models("p", "sales")} == {"churn"}
+
+    def test_delete_missing_raises_by_default(self) -> None:
+        repo = MemoryCatalogRepository()
+        with pytest.raises(NotFoundError):
+            repo.delete_model("p", "sales", "nope")
+
+    def test_delete_missing_not_found_ok(self) -> None:
+        repo = MemoryCatalogRepository()
+        repo.delete_model("p", "sales", "nope", not_found_ok=True)  # no raise
 
 
 class TestJobRegistry:

--- a/tests/unit/catalog/test_models.py
+++ b/tests/unit/catalog/test_models.py
@@ -9,6 +9,7 @@ import pytest
 from bqemulator.catalog.models import (
     DatasetMeta,
     JobMeta,
+    ModelMeta,
     RoutineArgument,
     RoutineMeta,
     TableFieldSchema,
@@ -135,6 +136,49 @@ class TestRoutineMeta:
         )
         assert r.language == "SQL"
         assert len(r.arguments) == 2
+
+
+class TestModelMeta:
+    def test_minimal_defaults(self) -> None:
+        m = ModelMeta(
+            project_id="p",
+            dataset_id="ml",
+            model_id="churn",
+            creation_time=NOW,
+            last_modified_time=NOW,
+            etag="e1",
+        )
+        assert m.model_type == "MODEL_TYPE_UNSPECIFIED"
+        assert m.location == "US"
+        assert m.labels == {}
+        assert m.feature_columns == ()
+        assert m.label_columns == ()
+        assert m.expiration_time is None
+        assert m.encryption_configuration is None
+        assert m.training_query is None
+
+    def test_full_surface_fields(self) -> None:
+        m = ModelMeta(
+            project_id="p",
+            dataset_id="ml",
+            model_id="churn",
+            model_type="LOGISTIC_REGRESSION",
+            friendly_name="Churn",
+            description="surface-only model",
+            labels={"team": "ds"},
+            feature_columns=({"name": "tenure", "type": {"typeKind": "FLOAT64"}},),
+            label_columns=({"name": "churned", "type": {"typeKind": "BOOL"}},),
+            encryption_configuration={"kmsKeyName": "projects/p/keys/k"},
+            training_query="SELECT tenure, churned FROM p.ml.customers",
+            expiration_time=NOW,
+            creation_time=NOW,
+            last_modified_time=NOW,
+            etag="e1",
+        )
+        assert m.model_type == "LOGISTIC_REGRESSION"
+        assert m.feature_columns[0]["name"] == "tenure"
+        assert m.label_columns[0]["type"] == {"typeKind": "BOOL"}
+        assert m.training_query == "SELECT tenure, churned FROM p.ml.customers"
 
 
 class TestJobMeta:


### PR DESCRIPTION
## Summary

Adds the surface-only BigQuery ML **Models** REST resource: a `ModelMeta`
catalog entity, repository CRUD across both the in-memory and DuckDB-backed
implementations, and the read-only `list` / `get` / `patch` / `delete` REST
routes. This is PR 1 of the BigQuery ML surface workstream defined in
[RFC 0002](docs/rfcs/0002-bigquery-ml-surface.md) / [ADR 0047](docs/adr/0047-bigquery-ml-surface.md).

## Motivation

Lets users register and inspect BigQuery ML model metadata locally, so the
Models API and downstream pipeline/workflow integration can be exercised
against the emulator. Real training and prediction accuracy remain out of
scope (Option B, a later workstream). `CREATE MODEL` DDL interception (which
populates these models) lands in PR 2; `ML.PREDICT` shape in PR 3.

## Changes

- `catalog/models.py`: frozen `ModelMeta` (identity, `model_type`, labels,
  description, location, expiration, feature/label column shapes as opaque
  StandardSqlField dicts, encryption config, and internal `training_query`
  provenance).
- `catalog/repository.py` + `memory_repository.py` + `duckdb_repository.py`:
  `list/get/create/update/delete_model`. `create_model` is internal (used by
  PR 2 + test seeding); there is **no** REST insert, matching BigQuery.
- `catalog/migrations/m004_models.py`: new `_bqemulator_catalog.models` table
  with write-through, hydration, and on-disk persistence.
- Dataset delete: models are blocking children, like tables and routines. A
  non-cascading delete fails when a model is present; a cascading delete
  purges models from both the in-memory cache and the persistent catalog.
- `api/routes/models.py`: `list` / `get` / `patch` / `delete`. `PATCH`
  accepts only the documented mutable fields (`description`, `friendlyName`,
  `labels`, `expirationTime`, `encryptionConfiguration`); `modelType`,
  feature/label columns, `location`, and `creationTime` are read-only.
  `training_query` is persisted but never surfaced in REST.
- `scripts/generate_api_coverage.py` + `docs/reference/api-coverage.md`:
  Models group registered and inventory regenerated (drift check passes).

## Verified decisions (no assumptions)

- **No `insert` route** and the exact field shapes verified against the
  installed `google-cloud-bigquery` client (`Model._PROPERTY_TO_API_FIELD`).
- **No top-level `kind`** is emitted: the documented Model resource carries
  none and the client ignores it. The exact response envelope (and any
  `kind`/`nextPageToken`) is pinned by the conformance corpus recorded from
  real BigQuery in PR 4.
- **List is single-page** (`{"models": [...]}`, ordered by `model_id`),
  matching BigQuery's single-page response for emulator-scale datasets and
  the codebase's other non-paginating list endpoints. Paging can be added in
  PR 4/5 if conformance shows it is needed.

## Testing

- [x] Unit tests added (`ModelMeta` shape; memory + DuckDB repo CRUD;
      dataset block + cascade; cross-engine on-disk persistence reopen; REST
      `list`/`get`/`patch`/`delete` with 404 parity and read-only immutability)
- [x] Property tests added (REST round-trip shape + provenance hiding; empty
      `PATCH` read-only preservation)
- [x] Integration surface exercised in-process via the full FastAPI app
      (`TestClient`) + real DuckDB engine; dedicated `tests/integration/`
      tier not needed for this catalog/REST slice
- [ ] E2E across client languages — deferred to PR 5 per RFC 0002
- [x] `make lint` passes (ruff, ruff format, mypy --strict, bandit,
      interrogate, typos), `make quality-complexity` (xenon B), and the full
      `tests/unit` + `tests/property` suite (3303 passed) pass locally
- [x] New-code coverage: `catalog/models.py` 100%; new memory-repo model
      methods + cascade fully covered. Engine-backed paths (REST endpoints,
      DuckDB repo) are exercised by passing tests but cannot be
      coverage-measured on this local Python 3.14 build — coverage's tracer
      breaks DuckDB's C-extension UDF registration, a hazard the repo already
      documents in `[tool.mutmut]`. CI (supported Python) is the enforcing
      authority for the 90%/70% gates.

## Documentation

- [x] Reference: `docs/reference/api-coverage.md` regenerated (auto)
- [x] ADR: covered by [ADR 0047](docs/adr/0047-bigquery-ml-surface.md) (PR 0)
- [ ] User guide + runnable example — deferred to PR 6 per RFC 0002

## Release hygiene

- [x] Catalog migration added (`m004_models`)
- [x] No `TODO` / `FIXME`
- [x] Conventional Commits
- [ ] `CHANGELOG.md` — N/A; this repo authors the changelog at release time
      only (no `[Unreleased]` section)
- Mutation scope unchanged: ADR 0026 intentionally defers FastAPI routes and
  repositories from the mutation pilot, which is exactly this PR's surface.

## Related

- Implements RFC 0002, ADR 0047 (BigQuery ML surface, PR 1 of 6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BigQuery ML **Models** REST support (list/get/patch/delete) scoped to project and dataset.
  * Models metadata is now end-to-end persisted (cache + DuckDB) and included in dataset cascade cleanup.
* **Bug Fixes**
  * PATCH updates only mutable fields, preserves read-only properties, regenerates `etag`, and enforces `expirationTime` semantics (absent vs `null` vs value).
  * Internal training-query provenance remains hidden from REST payloads.
* **Documentation**
  * Updated API coverage reference to include the new Models endpoints.
* **Tests**
  * Added property-based REST round-trip tests and expanded unit tests for routes and repository behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->