### PR TITLE
feat(sql): intercept ML.PREDICT as a surface-only passthrough rewrite

### DIFF
--- a/docs/reference/sql-function-mapping.md
+++ b/docs/reference/sql-function-mapping.md
@@ -51,7 +51,7 @@ table below maps each BigQuery view to its rewriter function.
 > **Auto-generated.** Edit translation rules under [`src/bqemulator/sql/rules/`](https://github.com/jjviscomi/bqemulator/blob/main/src/bqemulator/sql/rules/) or rewriters under [`src/bqemulator/sql/rewriter/`](https://github.com/jjviscomi/bqemulator/blob/main/src/bqemulator/sql/rewriter/), then run `make function-mapping` to regenerate this block. The CI gate (`--check`) refuses to merge a PR whose committed registry has drifted from the live source. Per-rule docstring summaries are extracted as the cell text — if a cell reads wrong, edit the rule's docstring.
 
 - **Registered rules**: 92 (13 rule modules)
-- **Rewriter functions**: 24 (24 rewriter modules; the INFORMATION_SCHEMA rewriter has its own hand-maintained per-view table below)
+- **Rewriter functions**: 25 (25 rewriter modules; the INFORMATION_SCHEMA rewriter has its own hand-maintained per-view table below)
 
 ### Translation rules (post-transpile AST passes)
 
@@ -177,6 +177,7 @@ table below maps each BigQuery view to its rewriter function.
 | Pre-translator (UNNEST STRUCT aliases) | Propagate named-struct field aliases inside `UNNEST([...])` arrays | — | `rewrite_unnest_struct` |
 | Pre-translator (wildcard tables) | Expand every wildcard table reference in `bq_sql` | — | `expand_wildcard_tables` |
 | Other rewriter | Return a no-op statement when `bq_sql` is `ALTER TABLE ... SET OPTIONS(...)` | — | `rewrite_alter_table_set_options` |
+| Other rewriter | Rewrite every `ML.PREDICT` table function into an equivalent subquery | — | `rewrite_ml_predict` |
 | Other rewriter | Pre-translate BigQuery SQL for every caller-identity spelling | — | `rewrite_session_user` |
 
 <!-- END AUTO-GENERATED RULE REGISTRY -->

--- a/src/bqemulator/sql/inner_query.py
+++ b/src/bqemulator/sql/inner_query.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING
 from bqemulator.domain.result import Err, Ok
 from bqemulator.sql.catalog_schema import build_catalog_schema
 from bqemulator.sql.rewriter.information_schema import expand_information_schema
+from bqemulator.sql.rewriter.ml_predict import rewrite_ml_predict
 from bqemulator.sql.rewriter.row_access_filter import rewrite_for_row_access
 from bqemulator.sql.rewriter.unnest_offset import rewrite_unnest_offset
 from bqemulator.sql.rewriter.wildcard_expander import expand_wildcard_tables
@@ -137,6 +138,11 @@ async def rewrite_and_translate_statement(
     """
     # Refresh any stale materialized views this statement reads.
     await refresh_dependent_mvs(project_id, bq_sql, ctx)
+    # Rewrite ML.PREDICT into a passthrough-plus-prediction subquery before
+    # the remaining passes, so its input query's tables flow through
+    # time-travel, row-access, INFORMATION_SCHEMA, and wildcard expansion
+    # like any other subquery (ADR 0047 / RFC 0002).
+    bq_sql = rewrite_ml_predict(bq_sql, project_id=project_id, catalog=ctx.catalog)
     # Resolve FOR SYSTEM_TIME AS OF before the translator runs.
     bq_sql = rewrite_for_system_time(bq_sql, project_id, ctx.snapshots, ctx.engine)
     # Enforce row access policies before any other rewrite.

--- a/src/bqemulator/sql/rewriter/ml_predict.py
+++ b/src/bqemulator/sql/rewriter/ml_predict.py
@@ -1,0 +1,154 @@
+"""``ML.PREDICT`` surface-only rewrite (ADR 0047 / RFC 0002).
+
+``ML.PREDICT(MODEL ref, (input_query | TABLE ref))`` is a surface-only
+construct: it resolves a registered model's metadata and returns the
+input rows unchanged plus a deterministic, explicitly non-real
+prediction column per label column. **No model is run.** The prediction
+value is a constant ``0.0`` (identical on every row, which genuine
+row-varying model output never is) and is documented as a stub
+everywhere it surfaces.
+
+This module turns the ``exp.Predict`` table function into an ordinary
+subquery *before* translation, so the surrounding query and the rest of
+the rewrite chain (row-access, ``INFORMATION_SCHEMA`` expansion,
+time-travel, wildcard expansion, BigQuery to DuckDB translation) need no
+special handling. Because it runs inside the shared
+:func:`bqemulator.sql.inner_query.rewrite_and_translate_statement`
+chain, standalone and scripted statements share one code path, exactly
+as ``EXPORT DATA`` and ``CREATE MODEL`` do.
+
+Scope (RFC 0002): the regression-shaped default ``predicted_<label>``
+(``FLOAT64``) per label column. Per-model-task output shapes
+(classifier probability arrays, k-means ``centroid_id``), exact column
+order, and the recorded prediction-value divergence are resolved by
+conformance recording in a later phase, not here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlglot
+from sqlglot import exp
+
+from bqemulator.domain.errors import ResourceRef, resource_not_found
+
+if TYPE_CHECKING:
+    from bqemulator.catalog.models import ModelMeta
+    from bqemulator.catalog.repository import CatalogRepository
+
+#: The deterministic, intentionally non-real prediction value (RFC 0002).
+#: Constant across every row, so it can never be mistaken for genuine,
+#: row-varying model output; documented as a stub wherever it appears.
+_STUB_PREDICTION = "CAST(0.0 AS FLOAT64)"
+
+#: Alias given to the wrapped input query inside the synthesised subquery.
+_INPUT_ALIAS = "_ml_predict_input"
+
+
+def rewrite_ml_predict(
+    bq_sql: str,
+    *,
+    project_id: str,
+    catalog: CatalogRepository,
+) -> str:
+    """Rewrite every ``ML.PREDICT`` table function into an equivalent subquery.
+
+    Returns ``bq_sql`` unchanged when it parses to no ``exp.Predict``
+    node (the common case) or fails to parse (a later layer reports the
+    error). Raises :func:`resource_not_found` (HTTP 404, ``notFound``)
+    when a referenced model is not registered, matching BigQuery.
+    """
+    if "predict" not in bq_sql.lower():
+        return bq_sql
+    try:
+        tree = sqlglot.parse_one(bq_sql, read="bigquery")
+    except Exception:  # noqa: BLE001 - parse failures fall through to later layers
+        return bq_sql
+
+    predicts = list(tree.find_all(exp.Predict))
+    if not predicts:
+        return bq_sql
+
+    for node in predicts:
+        target, alias_name = _replacement_target(node)
+        target.replace(
+            _predict_subquery(node, project_id=project_id, catalog=catalog, alias_name=alias_name)
+        )
+    return tree.sql(dialect="bigquery")
+
+
+def _replacement_target(node: exp.Predict) -> tuple[exp.Expression, str]:
+    """Return the node to replace and the alias to carry onto the subquery.
+
+    ``FROM ML.PREDICT(...) AS t`` wraps the ``Predict`` in a parent
+    ``exp.Table`` that holds the alias, so that wrapper is replaced and
+    its alias preserved. An unaliased ``ML.PREDICT`` is replaced in place.
+    """
+    parent = node.parent
+    if isinstance(parent, exp.Table) and parent.this is node:
+        return parent, parent.alias or ""
+    # sqlglot always wraps a FROM table function in exp.Table, so this
+    # in-place fallback only guards an unexpected future parse shape.
+    return node, ""  # pragma: no cover
+
+
+def _predict_subquery(
+    node: exp.Predict,
+    *,
+    project_id: str,
+    catalog: CatalogRepository,
+    alias_name: str,
+) -> exp.Subquery:
+    """Build the passthrough-plus-prediction subquery replacing one ``Predict``."""
+    model = _resolve_model(node.this, project_id=project_id, catalog=catalog)
+    projections = ["*", *(f"{_STUB_PREDICTION} AS {name}" for name in _predicted_columns(model))]
+    select = exp.select(*projections).from_(_input_from_clause(node.args.get("expression")))
+    return select.subquery(alias=alias_name) if alias_name else select.subquery()
+
+
+def _resolve_model(
+    model_ref: exp.Expression,
+    *,
+    project_id: str,
+    catalog: CatalogRepository,
+) -> ModelMeta:
+    """Resolve ``MODEL ref`` against the catalog or raise a BigQuery 404."""
+    model_id = model_ref.name
+    dataset_id = model_ref.args.get("db")
+    dataset_name = dataset_id.name if isinstance(dataset_id, exp.Identifier) else (dataset_id or "")
+    catalog_node = model_ref.args.get("catalog")
+    project_part = catalog_node.name if isinstance(catalog_node, exp.Identifier) else None
+    project = project_part or project_id
+    model = catalog.get_model(project, dataset_name, model_id) if dataset_name else None
+    if model is None:
+        raise resource_not_found(
+            ResourceRef("model", project, dataset_name or None, model_id or None)
+        )
+    return model
+
+
+def _predicted_columns(model: ModelMeta) -> list[str]:
+    """Return the ``predicted_<label>`` column name(s) for ``model``.
+
+    One per registered label column; falls back to a single generic
+    ``predicted`` column for a model with no label columns (an
+    unsupervised model whose exact output shape is out of scope here).
+    """
+    names = [f"predicted_{col['name']}" for col in model.label_columns if col.get("name")]
+    return names or ["predicted"]
+
+
+def _input_from_clause(expression: exp.Expression) -> str:
+    """Return the FROM-clause text for the ``ML.PREDICT`` input.
+
+    The input is either a subquery (``(SELECT ...)``), which is wrapped as an
+    aliased derived table so the passthrough ``*`` can read from it, or a
+    ``TABLE ref``, which is read directly.
+    """
+    if isinstance(expression, exp.Subquery):
+        return f"({expression.this.sql(dialect='bigquery')}) AS {_INPUT_ALIAS}"
+    return expression.sql(dialect="bigquery")
+
+
+__all__ = ["rewrite_ml_predict"]

--- a/src/bqemulator/sql/rewriter/ml_predict.py
+++ b/src/bqemulator/sql/rewriter/ml_predict.py
@@ -17,11 +17,11 @@ special handling. Because it runs inside the shared
 chain, standalone and scripted statements share one code path, exactly
 as ``EXPORT DATA`` and ``CREATE MODEL`` do.
 
-Scope (RFC 0002): the regression-shaped default ``predicted_<label>``
-(``FLOAT64``) per label column. Per-model-task output shapes
-(classifier probability arrays, k-means ``centroid_id``), exact column
-order, and the recorded prediction-value divergence are resolved by
-conformance recording in a later phase, not here.
+Scope (RFC 0002): this implements the regression-shaped default, one
+``predicted_<label>`` (``FLOAT64``) column per label column. Per-model-task
+output shapes (classifier probability arrays, k-means ``centroid_id``), exact
+column order, and prediction-value accuracy are out of scope: the values are
+deterministic stubs, never real predictions.
 """
 
 from __future__ import annotations
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 #: Constant across every row, so it can never be mistaken for genuine,
 #: row-varying model output; documented as a stub wherever it appears.
 _STUB_PREDICTION = "CAST(0.0 AS FLOAT64)"
+_STUB_NODE = sqlglot.parse_one(_STUB_PREDICTION, read="bigquery")
 
 #: Alias given to the wrapped input query inside the synthesised subquery.
 _INPUT_ALIAS = "_ml_predict_input"
@@ -105,9 +106,17 @@ def _predict_subquery(
     catalog: CatalogRepository,
     alias_name: str,
 ) -> exp.Subquery:
-    """Build the passthrough-plus-prediction subquery replacing one ``Predict``."""
+    """Build the passthrough-plus-prediction subquery replacing one ``Predict``.
+
+    Prediction columns are built as AST nodes with :func:`exp.to_identifier`
+    aliases so a label name needing quoting (spaces, punctuation) is escaped
+    safely rather than interpolated raw into the SQL text.
+    """
     model = _resolve_model(node.this, project_id=project_id, catalog=catalog)
-    projections = ["*", *(f"{_STUB_PREDICTION} AS {name}" for name in _predicted_columns(model))]
+    projections: list[exp.Expression | str] = ["*"]
+    projections.extend(
+        exp.alias_(_STUB_NODE.copy(), exp.to_identifier(name)) for name in _predicted_columns(model)
+    )
     select = exp.select(*projections).from_(_input_from_clause(node.args.get("expression")))
     return select.subquery(alias=alias_name) if alias_name else select.subquery()
 

--- a/src/bqemulator/sql/rewriter/ml_predict.py
+++ b/src/bqemulator/sql/rewriter/ml_predict.py
@@ -70,7 +70,12 @@ def rewrite_ml_predict(
     if not predicts:
         return bq_sql
 
-    for node in predicts:
+    # Rewrite deepest-first. A nested ML.PREDICT (one inside another's input
+    # query) must be rewritten before its parent: rewriting the parent first
+    # serialises the still-unrewritten inner call back into the generated SQL.
+    # ``find_all`` yields ancestors before descendants (DFS pre-order), so
+    # ``reversed`` gives children-before-parents.
+    for node in reversed(predicts):
         target, alias_name = _replacement_target(node)
         target.replace(
             _predict_subquery(node, project_id=project_id, catalog=catalog, alias_name=alias_name)

--- a/src/bqemulator/sql/translator.py
+++ b/src/bqemulator/sql/translator.py
@@ -64,11 +64,13 @@ _log = get_logger(__name__)
 # with a clear error instead of a confusing DuckDB parse failure.
 _UNSUPPORTED_KEYWORDS: frozenset[str] = frozenset(
     {
-        # ``CREATE MODEL`` is intercepted before translation (ADR 0047 /
-        # RFC 0002): the surface-only BigQuery ML path registers model
-        # metadata via ``jobs.executor.parse_create_model`` rather than
-        # failing here. The remaining ML.* constructs stay unsupported.
-        "ML.PREDICT",
+        # ``CREATE MODEL`` and ``ML.PREDICT`` are intercepted before
+        # translation (ADR 0047 / RFC 0002): the surface-only BigQuery ML
+        # path registers model metadata via
+        # ``jobs.executor.parse_create_model`` and rewrites ``ML.PREDICT``
+        # into a passthrough-plus-prediction subquery via
+        # ``sql.rewriter.ml_predict.rewrite_ml_predict`` rather than failing
+        # here. The remaining ML.* constructs stay unsupported.
         "ML.EVALUATE",
         "ML.FORECAST",
         "ML.GENERATE_TEXT",

--- a/tests/property/test_ml_predict_invariants.py
+++ b/tests/property/test_ml_predict_invariants.py
@@ -11,6 +11,7 @@ by the in-process tests in ``tests/unit/jobs/test_ml_predict.py``.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import re
 
 from hypothesis import given
 from hypothesis import strategies as st
@@ -69,9 +70,11 @@ def test_one_stub_per_label_and_input_preserved(labels: list[str]) -> None:
     # The rewrite is complete: no ML.PREDICT node survives to translation.
     assert not list(sqlglot.parse_one(out, read="bigquery").find_all(exp.Predict))
     # Exactly one deterministic stub column per label, each correctly named.
+    # Match whole alias tokens (not raw substrings) so a missing or duplicated
+    # alias is caught even for prefix-overlapping label names (e.g. "a", "aa").
     assert out.count("CAST(0.0 AS FLOAT64)") == len(labels)
-    for name in labels:
-        assert f"predicted_{name}" in out
+    predicted_aliases = re.findall(r"\bAS (predicted_\w+)", out)
+    assert sorted(predicted_aliases) == sorted(f"predicted_{name}" for name in labels)
     # The input query and the passthrough projection are preserved.
     assert "SELECT 1 AS x" in out
     assert "SELECT *" in out

--- a/tests/property/test_ml_predict_invariants.py
+++ b/tests/property/test_ml_predict_invariants.py
@@ -1,0 +1,77 @@
+"""Property invariants for the ``ML.PREDICT`` rewriter (RFC 0002 / ADR 0047).
+
+For any set of label columns, the rewrite is complete (no ``exp.Predict``
+survives), appends exactly one deterministic stub column per label, preserves
+the input query verbatim, and never drops the passthrough projection. These
+hold structurally, so they are checked against the pure rewriter without an
+engine. The execution-level row-count and passthrough invariants are pinned
+by the in-process tests in ``tests/unit/jobs/test_ml_predict.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from hypothesis import given
+from hypothesis import strategies as st
+import sqlglot
+from sqlglot import exp
+
+from bqemulator.catalog.memory_repository import MemoryCatalogRepository
+from bqemulator.catalog.models import DatasetMeta, ModelMeta
+from bqemulator.sql.rewriter.ml_predict import rewrite_ml_predict
+
+NOW = datetime(2026, 5, 16, tzinfo=UTC)
+
+#: Lowercase SQL-identifier-shaped label names (never collide with the input ``x``).
+_LABELS = st.lists(
+    st.from_regex(r"[a-z][a-z0-9_]{0,7}", fullmatch=True),
+    min_size=1,
+    max_size=4,
+    unique=True,
+)
+
+
+def _catalog_with_labels(labels: list[str]) -> MemoryCatalogRepository:
+    """Return a catalog with model ``p.ds.m`` carrying ``labels`` label columns."""
+    catalog = MemoryCatalogRepository()
+    catalog.create_dataset(
+        DatasetMeta(
+            project_id="p",
+            dataset_id="ds",
+            creation_time=NOW,
+            last_modified_time=NOW,
+            etag="e",
+        ),
+    )
+    catalog.create_model(
+        ModelMeta(
+            project_id="p",
+            dataset_id="ds",
+            model_id="m",
+            label_columns=tuple({"name": name, "type": {"typeKind": "FLOAT64"}} for name in labels),
+            creation_time=NOW,
+            last_modified_time=NOW,
+            etag="e",
+        ),
+    )
+    return catalog
+
+
+@given(labels=_LABELS)
+def test_one_stub_per_label_and_input_preserved(labels: list[str]) -> None:
+    """The rewrite appends one ``0.0`` stub per label and preserves the input."""
+    out = rewrite_ml_predict(
+        "SELECT * FROM ML.PREDICT(MODEL ds.m, (SELECT 1 AS x))",
+        project_id="p",
+        catalog=_catalog_with_labels(labels),
+    )
+    # The rewrite is complete: no ML.PREDICT node survives to translation.
+    assert not list(sqlglot.parse_one(out, read="bigquery").find_all(exp.Predict))
+    # Exactly one deterministic stub column per label, each correctly named.
+    assert out.count("CAST(0.0 AS FLOAT64)") == len(labels)
+    for name in labels:
+        assert f"predicted_{name}" in out
+    # The input query and the passthrough projection are preserved.
+    assert "SELECT 1 AS x" in out
+    assert "SELECT *" in out

--- a/tests/property/test_ml_predict_invariants.py
+++ b/tests/property/test_ml_predict_invariants.py
@@ -15,12 +15,15 @@ import re
 
 from hypothesis import given
 from hypothesis import strategies as st
+import pytest
 import sqlglot
 from sqlglot import exp
 
 from bqemulator.catalog.memory_repository import MemoryCatalogRepository
 from bqemulator.catalog.models import DatasetMeta, ModelMeta
 from bqemulator.sql.rewriter.ml_predict import rewrite_ml_predict
+
+pytestmark = pytest.mark.property
 
 NOW = datetime(2026, 5, 16, tzinfo=UTC)
 

--- a/tests/unit/api/test_routes_jobs.py
+++ b/tests/unit/api/test_routes_jobs.py
@@ -161,13 +161,15 @@ class TestJobsInsertEndpoint:
         assert r.json()["status"]["state"] == "DONE"
 
     def test_unsupported_bqml_returns_501(self, app: FastAPI) -> None:
+        # ``ML.PREDICT`` is now intercepted (ADR 0047 / RFC 0002); ``ML.EVALUATE``
+        # is still out of scope and must surface BigQuery's 501.
         c = TestClient(app, raise_server_exceptions=False)
         r = c.post(
             "/bigquery/v2/projects/p/jobs",
             json={
                 "configuration": {
                     "query": {
-                        "query": "SELECT * FROM ML.PREDICT(MODEL m, TABLE t)",
+                        "query": "SELECT * FROM ML.EVALUATE(MODEL m, TABLE t)",
                     },
                 },
             },

--- a/tests/unit/jobs/test_inner_query_error_boundary.py
+++ b/tests/unit/jobs/test_inner_query_error_boundary.py
@@ -142,10 +142,11 @@ async def test_unsupported_feature_translation_error_surfaces_unwrapped(
     with pytest.raises(UnsupportedFeatureError) as excinfo:
         await _run_single_sql(
             "p",
-            "SELECT * FROM ML.PREDICT(MODEL m, TABLE t)",
+            "SELECT * FROM ML.EVALUATE(MODEL m, TABLE t)",
             None,
             ctx,
             caller=_ANON,
         )
     # The unsupported feature itself is the cause, not some later failure.
-    assert "ML.PREDICT" in str(excinfo.value)
+    # (``ML.PREDICT`` is now intercepted; ``ML.EVALUATE`` stays unsupported.)
+    assert "ML.EVALUATE" in str(excinfo.value)

--- a/tests/unit/jobs/test_ml_predict.py
+++ b/tests/unit/jobs/test_ml_predict.py
@@ -1,0 +1,197 @@
+"""In-process tests for ``ML.PREDICT`` execution (RFC 0002 / ADR 0047).
+
+Exercises the surface-only ``ML.PREDICT`` path end-to-end against a real DuckDB
+engine (no mocking, per the project's testing contract): a model registered via
+``CREATE MODEL`` is predicted with, and the output is the input rows plus a
+deterministic ``predicted_<label>`` stub column (constant ``0.0``). Covers the
+subquery and ``TABLE`` input forms, passthrough preservation, the row-count
+invariant, model-not-found (404) parity, and the scripted (``BEGIN ... END``)
+path that proves the rewrite is dual-wired through the shared inner-query chain.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+
+import pytest
+
+from bqemulator.api.dependencies import AppContext
+from bqemulator.catalog.memory_repository import MemoryCatalogRepository
+from bqemulator.catalog.models import DatasetMeta
+from bqemulator.config import PersistenceMode, Settings
+from bqemulator.domain.clock import FrozenClock
+from bqemulator.domain.errors import NotFoundError
+from bqemulator.domain.events import EventBus
+from bqemulator.jobs.executor import JOB_RESULTS, JOB_SCHEMAS, execute_query_job
+from bqemulator.observability.metrics import MetricsRegistry
+from bqemulator.row_access.policy import RowAccessPolicyManager
+from bqemulator.storage.engine import DuckDBEngine
+from bqemulator.udf.runtime import UDFRegistry
+from bqemulator.versioning.snapshots import SnapshotManager
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime(2026, 5, 16, tzinfo=UTC)
+
+#: Register a regressor whose training query yields feature ``x`` + label ``label``.
+_CREATE = (
+    "CREATE MODEL ds.m OPTIONS(model_type='linear_reg', input_label_cols=['label']) "
+    "AS SELECT x, label FROM ds.t"
+)
+
+
+@asynccontextmanager
+async def _ctx() -> AsyncIterator[AppContext]:
+    """Yield an in-process ``AppContext`` with dataset ``p.ds`` + 3-row table ``p.ds.t``."""
+    settings = Settings(persistence_mode=PersistenceMode.EPHEMERAL, rest_port=0, grpc_port=0)  # type: ignore[arg-type]
+    engine = DuckDBEngine(settings)
+    await engine.start()
+    try:
+        catalog = MemoryCatalogRepository()
+        catalog.create_dataset(
+            DatasetMeta(
+                project_id="p",
+                dataset_id="ds",
+                creation_time=NOW,
+                last_modified_time=NOW,
+                etag="e",
+            ),
+        )
+        engine.execute('CREATE SCHEMA IF NOT EXISTS "p__ds"')
+        engine.execute(
+            'CREATE TABLE "p__ds"."t" AS '
+            "SELECT CAST(col0 AS DOUBLE) AS x, col1 AS label "
+            "FROM (VALUES (1.5, 'a'), (2.5, 'b'), (3.5, 'c'))",
+        )
+        yield AppContext(
+            settings=settings,
+            clock=FrozenClock(NOW),
+            engine=engine,
+            catalog=catalog,
+            metrics=MetricsRegistry(),
+            events=EventBus(),
+            udf_registry=UDFRegistry(settings),
+            snapshots=SnapshotManager(
+                engine=engine,
+                catalog=MemoryCatalogRepository(),
+                clock=FrozenClock(NOW),
+                events=EventBus(),
+                retention_days=7,
+            ),
+            row_access=RowAccessPolicyManager(catalog=catalog, clock=FrozenClock(NOW)),
+        )
+    finally:
+        await engine.stop()
+
+
+async def test_predict_subquery_appends_stub_column() -> None:
+    """``ML.PREDICT`` returns input rows plus a constant-0.0 ``predicted_<label>``."""
+    async with _ctx() as ctx:
+        await execute_query_job("p", "j-create", _CREATE, None, ctx)
+        await execute_query_job(
+            "p",
+            "j-pred",
+            "SELECT * FROM ML.PREDICT(MODEL ds.m, (SELECT x, label FROM ds.t))",
+            None,
+            ctx,
+        )
+        names = [f["name"] for f in JOB_SCHEMAS["j-pred"]]
+        result = JOB_RESULTS["j-pred"]
+        assert names == ["x", "label", "predicted_label"]
+        assert result.num_rows == 3
+        assert result.to_pydict()["predicted_label"] == [0.0, 0.0, 0.0]
+
+
+async def test_predict_table_form_preserves_passthrough() -> None:
+    """The ``TABLE ref`` input form preserves every input column plus the stub."""
+    async with _ctx() as ctx:
+        await execute_query_job("p", "j-create", _CREATE, None, ctx)
+        await execute_query_job(
+            "p",
+            "j-pred",
+            "SELECT * FROM ML.PREDICT(MODEL ds.m, TABLE ds.t)",
+            None,
+            ctx,
+        )
+        names = [f["name"] for f in JOB_SCHEMAS["j-pred"]]
+        assert names == ["x", "label", "predicted_label"]
+        assert JOB_RESULTS["j-pred"].num_rows == 3
+
+
+async def test_predict_predicted_column_type_is_float64() -> None:
+    """The appended ``predicted_<label>`` column is ``FLOAT64`` (same as feature ``x``).
+
+    Asserted against the type the emulator reports for the known-``FLOAT64``
+    passthrough column ``x`` rather than a hard-coded name, since the REST
+    schema uses BigQuery's legacy type spelling (``FLOAT``) for ``FLOAT64``.
+    """
+    async with _ctx() as ctx:
+        await execute_query_job("p", "j-create", _CREATE, None, ctx)
+        await execute_query_job(
+            "p",
+            "j-pred",
+            "SELECT * FROM ML.PREDICT(MODEL ds.m, (SELECT x, label FROM ds.t))",
+            None,
+            ctx,
+        )
+        types = {f["name"]: f["type"] for f in JOB_SCHEMAS["j-pred"]}
+        assert types["predicted_label"] == types["x"]
+
+
+@pytest.mark.parametrize("k", [0, 1, 3])
+async def test_predict_row_count_equals_input(k: int) -> None:
+    """The output row count equals the input row count (RFC 0002 invariant).
+
+    The 3-row seed table is sliced with ``LIMIT k`` to drive the input size.
+    """
+    async with _ctx() as ctx:
+        await execute_query_job("p", "j-create", _CREATE, None, ctx)
+        await execute_query_job(
+            "p",
+            f"j-pred-{k}",
+            f"SELECT * FROM ML.PREDICT(MODEL ds.m, (SELECT x, label FROM ds.t LIMIT {k}))",
+            None,
+            ctx,
+        )
+        assert JOB_RESULTS[f"j-pred-{k}"].num_rows == k
+
+
+async def test_predict_missing_model_raises_not_found() -> None:
+    """Predicting with an unregistered model surfaces BigQuery's 404 ``notFound``."""
+    async with _ctx() as ctx:
+        with pytest.raises(NotFoundError, match=r"model:p\.ds\.absent"):
+            await execute_query_job(
+                "p",
+                "j-pred",
+                "SELECT * FROM ML.PREDICT(MODEL ds.absent, (SELECT x FROM ds.t))",
+                None,
+                ctx,
+            )
+
+
+async def test_scripted_predict_is_dual_wired() -> None:
+    """A scripted ``ML.PREDICT`` flows through the shared rewrite (404 on missing model)."""
+    async with _ctx() as ctx:
+        with pytest.raises(NotFoundError, match=r"model:p\.ds\.absent"):
+            await execute_query_job(
+                "p",
+                "j-script",
+                "BEGIN\n  SELECT * FROM ML.PREDICT(MODEL ds.absent, (SELECT x FROM ds.t));\nEND",
+                None,
+                ctx,
+            )
+
+
+async def test_scripted_predict_runs_against_registered_model() -> None:
+    """A scripted ``ML.PREDICT`` on a registered model completes without error."""
+    async with _ctx() as ctx:
+        await execute_query_job("p", "j-create", _CREATE, None, ctx)
+        await execute_query_job(
+            "p",
+            "j-script",
+            "BEGIN\n  SELECT * FROM ML.PREDICT(MODEL ds.m, (SELECT x, label FROM ds.t));\nEND",
+            None,
+            ctx,
+        )

--- a/tests/unit/sql/rewriter/test_ml_predict.py
+++ b/tests/unit/sql/rewriter/test_ml_predict.py
@@ -111,6 +111,32 @@ class TestRewriteShape:
         assert "AS predicted FROM" in out
         assert "predicted_" not in out
 
+    def test_nested_ml_predict_both_levels_rewritten(self) -> None:
+        """A nested ``ML.PREDICT`` (inside another's input query) is fully rewritten.
+
+        Both levels must be rewritten deepest-first, or the outer rewrite would
+        serialise the un-rewritten inner call back into the generated SQL.
+        """
+        catalog = _catalog()
+        catalog.create_model(
+            ModelMeta(
+                project_id="p",
+                dataset_id="ds",
+                model_id="m2",
+                label_columns=_DEFAULT_LABELS,
+                creation_time=NOW,
+                last_modified_time=NOW,
+                etag="e",
+            ),
+        )
+        sql = (
+            "SELECT * FROM ML.PREDICT(MODEL ds.m, "
+            "(SELECT * FROM ML.PREDICT(MODEL ds.m2, (SELECT 1 AS x))))"
+        )
+        out = _rewrite(sql, catalog)
+        assert not _has_predict_node(out)
+        assert out.count("CAST(0.0 AS FLOAT64)") == 2
+
     def test_nested_in_cte(self) -> None:
         """``ML.PREDICT`` inside a CTE-bearing query is rewritten in place."""
         sql = "WITH s AS (SELECT 1 x) SELECT * FROM ML.PREDICT(MODEL ds.m, (SELECT * FROM s))"

--- a/tests/unit/sql/rewriter/test_ml_predict.py
+++ b/tests/unit/sql/rewriter/test_ml_predict.py
@@ -111,6 +111,13 @@ class TestRewriteShape:
         assert "AS predicted FROM" in out
         assert "predicted_" not in out
 
+    def test_label_name_requiring_quoting_is_escaped(self) -> None:
+        """A label name with special characters is safely quoted in the alias."""
+        catalog = _catalog(label_columns=({"name": "my col", "type": {"typeKind": "FLOAT64"}},))
+        out = _rewrite("SELECT * FROM ML.PREDICT(MODEL ds.m, (SELECT 1 AS x))", catalog)
+        assert "`predicted_my col`" in out
+        assert not _has_predict_node(out)
+
     def test_nested_ml_predict_both_levels_rewritten(self) -> None:
         """A nested ``ML.PREDICT`` (inside another's input query) is fully rewritten.
 

--- a/tests/unit/sql/rewriter/test_ml_predict.py
+++ b/tests/unit/sql/rewriter/test_ml_predict.py
@@ -1,0 +1,168 @@
+"""Unit tests for the ``ML.PREDICT`` surface-only rewriter (ADR 0047 / RFC 0002).
+
+The rewriter is a pure ``str -> str`` transform over the BigQuery AST that
+resolves a registered model and turns ``ML.PREDICT(MODEL ref, input)`` into a
+passthrough-plus-prediction subquery before translation. These tests pin the
+rewrite shape, the deterministic ``0.0`` stub, alias preservation, the
+not-found (404) parity, and the no-op fast paths, all without an engine.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+import sqlglot
+from sqlglot import exp
+
+from bqemulator.catalog.memory_repository import MemoryCatalogRepository
+from bqemulator.catalog.models import DatasetMeta, ModelMeta
+from bqemulator.domain.errors import NotFoundError
+from bqemulator.sql.rewriter.ml_predict import rewrite_ml_predict
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime(2026, 5, 16, tzinfo=UTC)
+_DEFAULT_LABELS = ({"name": "label", "type": {"typeKind": "FLOAT64"}},)
+
+
+def _catalog(
+    *,
+    label_columns: tuple[dict[str, object], ...] = _DEFAULT_LABELS,
+    project: str = "p",
+    dataset: str = "ds",
+    model_id: str = "m",
+) -> MemoryCatalogRepository:
+    """Return a catalog holding dataset ``project.dataset`` and one model."""
+    catalog = MemoryCatalogRepository()
+    catalog.create_dataset(
+        DatasetMeta(
+            project_id=project,
+            dataset_id=dataset,
+            creation_time=NOW,
+            last_modified_time=NOW,
+            etag="e",
+        ),
+    )
+    catalog.create_model(
+        ModelMeta(
+            project_id=project,
+            dataset_id=dataset,
+            model_id=model_id,
+            label_columns=label_columns,
+            creation_time=NOW,
+            last_modified_time=NOW,
+            etag="e",
+        ),
+    )
+    return catalog
+
+
+def _rewrite(sql: str, catalog: MemoryCatalogRepository | None = None) -> str:
+    """Rewrite ``sql`` against ``catalog`` (a default single-model catalog)."""
+    return rewrite_ml_predict(sql, project_id="p", catalog=catalog or _catalog())
+
+
+def _has_predict_node(sql: str) -> bool:
+    """Return True if ``sql`` still parses to an ``exp.Predict`` node."""
+    return bool(list(sqlglot.parse_one(sql, read="bigquery").find_all(exp.Predict)))
+
+
+class TestRewriteShape:
+    """The rewritten SQL preserves passthrough and appends the stub column(s)."""
+
+    def test_subquery_form(self) -> None:
+        """A subquery input becomes the inner FROM source with a stub column."""
+        out = _rewrite("SELECT * FROM ML.PREDICT(MODEL ds.m, (SELECT 1 AS x))")
+        assert not _has_predict_node(out)
+        assert "CAST(0.0 AS FLOAT64) AS predicted_label" in out
+        assert "SELECT 1 AS x" in out  # input query preserved
+
+    def test_table_form(self) -> None:
+        """A ``TABLE ref`` input is read directly as the FROM source."""
+        out = _rewrite("SELECT * FROM ML.PREDICT(MODEL ds.m, TABLE ds.scoring)")
+        assert not _has_predict_node(out)
+        assert "ds.scoring" in out
+        assert "AS predicted_label" in out
+
+    def test_alias_preserved(self) -> None:
+        """An alias on the table function carries onto the synthesised subquery."""
+        out = _rewrite("SELECT t.predicted_label FROM ML.PREDICT(MODEL ds.m, (SELECT 1 AS x)) AS t")
+        assert out.rstrip().endswith("AS t")
+        # The outer reference still resolves against the aliased subquery.
+        assert "t.predicted_label" in out
+
+    def test_multiple_label_columns(self) -> None:
+        """One ``predicted_<label>`` column is appended per label column."""
+        catalog = _catalog(
+            label_columns=(
+                {"name": "a", "type": {"typeKind": "FLOAT64"}},
+                {"name": "b", "type": {"typeKind": "FLOAT64"}},
+            ),
+        )
+        out = _rewrite("SELECT * FROM ML.PREDICT(MODEL ds.m, (SELECT 1 AS x))", catalog)
+        assert "AS predicted_a" in out
+        assert "AS predicted_b" in out
+
+    def test_no_label_columns_falls_back_to_predicted(self) -> None:
+        """A model with no label columns appends a single generic ``predicted``."""
+        catalog = _catalog(label_columns=())
+        out = _rewrite("SELECT * FROM ML.PREDICT(MODEL ds.m, (SELECT 1 AS x))", catalog)
+        assert "AS predicted FROM" in out
+        assert "predicted_" not in out
+
+    def test_nested_in_cte(self) -> None:
+        """``ML.PREDICT`` inside a CTE-bearing query is rewritten in place."""
+        sql = "WITH s AS (SELECT 1 x) SELECT * FROM ML.PREDICT(MODEL ds.m, (SELECT * FROM s))"
+        out = _rewrite(sql)
+        assert not _has_predict_node(out)
+        assert "WITH s AS" in out
+        assert "AS predicted_label" in out
+
+    def test_explicit_project_qualified_model(self) -> None:
+        """A fully ``project.dataset.model`` qualified reference resolves."""
+        out = _rewrite("SELECT * FROM ML.PREDICT(MODEL p.ds.m, (SELECT 1 AS x))")
+        assert not _has_predict_node(out)
+        assert "AS predicted_label" in out
+
+
+class TestStubValue:
+    """The prediction value is the deterministic, non-real ``0.0`` stub."""
+
+    def test_stub_is_constant_zero(self) -> None:
+        """Every predicted column is ``CAST(0.0 AS FLOAT64)``."""
+        out = _rewrite("SELECT * FROM ML.PREDICT(MODEL ds.m, (SELECT 1 AS x))")
+        assert out.count("CAST(0.0 AS FLOAT64)") == 1
+
+
+class TestModelResolution:
+    """Model-reference resolution and BigQuery 404 parity."""
+
+    def test_missing_model_raises_not_found(self) -> None:
+        """An unregistered model raises ``NotFoundError`` (HTTP 404, notFound)."""
+        with pytest.raises(NotFoundError, match=r"model:p\.ds\.missing"):
+            _rewrite("SELECT * FROM ML.PREDICT(MODEL ds.missing, (SELECT 1 AS x))")
+
+    def test_unqualified_model_raises_not_found(self) -> None:
+        """A model reference with no dataset cannot resolve and 404s."""
+        with pytest.raises(NotFoundError):
+            _rewrite("SELECT * FROM ML.PREDICT(MODEL m, (SELECT 1 AS x))")
+
+
+class TestNoOpFastPaths:
+    """Queries without a usable ``ML.PREDICT`` are returned unchanged."""
+
+    def test_no_predict_keyword_returns_unchanged(self) -> None:
+        """A query that never mentions predict is returned byte-identical."""
+        sql = "SELECT COUNT(*) FROM ds.t"
+        assert _rewrite(sql) == sql
+
+    def test_predict_substring_without_node_returns_unchanged(self) -> None:
+        """A column merely named like ``predict`` is not a table function."""
+        sql = "SELECT predict_score FROM ds.t"
+        assert _rewrite(sql) == sql
+
+    def test_unparseable_sql_returns_unchanged(self) -> None:
+        """Unparseable SQL falls through to later layers untouched."""
+        sql = "SELECT predict FROM FROM (("
+        assert _rewrite(sql) == sql

--- a/tests/unit/sql/test_translator.py
+++ b/tests/unit/sql/test_translator.py
@@ -99,8 +99,14 @@ class TestErrorHandling:
         assert isinstance(result, Err)
 
     def test_bqml_detected_as_unsupported(self, translator: SQLTranslator) -> None:
+        """A still-unsupported ``ML.*`` construct is keyword-rejected as 501.
+
+        ``ML.PREDICT`` is no longer rejected here: it is intercepted before
+        translation by the ``ml_predict`` rewriter (ADR 0047 / RFC 0002).
+        ``ML.EVALUATE`` and the other ``ML.*`` constructs remain unsupported.
+        """
         result = translator.translate(
-            "SELECT * FROM ML.PREDICT(MODEL my_model, TABLE t)",
+            "SELECT * FROM ML.EVALUATE(MODEL my_model, TABLE t)",
         )
         assert isinstance(result, Err)
         assert isinstance(result.error, UnsupportedFeatureError)


### PR DESCRIPTION
## Summary

Surface-only `ML.PREDICT` (RFC 0002 / ADR 0047, BQML PR 3 of the workstream). `ML.PREDICT(MODEL ref, (query | TABLE ref))` now runs: it resolves the registered model, returns the input rows unchanged, and appends a deterministic, explicitly non-real prediction column per label column. No model is run; the prediction value is a constant `0.0`.

## What changed

- **New rewriter** `src/bqemulator/sql/rewriter/ml_predict.py::rewrite_ml_predict`. It finds every `exp.Predict` node, resolves the `MODEL` reference against the catalog, and rewrites the table function into a passthrough-plus-prediction subquery: `SELECT *, CAST(0.0 AS FLOAT64) AS predicted_<label> [, ...] FROM (<input>)`. Alias on the table function is preserved.
- **Wired into the shared inner-query chain** (`rewrite_and_translate_statement`), so standalone and scripted (`BEGIN ... END`) statements share one code path, and `ML.PREDICT` nested in CTEs/joins/subqueries works for free. `"ML.PREDICT"` is removed from the translator's `_UNSUPPORTED_KEYWORDS`; `ML.EVALUATE` / `ML.FORECAST` / `ML.GENERATE_*` stay 501.
- **Model resolution parity**: an unregistered model raises `notFound` (HTTP 404), matching BigQuery.
- Regenerated `docs/reference/sql-function-mapping.md` (rewriter count 24 -> 25; new `rewrite_ml_predict` row).

## Architecture note (deviation from the RFC's literal wording)

RFC 0002 described the interception helpers living in `jobs/executor.py` (mirroring `CREATE MODEL` / `EXPORT DATA`). `ML.PREDICT` is structurally different: it is a table function nested in a SELECT's FROM clause, not a top-level statement. Implementing it as a rewriter in the shared `inner_query` chain honors the RFC's stated intent (pre-translation, one path for standalone and scripted) while fitting the nested shape cleanly and covering nested occurrences. The decision (regression-shaped default + constant `0.0` stub) was confirmed with the maintainer.

## Scope (per RFC 0002)

In scope: the regression-shaped default `predicted_<label>` (`FLOAT64`) per label column. Out of scope here (resolved by conformance recording in PR 4): per-model-task output shapes (classifier probability arrays, k-means `centroid_id`), exact column order, and the recorded prediction-value divergence. `ML.PREDICT` values are deterministic stubs, never real predictions.

## Tests

- Unit (`tests/unit/sql/rewriter/test_ml_predict.py`): rewrite shape across subquery / `TABLE` / aliased / multi-label / no-label / nested-in-CTE / project-qualified forms; the `0.0` stub; not-found (404); and the no-op fast paths. 100% module coverage.
- In-process (`tests/unit/jobs/test_ml_predict.py`): end-to-end against real DuckDB. Column shape, constant-`0.0` values, `FLOAT64` typing, the row-count-equals-input invariant, model-not-found (404), and the scripted (`BEGIN ... END`) dual-wiring.
- Property (`tests/property/test_ml_predict_invariants.py`): one stub column per label, input preserved, no `Predict` node survives.
- Updated three tests that asserted `ML.PREDICT` -> 501 to use the still-unsupported `ML.EVALUATE`.

Mutation scope is unchanged: rewriters are outside the curated ADR 0026 pilot (as routes/repos are).

## Validation

Full `make verify` green locally (lint, complexity, unit + property + integration, coverage >= 90%, drift checks, docker-build, e2e x5, mkdocs --strict). CI re-runs the same chain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `ML.PREDICT` with both subquery and `TABLE` inputs, returning passthrough rows plus deterministic `predicted_<label>` stub columns.
* **Bug Fixes**
  * Improved behavior when a referenced model is missing, returning BigQuery-style 404-style not-found errors.
* **Tests**
  * Added new unit and property-based coverage for rewrite structure, nested/scripted behavior, deterministic outputs, and row-count invariants; updated unsupported-ML checks to use `ML.EVALUATE`.
* **Documentation**
  * Clarified pipeline handling notes for `CREATE MODEL` and `ML.PREDICT`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->